### PR TITLE
Link to a blog post about git-notes(1)

### DIFF
--- a/src/note.rs
+++ b/src/note.rs
@@ -6,7 +6,7 @@ use crate::{raw, signature, Error, Oid, Repository, Signature};
 
 /// A structure representing a [note][note] in git.
 ///
-/// [note]: http://git-scm.com/blog/2010/08/25/notes.html
+/// [note]: http://alblue.bandlem.com/2011/11/git-tip-of-week-git-notes.html
 pub struct Note<'repo> {
     raw: *mut raw::git_note,
 


### PR DESCRIPTION
The documentation for the `Note` struct contains an expired link—the
blog doesn’t exist any more.  So replace that with a link to a good (and
live) blog post about git-notes(1) from 2011.

Fixes #480