### PR TITLE
Bump to 0.10.1 and 0.9.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "git2"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Josh Triplett <josh@joshtriplett.org>", "Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -24,7 +24,7 @@ url = "2.0"
 bitflags = "1.1.0"
 libc = "0.2"
 log = "0.4.8"
-libgit2-sys = { path = "libgit2-sys", version = "0.9.0" }
+libgit2-sys = { path = "libgit2-sys", version = "0.9.1" }
 
 [target."cfg(all(unix, not(target_os = \"macos\")))".dependencies]
 openssl-sys = { version = "0.9.0", optional = true }

--- a/libgit2-sys/Cargo.toml
+++ b/libgit2-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libgit2-sys"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Josh Triplett <josh@joshtriplett.org>", "Alex Crichton <alex@alexcrichton.com>"]
 links = "git2"
 build = "build.rs"
@@ -23,7 +23,7 @@ libz-sys = "1.0.22"
 
 [build-dependencies]
 pkg-config = "0.3.7"
-cc = { version = "1.0.25", features = ['parallel'] }
+cc = { version = "1.0.42", features = ['parallel'] }
 
 [target.'cfg(unix)'.dependencies]
 openssl-sys = { version = "0.9", optional = true }


### PR DESCRIPTION
Publish a version of `libgit2-sys` which activates the `parallel`
feature and otherwise pull in recent changes to `git2` as well.