### PR TITLE
Make sure that the argument of str::from_c_str is always of the right type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,7 +321,7 @@ impl ObjectType {
     pub fn str(&self) -> &'static str {
         unsafe {
             let ptr = call!(raw::git_object_type2string(*self));
-            mem::transmute::<&str, &'static str>(str::from_c_str(ptr))
+            mem::transmute::<&str, &'static str>(str::from_c_str(ptr as *const _))
         }
     }
 


### PR DESCRIPTION
Fixes #30 
