### PR TITLE
Fix for rust commit 3dcd2157403163789aaf21a9ab3c4d30a7c6494d 'Switch to ...

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -1,10 +1,13 @@
-#![feature(phase)]
+#![feature(globs, phase)]
 #![allow(non_camel_case_types)]
 
 extern crate libc;
 extern crate "libssh2-sys" as libssh2;
 #[cfg(unix)] extern crate "openssl-sys" as openssl;
 #[cfg(unix)] extern crate "libz-sys" as libz;
+
+pub use git_ref_t::*;
+pub use git_branch_t::*;
 
 use libc::{c_int, c_char, c_uint, size_t, c_uchar, c_void, c_ushort};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@
 //! source `Repository`, to ensure that they do not outlive the repository
 //! itself.
 
-#![feature(macro_rules, unsafe_destructor)]
+#![feature(globs, macro_rules, unsafe_destructor)]
 #![deny(missing_docs)]
 
 extern crate libc;
@@ -77,6 +77,14 @@ use std::mem;
 use std::rt;
 use std::str;
 use std::sync::{Once, ONCE_INIT};
+
+pub use BranchType::*;
+pub use ConfigLevel::*;
+pub use Direction::*;
+pub use ErrorCode::*;
+pub use ObjectType::*;
+pub use RepositoryState::*;
+pub use ResetType::*;
 
 pub use blob::Blob;
 pub use branch::{Branch, Branches};


### PR DESCRIPTION
...purely namespaced enums'
