### PR TITLE
Update to libgit2 0.28.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "libgit2-sys/libgit2"]
 	path = libgit2-sys/libgit2
 	url = https://github.com/libgit2/libgit2
+	branch = maint/v0.28

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "git2"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Josh Triplett <josh@joshtriplett.org>", "Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -23,7 +23,7 @@ url = "1.0"
 bitflags = "1.0"
 libc = "0.2"
 log = "0.4"
-libgit2-sys = { path = "libgit2-sys", version = "0.7.11" }
+libgit2-sys = { path = "libgit2-sys", version = "0.8.0" }
 
 [target."cfg(all(unix, not(target_os = \"macos\")))".dependencies]
 openssl-sys = { version = "0.9.0", optional = true }
@@ -39,10 +39,9 @@ thread-id = "3.3.0" # remove when we work with minimal-versions without it
 
 [features]
 unstable = []
-default = ["ssh", "https", "curl", "ssh_key_from_memory"]
+default = ["ssh", "https", "ssh_key_from_memory"]
 ssh = ["libgit2-sys/ssh"]
 https = ["libgit2-sys/https", "openssl-sys", "openssl-probe"]
-curl = ["libgit2-sys/curl"]
 vendored-openssl = ["openssl-sys/vendored"]
 ssh_key_from_memory = ["libgit2-sys/ssh_key_from_memory"]
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ version of Rust known to pass tests.
 
 ## Version of libgit2
 
-Currently this library requires libgit2 0.25.1. The source for libgit2 is
+Currently this library requires libgit2 0.28.0. The source for libgit2 is
 included in the libgit2-sys crate so there's no need to pre-install the libgit2
 library, the libgit2-sys crate will figure that and/or build that for you.
 

--- a/git2-curl/Cargo.toml
+++ b/git2-curl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "git2-curl"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Josh Triplett <josh@joshtriplett.org>", "Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rust-lang/git2-rs"
@@ -16,7 +16,7 @@ Intended to be used with the git2 crate.
 curl = "0.4"
 url = "1.0"
 log = "0.4"
-git2 = { path = "..", version = "0.8", default-features = false }
+git2 = { path = "..", version = "0.9", default-features = false }
 
 [dev-dependencies]
 civet = "0.11"

--- a/libgit2-sys/Cargo.toml
+++ b/libgit2-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libgit2-sys"
-version = "0.7.11"
+version = "0.8.0"
 authors = ["Josh Triplett <josh@joshtriplett.org>", "Alex Crichton <alex@alexcrichton.com>"]
 links = "git2"
 build = "build.rs"
@@ -16,13 +16,12 @@ name = "libgit2_sys"
 path = "lib.rs"
 
 [dependencies]
-curl-sys = { version = "0.4.10", optional = true }
 libc = "0.2"
 libssh2-sys = { version = "0.2.11", optional = true }
 libz-sys = "1.0.22"
 
 [build-dependencies]
-pkg-config = "0.3"
+pkg-config = "0.3.7"
 cc = "1.0.25"
 
 [target.'cfg(unix)'.dependencies]
@@ -31,5 +30,4 @@ openssl-sys = { version = "0.9", optional = true }
 [features]
 ssh = ["libssh2-sys"]
 https = ["openssl-sys"]
-curl = ["curl-sys"]
 ssh_key_from_memory = []

