### PR TITLE
Fix for Odb.exists, which always returns true

### DIFF
--- a/src/odb.rs
+++ b/src/odb.rs
@@ -152,7 +152,7 @@ impl<'repo> Odb<'repo> {
 
     /// Checks if the object database has an object.
     pub fn exists(&self, oid: Oid) -> bool {
-        unsafe { raw::git_odb_exists(self.raw, oid.raw()) != -1 }
+        unsafe { raw::git_odb_exists(self.raw, oid.raw()) != 0 }
     }
 
     /// Potentially finds an object that starts with the given prefix.


### PR DESCRIPTION
The [document](https://libgit2.org/libgit2/#v0.28.3/group/odb/git_odb_exists) of libgit2 says:

`git_odb_exists` returns "- 1, if the object was found - 0, otherwise".

However, the "-" there does not means negative. This API returns either 0 or 1.