### PR TITLE
Add Status::is_current convenience method for completeness

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -952,6 +952,7 @@ bitflags! {
 }
 
 impl Status {
+    is_bit_set!(is_current, Status::CURRENT);
     is_bit_set!(is_index_new, Status::INDEX_NEW);
     is_bit_set!(is_index_modified, Status::INDEX_MODIFIED);
     is_bit_set!(is_index_deleted, Status::INDEX_DELETED);


### PR DESCRIPTION
Now we have convenience methods for [all the constants](https://github.com/rust-lang/git2-rs/blob/718799c265d4e6fea635906cb57379a441021f3c/src/lib.rs#L922-L950).