### PR TITLE
Fix incorrect method name in Branch doc.

### DIFF
--- a/src/branch.rs
+++ b/src/branch.rs
@@ -9,7 +9,7 @@ use util::Binding;
 /// A structure to represent a git [branch][1]
 ///
 /// A branch is currently just a wrapper to an underlying `Reference`. The
-/// reference can be accessed through the `get` and `unwrap` methods.
+/// reference can be accessed through the `get` and `into_reference` methods.
 ///
 /// [1]: http://git-scm.com/book/en/Git-Branching-What-a-Branch-Is
 pub struct Branch<'repo> {


### PR DESCRIPTION
There is no `unwrap`. The method is called `into_reference`.