### PR TITLE
packbuilder: allow users to set number of threads

### DIFF
--- a/src/packbuilder.rs
+++ b/src/packbuilder.rs
@@ -138,6 +138,13 @@ impl<'repo> PackBuilder<'repo> {
         Ok(())
     }
 
+    /// Set the number of threads to be used.
+    ///
+    /// Returns the number of threads to be used.
+    pub fn set_threads(&mut self, threads: u32) -> u32 {
+        unsafe { raw::git_packbuilder_set_threads(self.raw, threads) }
+    }
+
     /// Get the total number of objects the packbuilder will write out.
     pub fn object_count(&self) -> usize {
         unsafe { raw::git_packbuilder_object_count(self.raw) }
@@ -382,5 +389,14 @@ mod tests {
             t!(builder.write_buf(&mut Buf::new()));
         }
         assert_eq!(progress_called, false);
+    }
+
+    #[test]
+    fn set_threads() {
+        let (_td, repo) = crate::test::repo_init();
+        let mut builder = t!(repo.packbuilder());
+        let used = builder.set_threads(4);
+        // Will be 1 if not compiled with threading.
+        assert!(used == 1 || used == 4);
     }
 }


### PR DESCRIPTION
libgit2 provides the option for the pack builder to be multi-threaded during deltification. On repositories of any significant size, such as the Linux kernel, threading provides a significant performance benefit. Allow users to specify the thread count used by a pack builder.

Opinions about the best interface here are welcome. The interface accepts 0 for "number of CPUs" and returns the number of threads actually set, which will always be 1 if threading is disabled. I'm unsure if we want an `Option<u32>` instead (with `None` as 0) or if specifying 0 as the value is better. Also, I considered checking the return value and coercing it into a Result if threads are disabled, but there isn't a really good value here (`GIT_EINVALID`? `GIT_ENOTFOUND`?).

I'm happy to revise (including the documentation) with whatever's decided if there's a better way forward.