### PR TITLE
Add new git_remote_create_with_opts API

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -916,6 +916,22 @@ pub struct git_repository_init_options {
     pub origin_url: *const c_char,
 }
 
+git_enum! {
+    pub enum git_remote_create_flags {
+        GIT_REMOTE_CREATE_SKIP_INSTEADOF = (1 << 0),
+        GIT_REMOTE_CREATE_SKIP_DEFAULT_FETCHSPEC = (1 << 1),
+    }
+}
+
+#[repr(C)]
+pub struct git_remote_create_options {
+    pub version: c_uint,
+    pub repository: *mut git_repository,
+    pub name: *const c_char,
+    pub fetchspec: *const c_char,
+    pub flags: u32,
+}
+
 pub const GIT_REPOSITORY_INIT_OPTIONS_VERSION: c_uint = 1;
 
 git_enum! {
@@ -1100,6 +1116,7 @@ pub const GIT_DIFF_ENABLE_FAST_UNTRACKED_DIRS: git_diff_option_t = 1 << 14;
 pub const GIT_DIFF_UPDATE_INDEX: git_diff_option_t = 1 << 15;
 pub const GIT_DIFF_INCLUDE_UNREADABLE: git_diff_option_t = 1 << 16;
 pub const GIT_DIFF_INCLUDE_UNREADABLE_AS_UNTRACKED: git_diff_option_t = 1 << 17;
+pub const GIT_DIFF_INDENT_HEURISTIC: git_diff_option_t = 1 << 18;
 pub const GIT_DIFF_FORCE_TEXT: git_diff_option_t = 1 << 20;
 pub const GIT_DIFF_FORCE_BINARY: git_diff_option_t = 1 << 21;
 pub const GIT_DIFF_IGNORE_WHITESPACE: git_diff_option_t = 1 << 22;
@@ -1110,7 +1127,6 @@ pub const GIT_DIFF_SHOW_UNMODIFIED: git_diff_option_t = 1 << 26;
 pub const GIT_DIFF_PATIENCE: git_diff_option_t = 1 << 28;
 pub const GIT_DIFF_MINIMAL: git_diff_option_t = 1 << 29;
 pub const GIT_DIFF_SHOW_BINARY: git_diff_option_t = 1 << 30;
-pub const GIT_DIFF_INDENT_HEURISTIC: git_diff_option_t = 1 << 31;
 
 #[repr(C)]
 pub struct git_diff_find_options {
@@ -1697,6 +1713,11 @@ extern {
                              repo: *mut git_repository,
                              name: *const c_char,
                              url: *const c_char) -> c_int;
+    pub fn git_remote_create_init_options(opts: *mut git_remote_create_options,
+                                          version: c_uint) -> c_int;
+    pub fn git_remote_create_with_opts(out: *mut *mut git_remote,
+                                       url: *const c_char,
+                                       opts: *const git_remote_create_options) -> c_int;
     pub fn git_remote_lookup(out: *mut *mut git_remote,
                              repo: *mut git_repository,
                              name: *const c_char) -> c_int;


### PR DESCRIPTION
- Bump version of the libgit2
- Add git_remote_create_with_opts
- Add git_remote_create_init_options
- Update GIT_DIFF_INDENT_HEURISTIC value

TODO: wait for a new libgit2 release to put the proper submodule commit,
instead of a random commit from master.

This should be ready for review modulo the submodule commit version.