### PR TITLE
Enable the `parallel` feature of `cc`

### DIFF
--- a/libgit2-sys/Cargo.toml
+++ b/libgit2-sys/Cargo.toml
@@ -23,7 +23,7 @@ libz-sys = "1.0.22"
 
 [build-dependencies]
 pkg-config = "0.3.7"
-cc = "1.0.25"
+cc = { version = "1.0.25", features = ['parallel'] }
 
 [target.'cfg(unix)'.dependencies]
 openssl-sys = { version = "0.9", optional = true }


### PR DESCRIPTION
There's a lot of C objects to compile so serial compilation can actually
take quite some time! This enables the `parallel` feature of the `cc`
crate to compile objects in parallel and regain some build time back.