### PR TITLE
Allow delegating all linking

### DIFF
--- a/libgit2-sys/build.rs
+++ b/libgit2-sys/build.rs
@@ -4,6 +4,14 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn main() {
+    let k = "LIBGIT2_SYS_DELEGATE_LINKING";
+
+    println!("cargo:rerun-if-env-changed={}", k);
+
+    if env::var(k).is_ok() {
+        return;
+    }
+
     let https = env::var("CARGO_FEATURE_HTTPS").is_ok();
     let ssh = env::var("CARGO_FEATURE_SSH").is_ok();
 


### PR DESCRIPTION
This is necessary when an external build system (e.g. Buck) is taking
care of linking in git-sys, and we don't want the Rust compiler to emit
any linking arguments.

To do so, this adds a flag to just bail out of the build script and not
build any native crate if LIBGIT2_SYS_DELEGATE_LINKING is set in the
environment.