### PR TITLE
Get CI passing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ git:
 
 matrix:
   include:
-    - rust: 1.30.0
+    - rust: 1.32.0
     - rust: stable
     - os: osx
       rust: stable

--- a/src/test.rs
+++ b/src/test.rs
@@ -44,7 +44,7 @@ pub fn realpath(original: &Path) -> io::Result<PathBuf> {
 pub fn realpath(original: &Path) -> io::Result<PathBuf> {
     use std::ffi::{CStr, OsString, CString};
     use std::os::unix::prelude::*;
-    use libc::{self, c_char};
+    use libc::c_char;
     extern {
         fn realpath(name: *const c_char, resolved: *mut c_char) -> *mut c_char;
     }


### PR DESCRIPTION
Bump minimum version to get CI passing.
Fix a warning in 1.35.