### PR TITLE
Accept all refspecs that implement AsRef<str>

### DIFF
--- a/examples/fetch.rs
+++ b/examples/fetch.rs
@@ -81,7 +81,7 @@ fn run(args: &Args) -> Result<(), git2::Error> {
     // progress.
     let mut fo = FetchOptions::new();
     fo.remote_callbacks(cb);
-    remote.download(&[], Some(&mut fo))?;
+    remote.download(&[] as &[&str], Some(&mut fo))?;
 
     {
         // If there are local objects (we got a thin pack), then tell the user

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -224,9 +224,9 @@ impl<'repo> Remote<'repo> {
     /// let repo = git2::Repository::discover("rust").unwrap();
     /// fetch_origin_master(repo).unwrap();
     /// ```
-    pub fn fetch(
+    pub fn fetch<Str: AsRef<str> + crate::IntoCString + Clone>(
         &mut self,
-        refspecs: &[&str],
+        refspecs: &[Str],
         opts: Option<&mut FetchOptions<'_>>,
         reflog_msg: Option<&str>,
     ) -> Result<(), Error> {
@@ -269,9 +269,9 @@ impl<'repo> Remote<'repo> {
     /// Note that you'll likely want to use `RemoteCallbacks` and set
     /// `push_update_reference` to test whether all the references were pushed
     /// successfully.
-    pub fn push(
+    pub fn push<Str: AsRef<str> + crate::IntoCString + Clone>(
         &mut self,
-        refspecs: &[&str],
+        refspecs: &[Str],
         opts: Option<&mut PushOptions<'_>>,
     ) -> Result<(), Error> {
         let (_a, _b, arr) = crate::util::iter2cstrs(refspecs.iter())?;
@@ -667,8 +667,8 @@ mod tests {
         }
         assert!(!origin.connected());
 
-        origin.fetch(&[], None, None).unwrap();
-        origin.fetch(&[], None, Some("foo")).unwrap();
+        origin.fetch(&[] as &[&str], None, None).unwrap();
+        origin.fetch(&[] as &[&str], None, Some("foo")).unwrap();
         origin
             .update_tips(None, true, AutotagOption::Unspecified, None)
             .unwrap();
@@ -722,7 +722,7 @@ mod tests {
             });
             origin
                 .fetch(
-                    &[],
+                    &[] as &[&str],
                     Some(FetchOptions::new().remote_callbacks(callbacks)),
                     None,
                 )

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -175,9 +175,9 @@ impl<'repo> Remote<'repo> {
     ///
     /// The `specs` argument is a list of refspecs to use for this negotiation
     /// and download. Use an empty array to use the base refspecs.
-    pub fn download(
+    pub fn download<Str: AsRef<str> + crate::IntoCString + Clone>(
         &mut self,
-        specs: &[&str],
+        specs: &[Str],
         opts: Option<&mut FetchOptions<'_>>,
     ) -> Result<(), Error> {
         let (_a, _b, arr) = crate::util::iter2cstrs(specs.iter())?;
@@ -652,7 +652,7 @@ mod tests {
 
         origin.connect(Direction::Fetch).unwrap();
         assert!(origin.connected());
-        origin.download(&[], None).unwrap();
+        origin.download(&[] as &[&str], None).unwrap();
         origin.disconnect();
 
         {


### PR DESCRIPTION
This changes the signature of the `Remote::fetch` and `Remote::push` methods to accept refspecs as slices over not only `&str` but anything that implements `AsRef<str>` (as well as `IntoCString` and `Clone`). In this way, refspecs can be provided, for example, by a `&Vec<String>`, which wasn’t possible before.

The reason I’d like to contribute this change is that I’m in a situation where I retrieve remote references with `RemoteConnection::list` and turn them into a list of refspecs I want to fetch (or push), leaving me with a `Vec<String>` of refspecs. However, in order to call `Remote::fetch` (or `Remote::push`), I currently have to allocate a new `Vec<&str>` from this `Vec<String>`, which I’d like to avoid if possible.

I’m still in the process of learning Rust, so I hope that this change and my explanations make sense :slightly_smiling_face:. As far as I can tell, it’s not a breaking change in the sense that existing code using `Remote::fetch` and `Remote::push` should still be working.