### PR TITLE
Add support for remotes of branches

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -2424,6 +2424,16 @@ extern "C" {
     ) -> c_int;
     pub fn git_branch_upstream(out: *mut *mut git_reference, branch: *const git_reference)
         -> c_int;
+    pub fn git_branch_upstream_name(
+        out: *mut git_buf,
+        repo: *mut git_repository,
+        refname: *const c_char,
+    ) -> c_int;
+    pub fn git_branch_upstream_remote(
+        out: *mut git_buf,
+        repo: *mut git_repository,
+        refname: *const c_char,
+    ) -> c_int;
 
     // index
     pub fn git_index_add(index: *mut git_index, entry: *const git_index_entry) -> c_int;

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -2433,6 +2433,31 @@ impl Repository {
             Ok(())
         }
     }
+
+    /// Retrieves the name of the reference supporting the remote tracking branch,
+    /// given the name of a local branch reference.
+    pub fn branch_upstream_name(&self, refname: &str) -> Result<Buf, Error> {
+        let refname = CString::new(refname)?;
+        unsafe {
+            let buf = Buf::new();
+            try_call!(raw::git_branch_upstream_name(buf.raw(), self.raw, refname));
+            Ok(buf)
+        }
+    }
+
+    /// Retrieve the name of the upstream remote of a local branch.
+    pub fn branch_upstream_remote(&self, refname: &str) -> Result<Buf, Error> {
+        let refname = CString::new(refname)?;
+        unsafe {
+            let buf = Buf::new();
+            try_call!(raw::git_branch_upstream_remote(
+                buf.raw(),
+                self.raw,
+                refname
+            ));
+            Ok(buf)
+        }
+    }
 }
 
 impl Binding for Repository {


### PR DESCRIPTION
Wrap `git_branch_upstream_name` and `git_branch_upstream_remote` which retrieve the configured upstream remote and branch, but do not attempt to resolve them, so unlike `Branch::upstream` these functions don't fail if the branch has a configured upstream which doesn't exist.  This way we can detect "gone" branches, i.e. branches whose upstream got deleted on the remote and was subsequently pruned by `git fetch`.

I don't know whether I put the functions in the correct place, and I'm not sure how to test these; I'm happy to amend this pull request if you would review it and give me directions.

Closes GH-469