### PR TITLE
Fix `bare_trait_objects` warning.

### DIFF
--- a/git2-curl/src/lib.rs
+++ b/git2-curl/src/lib.rs
@@ -94,7 +94,7 @@ fn factory(remote: &git2::Remote, handle: Arc<Mutex<Easy>>)
 
 impl SmartSubtransport for CurlTransport {
     fn action(&self, url: &str, action: Service)
-              -> Result<Box<SmartSubtransportStream>, Error> {
+              -> Result<Box<dyn SmartSubtransportStream>, Error> {
         let mut base_url = self.base_url.lock().unwrap();
         if base_url.len() == 0 {
             *base_url = url.to_string();
@@ -131,7 +131,7 @@ impl SmartSubtransport for CurlTransport {
 }
 
 impl CurlSubtransport {
-    fn err<E: Into<Box<error::Error+Send+Sync>>>(&self, err: E) -> io::Error {
+    fn err<E: Into<Box<dyn error::Error+Send+Sync>>>(&self, err: E) -> io::Error {
         io::Error::new(io::ErrorKind::Other, err)
     }
 

--- a/src/build.rs
+++ b/src/build.rs
@@ -26,7 +26,7 @@ pub struct RepoBuilder<'cb> {
 /// Type of callback passed to `RepoBuilder::remote_create`.
 ///
 /// The second and third arguments are the remote's name and the remote's url.
-pub type RemoteCreate<'cb> = for<'a> FnMut(&'a Repository, &str, &str)
+pub type RemoteCreate<'cb> = dyn for<'a> FnMut(&'a Repository, &str, &str)
     -> Result<Remote<'a>, Error> + 'cb;
 
 /// A builder struct for configuring checkouts of a repository.
@@ -50,7 +50,7 @@ pub struct CheckoutBuilder<'cb> {
 ///
 /// The first argument is the path for the notification, the next is the numver
 /// of completed steps so far, and the final is the total number of steps.
-pub type Progress<'a> = FnMut(Option<&Path>, usize, usize) + 'a;
+pub type Progress<'a> = dyn FnMut(Option<&Path>, usize, usize) + 'a;
 
 /// Checkout notifications callback.
 ///
@@ -59,7 +59,7 @@ pub type Progress<'a> = FnMut(Option<&Path>, usize, usize) + 'a;
 ///
 /// The callback must return a bool specifying whether the checkout should
 /// continue.
-pub type Notify<'a> = FnMut(CheckoutNotificationType, Option<&Path>,
+pub type Notify<'a> = dyn FnMut(CheckoutNotificationType, Option<&Path>,
                             Option<DiffFile>, Option<DiffFile>,
                             Option<DiffFile>) -> bool + 'a;
 

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -102,12 +102,12 @@ pub enum DiffBinaryKind {
     Delta,
 }
 
-type PrintCb<'a> = FnMut(DiffDelta, Option<DiffHunk>, DiffLine) -> bool + 'a;
+type PrintCb<'a> = dyn FnMut(DiffDelta, Option<DiffHunk>, DiffLine) -> bool + 'a;
 
-pub type FileCb<'a> = FnMut(DiffDelta, f32) -> bool + 'a;
-pub type BinaryCb<'a> = FnMut(DiffDelta, DiffBinary) -> bool + 'a;
-pub type HunkCb<'a> = FnMut(DiffDelta, DiffHunk) -> bool + 'a;
-pub type LineCb<'a> = FnMut(DiffDelta, Option<DiffHunk>, DiffLine) -> bool + 'a;
+pub type FileCb<'a> = dyn FnMut(DiffDelta, f32) -> bool + 'a;
+pub type BinaryCb<'a> = dyn FnMut(DiffDelta, DiffBinary) -> bool + 'a;
+pub type HunkCb<'a> = dyn FnMut(DiffDelta, DiffHunk) -> bool + 'a;
+pub type LineCb<'a> = dyn FnMut(DiffDelta, Option<DiffHunk>, DiffLine) -> bool + 'a;
 
 struct ForeachCallbacks<'a, 'b: 'a, 'c, 'd: 'c, 'e, 'f: 'e, 'g, 'h: 'g> {
     file: &'a mut FileCb<'b>,

--- a/src/index.rs
+++ b/src/index.rs
@@ -47,7 +47,7 @@ pub struct IndexConflict {
 /// Used by `Index::{add_all,remove_all,update_all}`.  The first argument is the
 /// path, and the second is the patchspec that matched it.  Return 0 to confirm
 /// the operation on the item, > 0 to skip the item, and < 0 to abort the scan.
-pub type IndexMatchedPath<'a> = FnMut(&Path, &[u8]) -> i32 + 'a;
+pub type IndexMatchedPath<'a> = dyn FnMut(&Path, &[u8]) -> i32 + 'a;
 
 /// A structure to represent an entry or a file inside of an index.
 ///

--- a/src/odb.rs
+++ b/src/odb.rs
@@ -312,7 +312,7 @@ impl<'repo> io::Write for OdbWriter<'repo> {
     fn flush(&mut self) -> io::Result<()> { Ok(()) }
 }
 
-pub type ForeachCb<'a> = FnMut(&Oid) -> bool + 'a;
+pub type ForeachCb<'a> = dyn FnMut(&Oid) -> bool + 'a;
 
 struct ForeachCbData<'a> {
     pub callback: &'a mut ForeachCb<'a>

--- a/src/packbuilder.rs
+++ b/src/packbuilder.rs
@@ -14,8 +14,8 @@ pub enum PackBuilderStage {
     Deltafication,
 }
 
-pub type ProgressCb<'a> = FnMut(PackBuilderStage, u32, u32) -> bool + 'a;
-pub type ForEachCb<'a> = FnMut(&[u8]) -> bool + 'a;
+pub type ProgressCb<'a> = dyn FnMut(PackBuilderStage, u32, u32) -> bool + 'a;
+pub type ForEachCb<'a> = dyn FnMut(&[u8]) -> bool + 'a;
 
 /// A builder for creating a packfile
 pub struct PackBuilder<'repo> {

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -1,7 +1,7 @@
 use std::any::Any;
 use std::cell::RefCell;
 
-thread_local!(static LAST_ERROR: RefCell<Option<Box<Any + Send>>> = {
+thread_local!(static LAST_ERROR: RefCell<Option<Box<dyn Any + Send>>> = {
     RefCell::new(None)
 });
 

--- a/src/remote_callbacks.rs
+++ b/src/remote_callbacks.rs
@@ -41,7 +41,7 @@ enum ProgressState {
 /// * `username_from_url` - the username that was embedded in the url, or `None`
 ///                         if it was not included.
 /// * `allowed_types` - a bitmask stating which cred types are ok to return.
-pub type Credentials<'a> = FnMut(&str, Option<&str>, CredentialType)
+pub type Credentials<'a> = dyn FnMut(&str, Option<&str>, CredentialType)
                                  -> Result<Cred, Error> + 'a;
 
 /// Callback to be invoked while a transfer is in progress.
@@ -51,15 +51,15 @@ pub type Credentials<'a> = FnMut(&str, Option<&str>, CredentialType)
 /// continue. A return value of `false` will cancel the transfer.
 ///
 /// * `progress` - the progress being made so far.
-pub type TransferProgress<'a> = FnMut(Progress) -> bool + 'a;
+pub type TransferProgress<'a> = dyn FnMut(Progress) -> bool + 'a;
 
 /// Callback for receiving messages delivered by the transport.
 ///
 /// The return value indicates whether the network operation should continue.
-pub type TransportMessage<'a> = FnMut(&[u8]) -> bool + 'a;
+pub type TransportMessage<'a> = dyn FnMut(&[u8]) -> bool + 'a;
 
 /// Callback for whenever a reference is updated locally.
-pub type UpdateTips<'a> = FnMut(&str, Oid, Oid) -> bool + 'a;
+pub type UpdateTips<'a> = dyn FnMut(&str, Oid, Oid) -> bool + 'a;
 
 /// Callback for a custom certificate check.
 ///
@@ -68,14 +68,14 @@ pub type UpdateTips<'a> = FnMut(&str, Oid, Oid) -> bool + 'a;
 ///
 /// The second argument is the hostname for the connection is passed as the last
 /// argument.
-pub type CertificateCheck<'a> = FnMut(&Cert, &str) -> bool + 'a;
+pub type CertificateCheck<'a> = dyn FnMut(&Cert, &str) -> bool + 'a;
 
 /// Callback for each updated reference on push.
 ///
 /// The first argument here is the `refname` of the reference, and the second is
 /// the status message sent by a server. If the status is `Some` then the update
 /// was rejected by the remote server with a reason why.
-pub type PushUpdateReference<'a> = FnMut(&str, Option<&str>) -> Result<(), Error> + 'a;
+pub type PushUpdateReference<'a> = dyn FnMut(&str, Option<&str>) -> Result<(), Error> + 'a;
 
 impl<'a> Default for RemoteCallbacks<'a> {
     fn default() -> Self {

--- a/src/stash.rs
+++ b/src/stash.rs
@@ -9,11 +9,11 @@ use std::mem;
 ///
 /// Return `true` to continue processing, or `false` to
 /// abort the stash application.
-pub type StashApplyProgressCb<'a> = FnMut(StashApplyProgress) -> bool + 'a;
+pub type StashApplyProgressCb<'a> = dyn FnMut(StashApplyProgress) -> bool + 'a;
 
 /// This is a callback function you can provide to iterate over all the
 /// stashed states that will be invoked per entry.
-pub type StashCb<'a> = FnMut(usize, &str, &Oid) -> bool + 'a;
+pub type StashCb<'a> = dyn FnMut(usize, &str, &Oid) -> bool + 'a;
 
 #[allow(unused)]
 /// Stash application options structure

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -40,7 +40,7 @@ pub trait SmartSubtransport: Send + 'static {
     /// returns a stream which can be read and written from in order to
     /// negotiate the git protocol.
     fn action(&self, url: &str, action: Service)
-              -> Result<Box<SmartSubtransportStream>, Error>;
+              -> Result<Box<dyn SmartSubtransportStream>, Error>;
 
     /// Terminates a connection with the remote.
     ///
@@ -73,7 +73,7 @@ pub trait SmartSubtransportStream: Read + Write + Send + 'static {}
 
 impl<T: Read + Write + Send + 'static> SmartSubtransportStream for T {}
 
-type TransportFactory = Fn(&Remote) -> Result<Transport, Error> + Send + Sync +
+type TransportFactory = dyn Fn(&Remote) -> Result<Transport, Error> + Send + Sync +
                                         'static;
 
 /// Boxed data payload used for registering new transports.
@@ -88,7 +88,7 @@ struct TransportData {
 #[repr(C)]
 struct RawSmartSubtransport {
     raw: raw::git_smart_subtransport,
-    obj: Box<SmartSubtransport>,
+    obj: Box<dyn SmartSubtransport>,
 }
 
 /// Instance of a `git_smart_subtransport_stream`, must use `#[repr(C)]` to
@@ -96,7 +96,7 @@ struct RawSmartSubtransport {
 #[repr(C)]
 struct RawSmartSubtransportStream {
     raw: raw::git_smart_subtransport_stream,
-    obj: Box<SmartSubtransportStream>,
+    obj: Box<dyn SmartSubtransportStream>,
 }
 
 /// Add a custom transport definition, to be used in addition to the built-in

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -199,7 +199,7 @@ impl<'repo> Tree<'repo> {
     }
 }
 
-type TreeWalkCb<'a, T> = FnMut(&str, &TreeEntry) -> T + 'a;
+type TreeWalkCb<'a, T> = dyn FnMut(&str, &TreeEntry) -> T + 'a;
 
 extern fn treewalk_cb<T: Into<i32>>(root: *const c_char, entry: *const raw::git_tree_entry, payload: *mut c_void) -> c_int {
     match panic::wrap(|| unsafe {

--- a/src/treebuilder.rs
+++ b/src/treebuilder.rs
@@ -98,7 +98,7 @@ impl<'repo> TreeBuilder<'repo> {
     }
 }
 
-type FilterCb<'a> = FnMut(&TreeEntry) -> bool + 'a;
+type FilterCb<'a> = dyn FnMut(&TreeEntry) -> bool + 'a;
 
 extern fn filter_cb(entry: *const raw::git_tree_entry,
                     payload: *mut c_void) -> c_int {


### PR DESCRIPTION
`bare_trait_objects` is now a warning on nightly (via https://github.com/rust-lang/rust/pull/61203). This is required to get tests passing on nightly.
