### PR TITLE
Refactor: Extract function util::c_cmp_to_ordering

### DIFF
--- a/src/oid.rs
+++ b/src/oid.rs
@@ -181,6 +181,7 @@ mod tests {
 
     use tempdir::TempDir;
     use {ObjectType};
+    use super::Error;
     use super::Oid;
 
     #[test]
@@ -189,6 +190,32 @@ mod tests {
         assert!(Oid::from_str("decbf2be529ab6557d5429922251e5ee36519817").is_ok());
         assert!(Oid::from_bytes(b"foo").is_err());
         assert!(Oid::from_bytes(b"00000000000000000000").is_ok());
+    }
+
+    #[test]
+    fn comparisons() -> Result<(), Error> {
+        assert_eq!(Oid::from_str("decbf2b")?, Oid::from_str("decbf2b")?);
+        assert!(Oid::from_str("decbf2b")? <= Oid::from_str("decbf2b")?);
+        assert!(Oid::from_str("decbf2b")? >= Oid::from_str("decbf2b")?);
+        {
+            let o = Oid::from_str("decbf2b")?;
+            assert_eq!(o, o);
+            assert!(o <= o);
+            assert!(o >= o);
+        }
+        assert_eq!(
+            Oid::from_str("decbf2b")?,
+            Oid::from_str("decbf2b000000000000000000000000000000000")?
+        );
+        assert!(
+            Oid::from_bytes(b"00000000000000000000")? < Oid::from_bytes(b"00000000000000000001")?
+        );
+        assert!(Oid::from_bytes(b"00000000000000000000")? < Oid::from_str("decbf2b")?);
+        assert_eq!(
+            Oid::from_bytes(b"00000000000000000000")?,
+            Oid::from_str("3030303030303030303030303030303030303030")?
+        );
+        Ok(())
     }
 
     #[test]

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -7,7 +7,7 @@ use libc;
 
 use {raw, Error, ObjectType, IntoCString};
 
-use util::Binding;
+use util::{c_cmp_to_ordering, Binding};
 
 /// Unique identity of any object (commit, tree, blob, tag).
 #[derive(Copy, Clone)]
@@ -156,11 +156,7 @@ impl PartialOrd for Oid {
 
 impl Ord for Oid {
     fn cmp(&self, other: &Oid) -> Ordering {
-        match unsafe { raw::git_oid_cmp(&self.raw, &other.raw) } {
-            0 => Ordering::Equal,
-            n if n < 0 => Ordering::Less,
-            _ => Ordering::Greater,
-        }
+        c_cmp_to_ordering(unsafe { raw::git_oid_cmp(&self.raw, &other.raw) })
     }
 }
 

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -7,7 +7,7 @@ use std::str;
 
 use {raw, Error, Oid, Repository, ReferenceType, Object, ObjectType, Blob, Commit, Tree, Tag};
 use object::CastOrPanic;
-use util::Binding;
+use util::{c_cmp_to_ordering, Binding};
 
 struct Refdb<'repo>(&'repo Repository);
 
@@ -246,11 +246,7 @@ impl<'repo> PartialOrd for Reference<'repo> {
 
 impl<'repo> Ord for Reference<'repo> {
     fn cmp(&self, other: &Reference<'repo>) -> Ordering {
-        match unsafe { raw::git_reference_cmp(&*self.raw, &*other.raw) } {
-            0 => Ordering::Equal,
-            n if n < 0 => Ordering::Less,
-            _ => Ordering::Greater,
-        }
+        c_cmp_to_ordering(unsafe { raw::git_reference_cmp(&*self.raw, &*other.raw) })
     }
 }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -9,7 +9,7 @@ use std::str;
 use libc::{self, c_int, c_char, c_void};
 
 use {panic, raw, Oid, Repository, Error, Object, ObjectType};
-use util::{Binding, IntoCString};
+use util::{c_cmp_to_ordering, Binding, IntoCString};
 
 /// A structure to represent a git [tree][1]
 ///
@@ -351,11 +351,7 @@ impl<'a> PartialOrd for TreeEntry<'a> {
 }
 impl<'a> Ord for TreeEntry<'a> {
     fn cmp(&self, other: &TreeEntry<'a>) -> Ordering {
-        match unsafe { raw::git_tree_entry_cmp(&*self.raw(), &*other.raw()) } {
-            0 => Ordering::Equal,
-            n if n < 0 => Ordering::Less,
-            _ => Ordering::Greater,
-        }
+        c_cmp_to_ordering(unsafe { raw::git_tree_entry_cmp(&*self.raw(), &*other.raw()) })
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,8 @@
+use std::cmp::Ordering;
 use std::ffi::{CString, OsStr, OsString};
 use std::iter::IntoIterator;
 use std::path::{Path, PathBuf};
-use libc::{c_char, size_t};
+use libc::{c_char, c_int, size_t};
 
 use {raw, Error};
 
@@ -148,5 +149,13 @@ pub fn into_opt_c_string<S>(opt_s: Option<S>) -> Result<Option<CString>, Error>
     match opt_s {
         None => Ok(None),
         Some(s) => Ok(Some(try!(s.into_c_string()))),
+    }
+}
+
+pub fn c_cmp_to_ordering(cmp: c_int) -> Ordering {
+    match cmp {
+        0 => Ordering::Equal,
+        n if n < 0 => Ordering::Less,
+        _ => Ordering::Greater,
     }
 }


### PR DESCRIPTION
I noticed some repeated code, and also added a test for good measure.