### PR TITLE
Fix documentation bug in merge function

### DIFF
--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1671,7 +1671,7 @@ impl Repository {
     ///
     /// For compatibility with git, the repository is put into a merging state.
     /// Once the commit is done (or if the user wishes to abort), you should
-    /// clear this state by calling git_repository_state_cleanup().
+    /// clear this state by calling cleanup_state().
     pub fn merge(
         &self,
         annotated_commits: &[&AnnotatedCommit<'_>],


### PR DESCRIPTION
The c function name was referenced instead of the rust function name.

Fixes Issue #471 