### PR TITLE
Replace deprecated tempdir crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ docopt = "1.0"
 serde = "1.0"
 serde_derive = "1.0"
 time = "0.1.39"
-tempdir = "0.3.7"
+tempfile = "3.1.0"
 thread-id = "3.3.0" # remove when we work with minimal-versions without it
 
 [features]

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -146,11 +146,11 @@ mod tests {
     use std::fs::File;
     use std::io::prelude::*;
     use std::path::Path;
-    use tempdir::TempDir;
+    use tempfile::TempDir;
 
     #[test]
     fn buffer() {
-        let td = TempDir::new("test").unwrap();
+        let td = TempDir::new().unwrap();
         let repo = Repository::init(td.path()).unwrap();
         let id = repo.blob(&[5, 4, 6]).unwrap();
         let blob = repo.find_blob(id).unwrap();
@@ -169,7 +169,7 @@ mod tests {
 
     #[test]
     fn path() {
-        let td = TempDir::new("test").unwrap();
+        let td = TempDir::new().unwrap();
         let path = td.path().join("foo");
         File::create(&path).unwrap().write_all(&[7, 8, 9]).unwrap();
         let repo = Repository::init(td.path()).unwrap();
@@ -181,7 +181,7 @@ mod tests {
 
     #[test]
     fn stream() {
-        let td = TempDir::new("test").unwrap();
+        let td = TempDir::new().unwrap();
         let repo = Repository::init(td.path()).unwrap();
         let mut ws = repo.blob_writer(Some(Path::new("foo"))).unwrap();
         let wl = ws.write(&[10, 11, 12]).unwrap();

--- a/src/build.rs
+++ b/src/build.rs
@@ -645,7 +645,7 @@ mod tests {
     use crate::{CheckoutNotificationType, Repository};
     use std::fs;
     use std::path::Path;
-    use tempdir::TempDir;
+    use tempfile::TempDir;
 
     #[test]
     fn smoke() {
@@ -655,7 +655,7 @@ mod tests {
 
     #[test]
     fn smoke2() {
-        let td = TempDir::new("test").unwrap();
+        let td = TempDir::new().unwrap();
         Repository::init_bare(&td.path().join("bare")).unwrap();
         let url = if cfg!(unix) {
             format!("file://{}/bare", td.path().display())
@@ -675,8 +675,8 @@ mod tests {
     /// Issue regression test #365
     #[test]
     fn notify_callback() {
-        let td = TempDir::new("test").unwrap();
-        let cd = TempDir::new("external-checkout").unwrap();
+        let td = TempDir::new().unwrap();
+        let cd = TempDir::new().unwrap();
 
         {
             let repo = Repository::init(&td.path()).unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -535,7 +535,7 @@ impl<'cfg> Drop for ConfigEntry<'cfg> {
 #[cfg(test)]
 mod tests {
     use std::fs::File;
-    use tempdir::TempDir;
+    use tempfile::TempDir;
 
     use crate::Config;
 
@@ -549,7 +549,7 @@ mod tests {
 
     #[test]
     fn persisted() {
-        let td = TempDir::new("test").unwrap();
+        let td = TempDir::new().unwrap();
         let path = td.path().join("foo");
         File::create(&path).unwrap();
 
@@ -578,7 +578,7 @@ mod tests {
 
     #[test]
     fn multivar() {
-        let td = TempDir::new("test").unwrap();
+        let td = TempDir::new().unwrap();
         let path = td.path().join("foo");
         File::create(&path).unwrap();
 

--- a/src/cred.rs
+++ b/src/cred.rs
@@ -438,12 +438,12 @@ mod test {
     use std::fs::File;
     use std::io::prelude::*;
     use std::path::Path;
-    use tempdir::TempDir;
+    use tempfile::TempDir;
 
     use crate::{Config, ConfigLevel, Cred, CredentialHelper};
 
     macro_rules! test_cfg( ($($k:expr => $v:expr),*) => ({
-        let td = TempDir::new("git2-rs").unwrap();
+        let td = TempDir::new().unwrap();
         let mut cfg = Config::new().unwrap();
         cfg.add_file(&td.path().join("cfg"), ConfigLevel::Highest, false).unwrap();
         $(cfg.set_str($k, $v).unwrap();)*
@@ -498,7 +498,7 @@ mod test {
             return;
         } // shell scripts don't work on Windows
 
-        let td = TempDir::new("git2-rs").unwrap();
+        let td = TempDir::new().unwrap();
         let path = td.path().join("script");
         File::create(&path)
             .unwrap()
@@ -528,7 +528,7 @@ echo username=c
         if cfg!(windows) {
             return;
         } // shell scripts don't work on Windows
-        let td = TempDir::new("git2-rs").unwrap();
+        let td = TempDir::new().unwrap();
         let path = td.path().join("git-credential-script");
         File::create(&path)
             .unwrap()
@@ -574,7 +574,7 @@ echo username=c
         if cfg!(windows) {
             return;
         } // shell scripts don't work on Windows
-        let td = TempDir::new("git2-rs").unwrap();
+        let td = TempDir::new().unwrap();
         let path = td.path().join("script");
         File::create(&path)
             .unwrap()

--- a/src/index.rs
+++ b/src/index.rs
@@ -701,7 +701,7 @@ impl Binding for IndexEntry {
 mod tests {
     use std::fs::{self, File};
     use std::path::Path;
-    use tempdir::TempDir;
+    use tempfile::TempDir;
 
     use crate::{Index, IndexEntry, IndexTime, Oid, Repository, ResetType};
 
@@ -797,7 +797,7 @@ mod tests {
         let obj = repo.find_object(commit, None).unwrap();
         repo.reset(&obj, ResetType::Hard, None).unwrap();
 
-        let td2 = TempDir::new("git").unwrap();
+        let td2 = TempDir::new().unwrap();
         let url = crate::test::path2url(&root);
         let repo = Repository::clone(&url, td2.path()).unwrap();
         let obj = repo.find_object(commit, None).unwrap();

--- a/src/odb.rs
+++ b/src/odb.rs
@@ -378,11 +378,11 @@ extern "C" fn foreach_cb(id: *const raw::git_oid, payload: *mut c_void) -> c_int
 mod tests {
     use crate::{ObjectType, Oid, Repository};
     use std::io::prelude::*;
-    use tempdir::TempDir;
+    use tempfile::TempDir;
 
     #[test]
     fn read() {
-        let td = TempDir::new("test").unwrap();
+        let td = TempDir::new().unwrap();
         let repo = Repository::init(td.path()).unwrap();
         let dat = [4, 3, 5, 6, 9];
         let id = repo.blob(&dat).unwrap();
@@ -397,7 +397,7 @@ mod tests {
 
     #[test]
     fn read_header() {
-        let td = TempDir::new("test").unwrap();
+        let td = TempDir::new().unwrap();
         let repo = Repository::init(td.path()).unwrap();
         let dat = [4, 3, 5, 6, 9];
         let id = repo.blob(&dat).unwrap();
@@ -410,7 +410,7 @@ mod tests {
 
     #[test]
     fn write() {
-        let td = TempDir::new("test").unwrap();
+        let td = TempDir::new().unwrap();
         let repo = Repository::init(td.path()).unwrap();
         let dat = [4, 3, 5, 6, 9];
         let db = repo.odb().unwrap();
@@ -421,7 +421,7 @@ mod tests {
 
     #[test]
     fn writer() {
-        let td = TempDir::new("test").unwrap();
+        let td = TempDir::new().unwrap();
         let repo = Repository::init(td.path()).unwrap();
         let dat = [4, 3, 5, 6, 9];
         let db = repo.odb().unwrap();
@@ -437,7 +437,7 @@ mod tests {
 
     #[test]
     fn exists() {
-        let td = TempDir::new("test").unwrap();
+        let td = TempDir::new().unwrap();
         let repo = Repository::init(td.path()).unwrap();
         let dat = [4, 3, 5, 6, 9];
         let db = repo.odb().unwrap();
@@ -447,7 +447,7 @@ mod tests {
 
     #[test]
     fn exists_prefix() {
-        let td = TempDir::new("test").unwrap();
+        let td = TempDir::new().unwrap();
         let repo = Repository::init(td.path()).unwrap();
         let dat = [4, 3, 5, 6, 9];
         let db = repo.odb().unwrap();

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -197,7 +197,7 @@ mod tests {
     use super::Error;
     use super::Oid;
     use crate::ObjectType;
-    use tempdir::TempDir;
+    use tempfile::TempDir;
 
     #[test]
     fn conversions() {
@@ -246,7 +246,7 @@ mod tests {
 
     #[test]
     fn hash_file() {
-        let td = TempDir::new("test").unwrap();
+        let td = TempDir::new().unwrap();
         let path = td.path().join("hello.txt");
         let mut file = File::create(&path).unwrap();
         file.write_all("Hello".as_bytes()).unwrap();

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -586,7 +586,7 @@ mod tests {
     use crate::{AutotagOption, PushOptions};
     use crate::{Direction, FetchOptions, Remote, RemoteCallbacks, Repository};
     use std::cell::Cell;
-    use tempdir::TempDir;
+    use tempfile::TempDir;
 
     #[test]
     fn smoke() {
@@ -609,7 +609,7 @@ mod tests {
 
     #[test]
     fn create_remote() {
-        let td = TempDir::new("test").unwrap();
+        let td = TempDir::new().unwrap();
         let remote = td.path().join("remote");
         Repository::init_bare(&remote).unwrap();
 
@@ -690,7 +690,7 @@ mod tests {
 
     #[test]
     fn create_remote_anonymous() {
-        let td = TempDir::new("test").unwrap();
+        let td = TempDir::new().unwrap();
         let repo = Repository::init(td.path()).unwrap();
 
         let origin = repo.remote_anonymous("/path/to/nowhere").unwrap();
@@ -707,7 +707,7 @@ mod tests {
     #[test]
     fn transfer_cb() {
         let (td, _repo) = crate::test::repo_init();
-        let td2 = TempDir::new("git").unwrap();
+        let td2 = TempDir::new().unwrap();
         let url = crate::test::path2url(&td.path());
 
         let repo = Repository::init(td2.path()).unwrap();
@@ -743,7 +743,7 @@ mod tests {
     #[test]
     fn connect_list() {
         let (td, _repo) = crate::test::repo_init();
-        let td2 = TempDir::new("git").unwrap();
+        let td2 = TempDir::new().unwrap();
         let url = crate::test::path2url(&td.path());
 
         let repo = Repository::init(td2.path()).unwrap();
@@ -774,8 +774,8 @@ mod tests {
     #[test]
     fn push() {
         let (_td, repo) = crate::test::repo_init();
-        let td2 = TempDir::new("git1").unwrap();
-        let td3 = TempDir::new("git2").unwrap();
+        let td2 = TempDir::new().unwrap();
+        let td3 = TempDir::new().unwrap();
         let url = crate::test::path2url(&td2.path());
 
         Repository::init_bare(td2.path()).unwrap();

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -2583,11 +2583,11 @@ mod tests {
     use std::ffi::OsStr;
     use std::fs;
     use std::path::Path;
-    use tempdir::TempDir;
+    use tempfile::TempDir;
 
     #[test]
     fn smoke_init() {
-        let td = TempDir::new("test").unwrap();
+        let td = TempDir::new().unwrap();
         let path = td.path();
 
         let repo = Repository::init(path).unwrap();
@@ -2596,7 +2596,7 @@ mod tests {
 
     #[test]
     fn smoke_init_bare() {
-        let td = TempDir::new("test").unwrap();
+        let td = TempDir::new().unwrap();
         let path = td.path();
 
         let repo = Repository::init_bare(path).unwrap();
@@ -2606,7 +2606,7 @@ mod tests {
 
     #[test]
     fn smoke_open() {
-        let td = TempDir::new("test").unwrap();
+        let td = TempDir::new().unwrap();
         let path = td.path();
         Repository::init(td.path()).unwrap();
         let repo = Repository::open(path).unwrap();
@@ -2622,7 +2622,7 @@ mod tests {
 
     #[test]
     fn smoke_open_bare() {
-        let td = TempDir::new("test").unwrap();
+        let td = TempDir::new().unwrap();
         let path = td.path();
         Repository::init_bare(td.path()).unwrap();
 
@@ -2659,13 +2659,13 @@ mod tests {
 
     #[test]
     fn makes_dirs() {
-        let td = TempDir::new("foo").unwrap();
+        let td = TempDir::new().unwrap();
         Repository::init(&td.path().join("a/b/c/d")).unwrap();
     }
 
     #[test]
     fn smoke_discover() {
-        let td = TempDir::new("test").unwrap();
+        let td = TempDir::new().unwrap();
         let subdir = td.path().join("subdi");
         fs::create_dir(&subdir).unwrap();
         Repository::init_bare(td.path()).unwrap();
@@ -2678,7 +2678,7 @@ mod tests {
 
     #[test]
     fn smoke_open_ext() {
-        let td = TempDir::new("test").unwrap();
+        let td = TempDir::new().unwrap();
         let subdir = td.path().join("subdir");
         fs::create_dir(&subdir).unwrap();
         Repository::init(td.path()).unwrap();

--- a/src/submodule.rs
+++ b/src/submodule.rs
@@ -281,7 +281,7 @@ impl<'cb> Default for SubmoduleUpdateOptions<'cb> {
 mod tests {
     use std::fs;
     use std::path::Path;
-    use tempdir::TempDir;
+    use tempfile::TempDir;
     use url::Url;
 
     use crate::Repository;
@@ -289,7 +289,7 @@ mod tests {
 
     #[test]
     fn smoke() {
-        let td = TempDir::new("test").unwrap();
+        let td = TempDir::new().unwrap();
         let repo = Repository::init(td.path()).unwrap();
         let mut s1 = repo
             .submodule("/path/to/nowhere", Path::new("foo"), true)

--- a/src/test.rs
+++ b/src/test.rs
@@ -2,7 +2,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 #[cfg(unix)]
 use std::ptr;
-use tempdir::TempDir;
+use tempfile::TempDir;
 use url::Url;
 
 use crate::Repository;
@@ -17,7 +17,7 @@ macro_rules! t {
 }
 
 pub fn repo_init() -> (TempDir, Repository) {
-    let td = TempDir::new("test").unwrap();
+    let td = TempDir::new().unwrap();
     let repo = Repository::init(td.path()).unwrap();
     {
         let mut config = repo.config().unwrap();

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -403,7 +403,7 @@ mod tests {
     use std::fs::File;
     use std::io::prelude::*;
     use std::path::Path;
-    use tempdir::TempDir;
+    use tempfile::TempDir;
 
     pub struct TestTreeIter<'a> {
         entries: Vec<TreeEntry<'a>>,


### PR DESCRIPTION
`tempdir` is deprecated and recommends using `tempfile` instead.