### PR TITLE
split Repo::init and Repo::init_bare

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -107,7 +107,7 @@ mod tests {
     #[test]
     fn buffer() {
         let td = TempDir::new("test").unwrap();
-        let repo = Repository::init(td.path(), false).unwrap();
+        let repo = Repository::init(td.path()).unwrap();
         let id = Blob::new(&repo, &[5, 4, 6]).unwrap();
         let blob = Blob::lookup(&repo, id).unwrap();
 
@@ -120,7 +120,7 @@ mod tests {
         let td = TempDir::new("test").unwrap();
         let path = td.path().join("foo");
         File::create(&path).write(&[7, 8, 9]).unwrap();
-        let repo = Repository::init(td.path(), false).unwrap();
+        let repo = Repository::init(td.path()).unwrap();
         let id = Blob::new_path(&repo, &path).unwrap();
         let blob = Blob::lookup(&repo, id).unwrap();
         assert_eq!(blob.content(), &[7, 8, 9]);

--- a/src/build.rs
+++ b/src/build.rs
@@ -393,7 +393,7 @@ mod tests {
     #[test]
     fn smoke2() {
         let td = TempDir::new("test").unwrap();
-        Repository::init(&td.path().join("bare"), true).unwrap();
+        Repository::init_bare(&td.path().join("bare")).unwrap();
         let url = format!("file://{}/bare", td.path().display());
         let dst = td.path().join("foo");
         RepoBuilder::new().clone(url.as_slice(), &dst).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //! use git2::Repository;
 //!
 //! let path = Path::new("/path/to/a/repo");
-//! let repo = match Repository::init(&path, false) { // false for not a bare repo
+//! let repo = match Repository::init(&path) {
 //!     Ok(repo) => repo,
 //!     Err(e) => fail!("failed to init `{}`: {}", path.display(), e),
 //! };

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -341,7 +341,7 @@ mod tests {
         repo.remote_create("origin", "/path/to/nowhere").unwrap();
         drop(repo);
 
-        let repo = Repository::init(td.path(), false).unwrap();
+        let repo = Repository::init(td.path()).unwrap();
         let origin = repo.remote_load("origin").unwrap();
         assert_eq!(origin.name(), Some("origin"));
         assert_eq!(origin.url(), Some("/path/to/nowhere"));
@@ -351,7 +351,7 @@ mod tests {
     fn create_remote() {
         let td = TempDir::new("test").unwrap();
         let remote = td.path().join("remote");
-        Repository::init(&remote, true).unwrap();
+        Repository::init_bare(&remote).unwrap();
 
         let (_td, repo) = ::test::repo_init();
         let url = format!("file://{}", remote.display());
@@ -408,7 +408,7 @@ mod tests {
     #[test]
     fn create_remote_anonymous() {
         let td = TempDir::new("test").unwrap();
-        let repo = Repository::init(td.path(), false).unwrap();
+        let repo = Repository::init(td.path()).unwrap();
 
         let origin = repo.remote_create_anonymous("/path/to/nowhere",
                                                   "master").unwrap();

--- a/src/submodule.rs
+++ b/src/submodule.rs
@@ -239,7 +239,7 @@ mod tests {
     #[test]
     fn smoke() {
         let td = TempDir::new("test").unwrap();
-        let repo = Repository::init(td.path(), false).unwrap();
+        let repo = Repository::init(td.path()).unwrap();
         let mut s1 = Submodule::new(&repo, "/path/to/nowhere",
                                     &td.path().join("foo"), true).unwrap();
         s1.init(false).unwrap();

--- a/src/test.rs
+++ b/src/test.rs
@@ -3,7 +3,7 @@ use {Repository, Commit, Tree, Signature};
 
 pub fn repo_init() -> (TempDir, Repository) {
     let td = TempDir::new("test").unwrap();
-    let repo = Repository::init(td.path(), false).unwrap();
+    let repo = Repository::init(td.path()).unwrap();
     {
         let mut config = repo.config().unwrap();
         config.set_str("user.name", "name").unwrap();


### PR DESCRIPTION
boolean args can be confusing to read, so expose 2 explicit static methods instead. The comment in the docs `// false for not bare repo` was an immediate sign that the boolean was confusing.
