### PR TITLE
Add a CMake module for detecting libssh2 via pkg-config

### DIFF
--- a/libgit2-sys/build.rs
+++ b/libgit2-sys/build.rs
@@ -45,7 +45,8 @@ fn main() {
            .arg("-DCMAKE_BUILD_TYPE=RelWithDebInfo")
            .arg(format!("-DCMAKE_INSTALL_PREFIX={}", dst.display()))
            .arg("-DBUILD_EXAMPLES=OFF")
-           .arg(format!("-DCMAKE_C_FLAGS={}", cflags)));
+           .arg(format!("-DCMAKE_C_FLAGS={}", cflags))
+           .arg(format!("-DCMAKE_MODULE_PATH={}", src.join("cmake").display())));
     run(Command::new("cmake")
                 .arg("--build").arg(".")
                 .arg("--target").arg("install")

--- a/libgit2-sys/cmake/FindLIBSSH2.cmake
+++ b/libgit2-sys/cmake/FindLIBSSH2.cmake
@@ -1,0 +1,21 @@
+# https://github.com/nutjunkie/IQmol/blob/master/cmake/FindLibSsh2.cmake
+
+find_package(PkgConfig)
+pkg_check_modules(PC_LIBSSH2 QUIET libssh2)
+set(LIBSSH2_DEFINITIONS ${PC_LIBSSH2_CFLAGS_OTHER})
+
+find_path(LIBSSH2_INCLUDE_DIR libssh2.h
+          HINTS ${PC_LIBSSH2_INCLUDEDIR} ${PC_LIBSSH2_INCLUDE_DIRS}
+          PATH_SUFFIXES libssh2)
+
+find_library(LIBSSH2_LIBRARY NAMES ssh2 libssh2
+             HINTS ${PC_LIBSSH2_LIBDIR} ${PC_LIBSSH2_LIBRARY_DIRS})
+
+set(LIBSSH2_LIBRARIES ${LIBSSH2_LIBRARY})
+set(LIBSSH2_INCLUDE_DIRS ${LIBSSH2_INCLUDE_DIR})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(LIBSSH2 DEFAULT_MSG
+                                  LIBSSH2_LIBRARY LIBSSH2_INCLUDE_DIR)
+
+mark_as_advanced(LIBSSH2_INCLUDE_DIR LIBSSH2_LIBRARY)


### PR DESCRIPTION
Hello,

`cmake` has [its own mechanisms](http://www.cmake.org/Wiki/CMake:How_To_Find_Libraries) of searching for libraries, which differ from the ones that `pkg-config` has. As a result, `pkg-config` might be able to find some library while `cmake` might fail to do so, and vice versa.

In this regard, I’ve encountered the following problem. I’m on a mac, and I’ve installed `libssh2` using Homebrew; `libssh2` got installed in some subdirectory of my home directory. Since my `DYLD_LIBRARY_PATH` is set properly, `pkg-config` works just fine. When compiling `libgit2`, however, `cmake` fails to find `libssh2` and, therefore, [does not turn on](https://github.com/alexcrichton/libgit2/blob/156208bd5b43860d0cd1eda5cd2ce1b6ca95341e/CMakeLists.txt#L235) the SSH support. Consequently, even though `ssh2-rs` gets compiled and so on, `git2-rs` ends up without SSH.

The solution that I came up with can be seen in the pull request. However, this problem is more general: it concerns any Cargo’s build script that involves a mixture of `cmake` and `pkg-config`.

I would be happy to hear any feedback. Thank you.

Regards,
Ivan
