### PR TITLE
replace the azure link in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ git2 = "0.10"
 ## Rust version requirements
 
 git2-rs works with stable Rust, and typically works with the most recent prior
-stable release as well. Check [GitHub Actions](https://github.com/rust-lang/git2-rs/actions) to see the oldest
+stable release as well. Check the MSRV job of [the CI script](.github/workflows/main.yml) to see the oldest
 version of Rust known to pass tests.
 
 ## Version of libgit2

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ git2 = "0.10"
 ## Rust version requirements
 
 git2-rs works with stable Rust, and typically works with the most recent prior
-stable release as well. Check [azure-pipelines.yml](azure-pipelines.yml) to see the oldest
+stable release as well. Check [GitHub Actions](https://github.com/rust-lang/git2-rs/actions) to see the oldest
 version of Rust known to pass tests.
 
 ## Version of libgit2


### PR DESCRIPTION
the readme contained a url to the azure pipelines which were replaced with
GitHub actions in #468 (c9aaff5a2b60c562fcf178bbdb4f9bb1c4e008db).