### PR TITLE
Fix git-dir CLI option in rev-parse example

### DIFF
--- a/examples/rev-parse.rs
+++ b/examples/rev-parse.rs
@@ -58,7 +58,7 @@ fn main() {
 usage: rev-parse [options] <spec>
 
 Options:
-    --git-dir           directory for the git repository to check
+    --git-dir <dir>     directory of the git repository to check
 ";
 
     let args = Docopt::new(USAGE).and_then(|d| d.deserialize())


### PR DESCRIPTION
You can actually set it now.