### PR TITLE
Correct dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,9 @@ azure-devops = { project = "rust-lang/git2-rs", pipeline = "rust-lang.git2-rs", 
 
 [dependencies]
 url = "2.0"
-bitflags = "1.0"
+bitflags = "1.1.0"
 libc = "0.2"
-log = "0.4"
+log = "0.4.8"
 libgit2-sys = { path = "libgit2-sys", version = "0.8.2" }
 
 [target."cfg(all(unix, not(target_os = \"macos\")))".dependencies]


### PR DESCRIPTION
This crate does *not* compile with bitflags 1.0.0 or log 0.4.0, newer versions are required.