--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -190,37 +190,37 @@ git_enum! {
 
 git_enum! {
     pub enum git_error_t {
-        GITERR_NONE = 0,
-        GITERR_NOMEMORY,
-        GITERR_OS,
-        GITERR_INVALID,
-        GITERR_REFERENCE,
-        GITERR_ZLIB,
-        GITERR_REPOSITORY,
-        GITERR_CONFIG,
-        GITERR_REGEX,
-        GITERR_ODB,
-        GITERR_INDEX,
-        GITERR_OBJECT,
-        GITERR_NET,
-        GITERR_TAG,
-        GITERR_TREE,
-        GITERR_INDEXER,
-        GITERR_SSL,
-        GITERR_SUBMODULE,
-        GITERR_THREAD,
-        GITERR_STASH,
-        GITERR_CHECKOUT,
-        GITERR_FETCHHEAD,
-        GITERR_MERGE,
-        GITERR_SSH,
-        GITERR_FILTER,
-        GITERR_REVERT,
-        GITERR_CALLBACK,
-        GITERR_CHERRYPICK,
-        GITERR_DESCRIBE,
-        GITERR_REBASE,
-        GITERR_FILESYSTEM,
+        GIT_ERROR_NONE = 0,
+        GIT_ERROR_NOMEMORY,
+        GIT_ERROR_OS,
+        GIT_ERROR_INVALID,
+        GIT_ERROR_REFERENCE,
+        GIT_ERROR_ZLIB,
+        GIT_ERROR_REPOSITORY,
+        GIT_ERROR_CONFIG,
+        GIT_ERROR_REGEX,
+        GIT_ERROR_ODB,
+        GIT_ERROR_INDEX,
+        GIT_ERROR_OBJECT,
+        GIT_ERROR_NET,
+        GIT_ERROR_TAG,
+        GIT_ERROR_TREE,
+        GIT_ERROR_INDEXER,
+        GIT_ERROR_SSL,
+        GIT_ERROR_SUBMODULE,
+        GIT_ERROR_THREAD,
+        GIT_ERROR_STASH,
+        GIT_ERROR_CHECKOUT,
+        GIT_ERROR_FETCHHEAD,
+        GIT_ERROR_MERGE,
+        GIT_ERROR_SSH,
+        GIT_ERROR_FILTER,
+        GIT_ERROR_REVERT,
+        GIT_ERROR_CALLBACK,
+        GIT_ERROR_CHERRYPICK,
+        GIT_ERROR_DESCRIBE,
+        GIT_ERROR_REBASE,
+        GIT_ERROR_FILESYSTEM,
     }
 }
 
@@ -611,26 +611,24 @@ git_enum! {
 }
 
 git_enum! {
-    pub enum git_otype: c_int {
-        GIT_OBJ_ANY = -2,
-        GIT_OBJ_BAD = -1,
-        GIT_OBJ__EXT1 = 0,
-        GIT_OBJ_COMMIT = 1,
-        GIT_OBJ_TREE = 2,
-        GIT_OBJ_BLOB = 3,
-        GIT_OBJ_TAG = 4,
-        GIT_OBJ__EXT2 = 5,
-        GIT_OBJ_OFS_DELTA = 6,
-        GIT_OBJ_REF_DELTA = 7,
+    pub enum git_object_t: c_int {
+        GIT_OBJECT_ANY = -2,
+        GIT_OBJECT_INVALID = -1,
+        GIT_OBJECT_COMMIT = 1,
+        GIT_OBJECT_TREE = 2,
+        GIT_OBJECT_BLOB = 3,
+        GIT_OBJECT_TAG = 4,
+        GIT_OBJECT_OFS_DELTA = 6,
+        GIT_OBJECT_REF_DELTA = 7,
     }
 }
 
 git_enum! {
-    pub enum git_ref_t {
-        GIT_REF_INVALID = 0,
-        GIT_REF_OID = 1,
-        GIT_REF_SYMBOLIC = 2,
-        GIT_REF_LISTALL = GIT_REF_OID | GIT_REF_SYMBOLIC,
+    pub enum git_reference_t {
+        GIT_REFERENCE_INVALID = 0,
+        GIT_REFERENCE_DIRECT = 1,
+        GIT_REFERENCE_SYMBOLIC = 2,
+        GIT_REFERENCE_ALL = GIT_REFERENCE_DIRECT | GIT_REFERENCE_SYMBOLIC,
     }
 }
 
@@ -713,30 +711,18 @@ pub type git_index_matched_path_cb = extern fn(*const c_char, *const c_char,
                                                *mut c_void) -> c_int;
 
 git_enum! {
-    pub enum git_idxentry_extended_flag_t {
-        GIT_IDXENTRY_INTENT_TO_ADD     = 1 << 13,
-        GIT_IDXENTRY_SKIP_WORKTREE     = 1 << 14,
-        GIT_IDXENTRY_EXTENDED2         = 1 << 15,
+    pub enum git_index_entry_extended_flag_t {
+        GIT_INDEX_ENTRY_INTENT_TO_ADD     = 1 << 13,
+        GIT_INDEX_ENTRY_SKIP_WORKTREE     = 1 << 14,
 
-        GIT_IDXENTRY_UPDATE            = 1 << 0,
-        GIT_IDXENTRY_REMOVE            = 1 << 1,
-        GIT_IDXENTRY_UPTODATE          = 1 << 2,
-        GIT_IDXENTRY_ADDED             = 1 << 3,
-
-        GIT_IDXENTRY_HASHED            = 1 << 4,
-        GIT_IDXENTRY_UNHASHED          = 1 << 5,
-        GIT_IDXENTRY_WT_REMOVE         = 1 << 6,
-        GIT_IDXENTRY_CONFLICTED        = 1 << 7,
-
-        GIT_IDXENTRY_UNPACKED          = 1 << 8,
-        GIT_IDXENTRY_NEW_SKIP_WORKTREE = 1 << 9,
+        GIT_INDEX_ENTRY_UPTODATE          = 1 << 2,
     }
 }
 
 git_enum! {
-    pub enum git_indxentry_flag_t {
-        GIT_IDXENTRY_EXTENDED = 0x4000,
-        GIT_IDXENTRY_VALID    = 0x8000,
+    pub enum git_index_entry_flag_t {
+        GIT_INDEX_ENTRY_EXTENDED = 0x4000,
+        GIT_INDEX_ENTRY_VALID    = 0x8000,
     }
 }
 
@@ -757,9 +743,9 @@ pub struct git_index_entry {
     pub path: *const c_char,
 }
 
-pub const GIT_IDXENTRY_NAMEMASK: u16 = 0xfff;
-pub const GIT_IDXENTRY_STAGEMASK: u16 = 0x3000;
-pub const GIT_IDXENTRY_STAGESHIFT: u16 = 12;
+pub const GIT_INDEX_ENTRY_NAMEMASK: u16 = 0xfff;
+pub const GIT_INDEX_ENTRY_STAGEMASK: u16 = 0x3000;
+pub const GIT_INDEX_ENTRY_STAGESHIFT: u16 = 12;
 
 #[repr(C)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1297,19 +1283,19 @@ pub struct git_odb_backend {
     pub odb: *mut git_odb,
     pub read: extern fn(*mut *mut c_void,
                         *mut size_t,
-                        *mut git_otype,
+                        *mut git_object_t,
                         *mut git_odb_backend,
                         *const git_oid) -> c_int,
 
     pub read_prefix: extern fn(*mut git_oid,
                                *mut *mut c_void,
                                *mut size_t,
-                               *mut git_otype,
+                               *mut git_object_t,
                                *mut git_odb_backend,
                                *const git_oid,
                                size_t) -> c_int,
     pub read_header: extern fn(*mut size_t,
-                               *mut git_otype,
+                               *mut git_object_t,
                                *mut git_odb_backend,
                                *const git_oid) -> c_int,
 
@@ -1317,16 +1303,16 @@ pub struct git_odb_backend {
                          *const git_oid,
                          *const c_void,
                          size_t,
-                         git_otype) -> c_int,
+                         git_object_t) -> c_int,
 
     pub writestream: extern fn(*mut *mut git_odb_stream,
                                *mut git_odb_backend,
                                git_off_t,
-                               git_otype) -> c_int,
+                               git_object_t) -> c_int,
 
     pub readstream: extern fn(*mut *mut git_odb_stream,
                               *mut size_t,
-                              *mut git_otype,
+                              *mut git_object_t,
                               *mut git_odb_backend,
                               *const git_oid) -> c_int,
 
@@ -1697,16 +1683,16 @@ extern {
     pub fn git_object_lookup(dest: *mut *mut git_object,
                              repo: *mut git_repository,
                              id: *const git_oid,
-                             kind: git_otype) -> c_int;
-    pub fn git_object_type(obj: *const git_object) -> git_otype;
+                             kind: git_object_t) -> c_int;
+    pub fn git_object_type(obj: *const git_object) -> git_object_t;
     pub fn git_object_peel(peeled: *mut *mut git_object,
                            object: *const git_object,
-                           target_type: git_otype) -> c_int;
+                           target_type: git_object_t) -> c_int;
     pub fn git_object_short_id(out: *mut git_buf,
                                obj: *const git_object) -> c_int;
-    pub fn git_object_type2string(kind: git_otype) -> *const c_char;
-    pub fn git_object_string2type(s: *const c_char) -> git_otype;
-    pub fn git_object_typeisloose(kind: git_otype) -> c_int;
+    pub fn git_object_type2string(kind: git_object_t) -> *const c_char;
+    pub fn git_object_string2type(s: *const c_char) -> git_object_t;
+    pub fn git_object_typeisloose(kind: git_object_t) -> c_int;
 
     // oid
     pub fn git_oid_fromraw(out: *mut git_oid, raw: *const c_uchar);
@@ -1719,10 +1705,10 @@ extern {
     pub fn git_oid_streq(id: *const git_oid, str: *const c_char) -> c_int;
     pub fn git_oid_iszero(id: *const git_oid) -> c_int;
 
-    // giterr
-    pub fn giterr_last() -> *const git_error;
-    pub fn giterr_clear();
-    pub fn giterr_set_str(error_class: c_int, string: *const c_char);
+    // error
+    pub fn git_error_last() -> *const git_error;
+    pub fn git_error_clear();
+    pub fn git_error_set_str(error_class: c_int, string: *const c_char);
 
     // remote
     pub fn git_remote_create(out: *mut *mut git_remote,
@@ -1891,8 +1877,8 @@ extern {
                                     repo: *mut git_repository,
                                     name: *const c_char) -> c_int;
     pub fn git_reference_peel(out: *mut *mut git_object,
-                              r: *mut git_reference,
-                              otype: git_otype) -> c_int;
+                              r: *const git_reference,
+                              otype: git_object_t) -> c_int;
     pub fn git_reference_rename(new_ref: *mut *mut git_reference,
                                 r: *mut git_reference,
                                 new_name: *const c_char,
@@ -1908,7 +1894,7 @@ extern {
                                     r: *mut git_reference,
                                     id: *const git_oid,
                                     log_message: *const c_char) -> c_int;
-    pub fn git_reference_type(r: *const git_reference) -> git_ref_t;
+    pub fn git_reference_type(r: *const git_reference) -> git_reference_t;
     pub fn git_reference_iterator_new(out: *mut *mut git_reference_iterator,
                                       repo: *mut git_repository) -> c_int;
     pub fn git_reference_iterator_glob_new(out: *mut *mut git_reference_iterator,
@@ -2085,7 +2071,7 @@ extern {
     pub fn git_tree_entry_to_object(out: *mut *mut git_object,
                                     repo: *mut git_repository,
                                     entry: *const git_tree_entry) -> c_int;
-    pub fn git_tree_entry_type(entry: *const git_tree_entry) -> git_otype;
+    pub fn git_tree_entry_type(entry: *const git_tree_entry) -> git_object_t;
     pub fn git_tree_entrycount(tree: *const git_tree) -> size_t;
     pub fn git_tree_free(tree: *mut git_tree);
     pub fn git_tree_id(tree: *const git_tree) -> *const git_oid;
@@ -2120,7 +2106,7 @@ extern {
                                  bld: *mut git_treebuilder) -> c_int;
 
     // buf
-    pub fn git_buf_free(buffer: *mut git_buf);
+    pub fn git_buf_dispose(buffer: *mut git_buf);
     pub fn git_buf_grow(buffer: *mut git_buf, target_size: size_t) -> c_int;
     pub fn git_buf_set(buffer: *mut git_buf, data: *const c_void,
                        datalen: size_t) -> c_int;
@@ -2457,7 +2443,7 @@ extern {
     pub fn git_tag_target(target_out: *mut *mut git_object,
                           tag: *const git_tag) -> c_int;
     pub fn git_tag_target_id(tag: *const git_tag) -> *const git_oid;
-    pub fn git_tag_target_type(tag: *const git_tag) -> git_otype;
+    pub fn git_tag_target_type(tag: *const git_tag) -> git_object_t;
 
     // checkout
     pub fn git_checkout_head(repo: *mut git_repository,
@@ -2894,7 +2880,7 @@ extern {
     pub fn git_odb_free(db: *mut git_odb);
     pub fn git_odb_open_rstream(out: *mut *mut git_odb_stream,
                                 len: *mut size_t,
-                                otype: *mut git_otype,
+                                otype: *mut git_object_t,
                                 db: *mut git_odb,
                                 oid: *const git_oid) -> c_int;
     pub fn git_odb_stream_read(stream: *mut git_odb_stream,
@@ -2903,7 +2889,7 @@ extern {
     pub fn git_odb_open_wstream(out: *mut *mut git_odb_stream,
                                 db: *mut git_odb,
                                 size: git_off_t,
-                                obj_type: git_otype) -> c_int;
+                                obj_type: git_object_t) -> c_int;
     pub fn git_odb_stream_write(stream: *mut git_odb_stream,
                                 buffer: *const c_char,
                                 len: size_t) -> c_int;
@@ -2917,7 +2903,7 @@ extern {
                         oid: *const git_oid) -> c_int;
 
     pub fn git_odb_read_header(len_out: *mut size_t,
-                               type_out: *mut git_otype,
+                               type_out: *mut git_object_t,
                                odb: *mut git_odb,
                                oid: *const git_oid) -> c_int;
 
@@ -2925,16 +2911,16 @@ extern {
                          odb: *mut git_odb,
                          data: *const c_void,
                          len: size_t,
-                         otype: git_otype) -> c_int;
+                         otype: git_object_t) -> c_int;
 
     pub fn git_odb_hash(out: *mut git_oid,
                         data: *const c_void,
                         len: size_t,
-                        otype: git_otype) -> c_int;
+                        otype: git_object_t) -> c_int;
 
     pub fn git_odb_hashfile(out: *mut git_oid,
                             path: *const c_char,
-                            otype: git_otype) -> c_int;
+                            otype: git_object_t) -> c_int;
 
     pub fn git_odb_exists_prefix(out: *mut git_oid,
                                  odb: *mut git_odb,
@@ -2948,7 +2934,7 @@ extern {
 
     pub fn git_odb_object_id(obj: *mut git_odb_object) -> *const git_oid;
     pub fn git_odb_object_size(obj: *mut git_odb_object) -> size_t;
-    pub fn git_odb_object_type(obj: *mut git_odb_object) -> git_otype;
+    pub fn git_odb_object_type(obj: *mut git_odb_object) -> git_object_t;
     pub fn git_odb_object_data(obj: *mut git_odb_object) -> *const c_void;
     pub fn git_odb_object_dup(out: *mut *mut git_odb_object,
                               obj: *mut git_odb_object) -> c_int;

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -68,6 +68,6 @@ impl Binding for Buf {
 
 impl Drop for Buf {
     fn drop(&mut self) {
-        unsafe { raw::git_buf_free(&mut self.raw) }
+        unsafe { raw::git_buf_dispose(&mut self.raw) }
     }
 }

--- a/src/call.rs
+++ b/src/call.rs
@@ -110,20 +110,20 @@ mod impls {
         }
     }
 
-    impl Convert<raw::git_otype> for ObjectType {
-        fn convert(&self) -> raw::git_otype {
+    impl Convert<raw::git_object_t> for ObjectType {
+        fn convert(&self) -> raw::git_object_t {
             match *self {
-                ObjectType::Any => raw::GIT_OBJ_ANY,
-                ObjectType::Commit => raw::GIT_OBJ_COMMIT,
-                ObjectType::Tree => raw::GIT_OBJ_TREE,
-                ObjectType::Blob => raw::GIT_OBJ_BLOB,
-                ObjectType::Tag => raw::GIT_OBJ_TAG,
+                ObjectType::Any => raw::GIT_OBJECT_ANY,
+                ObjectType::Commit => raw::GIT_OBJECT_COMMIT,
+                ObjectType::Tree => raw::GIT_OBJECT_TREE,
+                ObjectType::Blob => raw::GIT_OBJECT_BLOB,
+                ObjectType::Tag => raw::GIT_OBJECT_TAG,
             }
         }
     }
 
-    impl Convert<raw::git_otype> for Option<ObjectType> {
-        fn convert(&self) -> raw::git_otype {
+    impl Convert<raw::git_object_t> for Option<ObjectType> {
+        fn convert(&self) -> raw::git_object_t {
             self.unwrap_or(ObjectType::Any).convert()
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,7 +22,7 @@ impl Error {
     /// call. This code will later be returned from the `code` function.
     ///
     /// Historically this function returned `Some` or `None` based on the return
-    /// value of `giterr_last` but nowadays it always returns `Some` so it's
+    /// value of `git_error_last` but nowadays it always returns `Some` so it's
     /// safe to unwrap the return value. This API will change in the next major
     /// version.
     pub fn last_error(code: c_int) -> Option<Error> {
@@ -30,20 +30,20 @@ impl Error {
         unsafe {
             // Note that whenever libgit2 returns an error any negative value
             // indicates that an error happened. Auxiliary information is
-            // *usually* in `giterr_last` but unfortunately that's not always
+            // *usually* in `git_error_last` but unfortunately that's not always
             // the case. Sometimes a negative error code is returned from
-            // libgit2 *without* calling `giterr_set` internally to configure
+            // libgit2 *without* calling `git_error_set` internally to configure
             // the error.
             //
             // To handle this case and hopefully provide better error messages
-            // on our end we unconditionally call `giterr_clear` when we're done
+            // on our end we unconditionally call `git_error_clear` when we're done
             // with an error. This is an attempt to clear it as aggressively as
             // possible when we can to ensure that error information from one
             // api invocation doesn't leak over to the next api invocation.
             //
-            // Additionally if `giterr_last` returns null then we returned a
+            // Additionally if `git_error_last` returns null then we returned a
             // canned error out.
-            let ptr = raw::giterr_last();
+            let ptr = raw::git_error_last();
             let err = if ptr.is_null() {
                 let mut error = Error::from_str("an unknown git error occurred");
                 error.code = code;
@@ -51,7 +51,7 @@ impl Error {
             } else {
                 Error::from_raw(code, ptr)
             };
-            raw::giterr_clear();
+            raw::git_error_clear();
             Some(err)
         }
     }
@@ -65,11 +65,11 @@ impl Error {
     /// Creates a new error from the given string as the error.
     ///
     /// The error returned will have the code `GIT_ERROR` and the class
-    /// `GITERR_NONE`.
+    /// `GIT_ERROR_NONE`.
     pub fn from_str(s: &str) -> Error {
         Error {
             code: raw::GIT_ERROR as c_int,
-            klass: raw::GITERR_NONE as c_int,
+            klass: raw::GIT_ERROR_NONE as c_int,
             message: s.to_string(),
         }
     }
@@ -118,37 +118,37 @@ impl Error {
     /// typically not directly actionable.
     pub fn class(&self) -> ErrorClass {
         match self.raw_class() {
-            raw::GITERR_NONE => super::ErrorClass::None,
-            raw::GITERR_NOMEMORY => super::ErrorClass::NoMemory,
-            raw::GITERR_OS => super::ErrorClass::Os,
-            raw::GITERR_INVALID => super::ErrorClass::Invalid,
-            raw::GITERR_REFERENCE => super::ErrorClass::Reference,
-            raw::GITERR_ZLIB => super::ErrorClass::Zlib,
-            raw::GITERR_REPOSITORY => super::ErrorClass::Repository,
-            raw::GITERR_CONFIG => super::ErrorClass::Config,
-            raw::GITERR_REGEX => super::ErrorClass::Regex,
-            raw::GITERR_ODB => super::ErrorClass::Odb,
-            raw::GITERR_INDEX => super::ErrorClass::Index,
-            raw::GITERR_OBJECT => super::ErrorClass::Object,
-            raw::GITERR_NET => super::ErrorClass::Net,
-            raw::GITERR_TAG => super::ErrorClass::Tag,
-            raw::GITERR_TREE => super::ErrorClass::Tree,
-            raw::GITERR_INDEXER => super::ErrorClass::Indexer,
-            raw::GITERR_SSL => super::ErrorClass::Ssl,
-            raw::GITERR_SUBMODULE => super::ErrorClass::Submodule,
-            raw::GITERR_THREAD => super::ErrorClass::Thread,
-            raw::GITERR_STASH => super::ErrorClass::Stash,
-            raw::GITERR_CHECKOUT => super::ErrorClass::Checkout,
-            raw::GITERR_FETCHHEAD => super::ErrorClass::FetchHead,
-            raw::GITERR_MERGE => super::ErrorClass::Merge,
-            raw::GITERR_SSH => super::ErrorClass::Ssh,
-            raw::GITERR_FILTER => super::ErrorClass::Filter,
-            raw::GITERR_REVERT => super::ErrorClass::Revert,
-            raw::GITERR_CALLBACK => super::ErrorClass::Callback,
-            raw::GITERR_CHERRYPICK => super::ErrorClass::CherryPick,
-            raw::GITERR_DESCRIBE => super::ErrorClass::Describe,
-            raw::GITERR_REBASE => super::ErrorClass::Rebase,
-            raw::GITERR_FILESYSTEM => super::ErrorClass::Filesystem,
+            raw::GIT_ERROR_NONE => super::ErrorClass::None,
+            raw::GIT_ERROR_NOMEMORY => super::ErrorClass::NoMemory,
+            raw::GIT_ERROR_OS => super::ErrorClass::Os,
+            raw::GIT_ERROR_INVALID => super::ErrorClass::Invalid,
+            raw::GIT_ERROR_REFERENCE => super::ErrorClass::Reference,
+            raw::GIT_ERROR_ZLIB => super::ErrorClass::Zlib,
+            raw::GIT_ERROR_REPOSITORY => super::ErrorClass::Repository,
+            raw::GIT_ERROR_CONFIG => super::ErrorClass::Config,
+            raw::GIT_ERROR_REGEX => super::ErrorClass::Regex,
+            raw::GIT_ERROR_ODB => super::ErrorClass::Odb,
+            raw::GIT_ERROR_INDEX => super::ErrorClass::Index,
+            raw::GIT_ERROR_OBJECT => super::ErrorClass::Object,
+            raw::GIT_ERROR_NET => super::ErrorClass::Net,
+            raw::GIT_ERROR_TAG => super::ErrorClass::Tag,
+            raw::GIT_ERROR_TREE => super::ErrorClass::Tree,
+            raw::GIT_ERROR_INDEXER => super::ErrorClass::Indexer,
+            raw::GIT_ERROR_SSL => super::ErrorClass::Ssl,
+            raw::GIT_ERROR_SUBMODULE => super::ErrorClass::Submodule,
+            raw::GIT_ERROR_THREAD => super::ErrorClass::Thread,
+            raw::GIT_ERROR_STASH => super::ErrorClass::Stash,
+            raw::GIT_ERROR_CHECKOUT => super::ErrorClass::Checkout,
+            raw::GIT_ERROR_FETCHHEAD => super::ErrorClass::FetchHead,
+            raw::GIT_ERROR_MERGE => super::ErrorClass::Merge,
+            raw::GIT_ERROR_SSH => super::ErrorClass::Ssh,
+            raw::GIT_ERROR_FILTER => super::ErrorClass::Filter,
+            raw::GIT_ERROR_REVERT => super::ErrorClass::Revert,
+            raw::GIT_ERROR_CALLBACK => super::ErrorClass::Callback,
+            raw::GIT_ERROR_CHERRYPICK => super::ErrorClass::CherryPick,
+            raw::GIT_ERROR_DESCRIBE => super::ErrorClass::Describe,
+            raw::GIT_ERROR_REBASE => super::ErrorClass::Rebase,
+            raw::GIT_ERROR_FILESYSTEM => super::ErrorClass::Filesystem,
             _ => super::ErrorClass::None,
         }
     }
@@ -194,41 +194,41 @@ impl Error {
         macro_rules! check( ($($e:ident,)*) => (
             $(if self.klass == raw::$e as c_int { raw::$e }) else *
             else {
-                raw::GITERR_NONE
+                raw::GIT_ERROR_NONE
             }
         ) );
         check!(
-            GITERR_NONE,
-            GITERR_NOMEMORY,
-            GITERR_OS,
-            GITERR_INVALID,
-            GITERR_REFERENCE,
-            GITERR_ZLIB,
-            GITERR_REPOSITORY,
-            GITERR_CONFIG,
-            GITERR_REGEX,
-            GITERR_ODB,
-            GITERR_INDEX,
-            GITERR_OBJECT,
-            GITERR_NET,
-            GITERR_TAG,
-            GITERR_TREE,
-            GITERR_INDEXER,
-            GITERR_SSL,
-            GITERR_SUBMODULE,
-            GITERR_THREAD,
-            GITERR_STASH,
-            GITERR_CHECKOUT,
-            GITERR_FETCHHEAD,
-            GITERR_MERGE,
-            GITERR_SSH,
-            GITERR_FILTER,
-            GITERR_REVERT,
-            GITERR_CALLBACK,
-            GITERR_CHERRYPICK,
-            GITERR_DESCRIBE,
-            GITERR_REBASE,
-            GITERR_FILESYSTEM,
+            GIT_ERROR_NONE,
+            GIT_ERROR_NOMEMORY,
+            GIT_ERROR_OS,
+            GIT_ERROR_INVALID,
+            GIT_ERROR_REFERENCE,
+            GIT_ERROR_ZLIB,
+            GIT_ERROR_REPOSITORY,
+            GIT_ERROR_CONFIG,
+            GIT_ERROR_REGEX,
+            GIT_ERROR_ODB,
+            GIT_ERROR_INDEX,
+            GIT_ERROR_OBJECT,
+            GIT_ERROR_NET,
+            GIT_ERROR_TAG,
+            GIT_ERROR_TREE,
+            GIT_ERROR_INDEXER,
+            GIT_ERROR_SSL,
+            GIT_ERROR_SUBMODULE,
+            GIT_ERROR_THREAD,
+            GIT_ERROR_STASH,
+            GIT_ERROR_CHECKOUT,
+            GIT_ERROR_FETCHHEAD,
+            GIT_ERROR_MERGE,
+            GIT_ERROR_SSH,
+            GIT_ERROR_FILTER,
+            GIT_ERROR_REVERT,
+            GIT_ERROR_CALLBACK,
+            GIT_ERROR_CHERRYPICK,
+            GIT_ERROR_DESCRIBE,
+            GIT_ERROR_REBASE,
+            GIT_ERROR_FILESYSTEM,
         )
     }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -112,12 +112,12 @@ impl Index {
         // libgit2 encodes the length of the path in the lower bits of the
         // `flags` entry, so mask those out and recalculate here to ensure we
         // don't corrupt anything.
-        let mut flags = entry.flags & !raw::GIT_IDXENTRY_NAMEMASK;
+        let mut flags = entry.flags & !raw::GIT_INDEX_ENTRY_NAMEMASK;
 
-        if entry.path.len() < raw::GIT_IDXENTRY_NAMEMASK as usize {
+        if entry.path.len() < raw::GIT_INDEX_ENTRY_NAMEMASK as usize {
             flags |= entry.path.len() as u16;
         } else {
-            flags |= raw::GIT_IDXENTRY_NAMEMASK;
+            flags |= raw::GIT_INDEX_ENTRY_NAMEMASK;
         }
 
         unsafe {
@@ -169,12 +169,12 @@ impl Index {
         // libgit2 encodes the length of the path in the lower bits of the
         // `flags` entry, so mask those out and recalculate here to ensure we
         // don't corrupt anything.
-        let mut flags = entry.flags & !raw::GIT_IDXENTRY_NAMEMASK;
+        let mut flags = entry.flags & !raw::GIT_INDEX_ENTRY_NAMEMASK;
 
-        if entry.path.len() < raw::GIT_IDXENTRY_NAMEMASK as usize {
+        if entry.path.len() < raw::GIT_INDEX_ENTRY_NAMEMASK as usize {
             flags |= entry.path.len() as u16;
         } else {
-            flags |= raw::GIT_IDXENTRY_NAMEMASK;
+            flags |= raw::GIT_INDEX_ENTRY_NAMEMASK;
         }
 
         unsafe {
@@ -608,8 +608,8 @@ impl Binding for IndexEntry {
         // libgit2 encodes the length of the path in the lower bits of `flags`,
         // but if the length exceeds the number of bits then the path is
         // nul-terminated.
-        let mut pathlen = (flags & raw::GIT_IDXENTRY_NAMEMASK) as usize;
-        if pathlen == raw::GIT_IDXENTRY_NAMEMASK as usize {
+        let mut pathlen = (flags & raw::GIT_INDEX_ENTRY_NAMEMASK) as usize;
+        if pathlen == raw::GIT_INDEX_ENTRY_NAMEMASK as usize {
             pathlen = CStr::from_ptr(path).to_bytes().len();
         }
 

--- a/src/odb.rs
+++ b/src/odb.rs
@@ -52,7 +52,7 @@ impl<'repo> Odb<'repo> {
     pub fn reader(&self, oid: Oid) -> Result<(OdbReader, usize, ObjectType), Error> {
         let mut out = ptr::null_mut();
         let mut size = 0usize;
-        let mut otype: raw::git_otype = ObjectType::Any.raw();
+        let mut otype: raw::git_object_t = ObjectType::Any.raw();
         unsafe {
             try_call!(raw::git_odb_open_rstream(&mut out, &mut size, &mut otype, self.raw, oid.raw()));
             Ok((OdbReader::from_raw(out), size, ObjectType::from_raw(otype).unwrap()))
@@ -103,7 +103,7 @@ impl<'repo> Odb<'repo> {
             try_call!(raw::git_odb_read_header(&mut size
                                                   as *mut size_t,
                                                &mut kind_id
-                                                  as *mut raw::git_otype,
+                                                  as *mut raw::git_object_t,
                                                self.raw,
                                                oid.raw()));
 

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -345,8 +345,8 @@ mod tests {
         assert!(!head.is_note());
 
         // HEAD is a symbolic reference but git_repository_head resolves it
-        // so it is a GIT_REF_OID.
-        assert_eq!(head.kind().unwrap(), ReferenceType::Oid);
+        // so it is a GIT_REFERENCE_DIRECT.
+        assert_eq!(head.kind().unwrap(), ReferenceType::Direct);
 
         assert!(head == repo.head().unwrap());
         assert_eq!(head.name(), Some("refs/heads/master"));
@@ -365,7 +365,7 @@ mod tests {
                                       head.target().unwrap(),
                                       false, "test").unwrap();
         assert!(tag1.is_tag());
-        assert_eq!(tag1.kind().unwrap(), ReferenceType::Oid);
+        assert_eq!(tag1.kind().unwrap(), ReferenceType::Direct);
 
         let peeled_commit = tag1.peel(ObjectType::Commit).unwrap();
         assert_eq!(ObjectType::Commit, peeled_commit.kind().unwrap());

--- a/src/remote_callbacks.rs
+++ b/src/remote_callbacks.rs
@@ -280,7 +280,7 @@ extern fn credentials_cb(ret: *mut *mut raw::git_cred,
 
             callback(url, username_from_url, cred_type).map_err(|e| {
                 let s = CString::new(e.to_string()).unwrap();
-                raw::giterr_set_str(e.raw_code() as c_int, s.as_ptr());
+                raw::git_error_set_str(e.raw_code() as c_int, s.as_ptr());
                 e.raw_code() as c_int
             })
         });

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -315,7 +315,7 @@ extern fn stream_write(stream: *mut raw::git_smart_subtransport_stream,
 
 unsafe fn set_err(e: &io::Error) {
     let s = CString::new(e.to_string()).unwrap();
-    raw::giterr_set_str(raw::GITERR_NET as c_int, s.as_ptr())
+    raw::git_error_set_str(raw::GIT_ERROR_NET as c_int, s.as_ptr())
 }
 
 // callback used by smart transports to free a `SmartSubtransportStream`

--- a/systest/Cargo.toml
+++ b/systest/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 build = "build.rs"
 
 [dependencies]
-libgit2-sys = { path = "../libgit2-sys", features = ['curl', 'https', 'ssh'] }
+libgit2-sys = { path = "../libgit2-sys", features = ['https', 'ssh'] }
 libc = "0.2"
 
 [build-dependencies]

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -4,9 +4,10 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
-    let root = PathBuf::from(env::var_os("DEP_GIT2_ROOT").unwrap());
-
     let mut cfg = ctest::TestGenerator::new();
+    if let Some(root) = env::var_os("DEP_GIT2_ROOT") {
+       cfg.include(PathBuf::from(root).join("include"));
+    }
     cfg.header("git2.h")
        .header("git2/sys/transport.h")
        .header("git2/sys/refs.h")
@@ -15,7 +16,6 @@ fn main() {
        .header("git2/sys/mempack.h")
        .header("git2/sys/repository.h")
        .header("git2/cred_helpers.h")
-       .include(root.join("include"))
        .type_name(|s, _, _| s.to_string());
     cfg.field_name(|_, f| {
         match f {


### PR DESCRIPTION
ref: [Upstream changelog](https://github.com/libgit2/libgit2/blob/maint/v0.28/docs/changelog.md)

This includes a semver bump for all crates, as a few APIs have been
renamed in 0.28. Upstream provides `deprecated.h` aliases, if we'd like
to follow suit, but I feel it's better to just move forward.

- `giterr_*` -> `git_error_*`
- `GITERR_*` -> `GIT_ERROR_*`
- `git_otype` -> `git_object_t`
- `GIT_OBJ_*` -> `GIT_OBJECT_*`
- `git_ref_t` -> `git_reference_t`
- `GIT_REF_*` -> `GIT_REFERENCE_*`
- `git_idxentry_*` -> `git_index_entry_*`
- `GIT_IDXENTRY_*` -> `GIT_INDEX_ENTRY_*`
- `git_buf_free` -> `git_buf_dispose`

Proxy support is now builtin to `libgit2`, so `libcurl` is no longer a
dependency at all. Proxies were also the reason for `git2-curl` to
exist, which seems to be unnecessary for a while now, since `libgit2`
used `libcurl` itself since 0.23 anyway. Maybe `git2-curl` can just be
retired now, but I've updated it just for the sake of compatibility.

The minimum pkg-config libgit2 is now documented and tested for 0.28.
While it previously claimed support for 0.25.1, this was broken by
`git_config_entry`'s `include_depth` field, which was added *after* the
0.27 release branched.