### PR TITLE
Update libgit2 submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "libgit2-sys/libgit2"]
 	path = libgit2-sys/libgit2
 	url = https://github.com/libgit2/libgit2
-	branch = maint/v0.28

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git2"
-version = "0.10.2"
+version = "0.11.0"
 authors = ["Josh Triplett <josh@joshtriplett.org>", "Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -20,7 +20,7 @@ url = "2.0"
 bitflags = "1.1.0"
 libc = "0.2"
 log = "0.4.8"
-libgit2-sys = { path = "libgit2-sys", version = "0.9.2" }
+libgit2-sys = { path = "libgit2-sys", version = "0.10.0" }
 
 [target."cfg(all(unix, not(target_os = \"macos\")))".dependencies]
 openssl-sys = { version = "0.9.0", optional = true }

--- a/git2-curl/Cargo.toml
+++ b/git2-curl/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2018"
 curl = "0.4"
 url = "2.0"
 log = "0.4"
-git2 = { path = "..", version = "0.10", default-features = false }
+git2 = { path = "..", version = "0.11", default-features = false }
 
 [dev-dependencies]
 civet = "0.11"

--- a/libgit2-sys/Cargo.toml
+++ b/libgit2-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libgit2-sys"
-version = "0.9.2"
+version = "0.10.0"
 authors = ["Josh Triplett <josh@joshtriplett.org>", "Alex Crichton <alex@alexcrichton.com>"]
 links = "git2"
 build = "build.rs"

--- a/src/call.rs
+++ b/src/call.rs
@@ -181,6 +181,7 @@ mod impls {
                 DiffFormat::Raw => raw::GIT_DIFF_FORMAT_RAW,
                 DiffFormat::NameOnly => raw::GIT_DIFF_FORMAT_NAME_ONLY,
                 DiffFormat::NameStatus => raw::GIT_DIFF_FORMAT_NAME_STATUS,
+                DiffFormat::PatchId => raw::GIT_DIFF_FORMAT_PATCH_ID,
             }
         }
     }

--- a/src/cert.rs
+++ b/src/cert.rs
@@ -76,6 +76,17 @@ impl<'a> CertHostkey<'a> {
             }
         }
     }
+
+    /// Returns the SHA-256 hash of the hostkey, if available.
+    pub fn hash_sha256(&self) -> Option<&[u8; 32]> {
+        unsafe {
+            if (*self.raw).kind as u32 & raw::GIT_CERT_SSH_SHA256 as u32 == 0 {
+                None
+            } else {
+                Some(&(*self.raw).hash_sha256)
+            }
+        }
+    }
 }
 
 impl<'a> CertX509<'a> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1187,6 +1187,8 @@ pub enum DiffFormat {
     NameOnly,
     /// like git diff --name-status
     NameStatus,
+    /// git diff as used by git patch-id
+    PatchId,
 }
 
 bitflags! {

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -44,7 +44,7 @@ impl MergeOptions {
         opts
     }
 
-    fn flag(&mut self, opt: raw::git_merge_flag_t, val: bool) -> &mut MergeOptions {
+    fn flag(&mut self, opt: u32, val: bool) -> &mut MergeOptions {
         if val {
             self.raw.flags |= opt;
         } else {
@@ -55,25 +55,25 @@ impl MergeOptions {
 
     /// Detect file renames
     pub fn find_renames(&mut self, find: bool) -> &mut MergeOptions {
-        self.flag(raw::GIT_MERGE_FIND_RENAMES, find)
+        self.flag(raw::GIT_MERGE_FIND_RENAMES as u32, find)
     }
 
     /// If a conflict occurs, exit immediately instead of attempting to continue
     /// resolving conflicts
     pub fn fail_on_conflict(&mut self, fail: bool) -> &mut MergeOptions {
-        self.flag(raw::GIT_MERGE_FAIL_ON_CONFLICT, fail)
+        self.flag(raw::GIT_MERGE_FAIL_ON_CONFLICT as u32, fail)
     }
 
     /// Do not write the REUC extension on the generated index
     pub fn skip_reuc(&mut self, skip: bool) -> &mut MergeOptions {
-        self.flag(raw::GIT_MERGE_FAIL_ON_CONFLICT, skip)
+        self.flag(raw::GIT_MERGE_FAIL_ON_CONFLICT as u32, skip)
     }
 
     /// If the commits being merged have multiple merge bases, do not build a
     /// recursive merge base (by merging the multiple merge bases), instead
     /// simply use the first base.
     pub fn no_recursive(&mut self, disable: bool) -> &mut MergeOptions {
-        self.flag(raw::GIT_MERGE_NO_RECURSIVE, disable)
+        self.flag(raw::GIT_MERGE_NO_RECURSIVE as u32, disable)
     }
 
     /// Similarity to consider a file renamed (default 50)
@@ -106,7 +106,7 @@ impl MergeOptions {
         self
     }
 
-    fn file_flag(&mut self, opt: raw::git_merge_file_flag_t, val: bool) -> &mut MergeOptions {
+    fn file_flag(&mut self, opt: u32, val: bool) -> &mut MergeOptions {
         if val {
             self.raw.file_flags |= opt;
         } else {
@@ -117,42 +117,42 @@ impl MergeOptions {
 
     /// Create standard conflicted merge files
     pub fn standard_style(&mut self, standard: bool) -> &mut MergeOptions {
-        self.file_flag(raw::GIT_MERGE_FILE_STYLE_MERGE, standard)
+        self.file_flag(raw::GIT_MERGE_FILE_STYLE_MERGE as u32, standard)
     }
 
     /// Create diff3-style file
     pub fn diff3_style(&mut self, diff3: bool) -> &mut MergeOptions {
-        self.file_flag(raw::GIT_MERGE_FILE_STYLE_DIFF3, diff3)
+        self.file_flag(raw::GIT_MERGE_FILE_STYLE_DIFF3 as u32, diff3)
     }
 
     /// Condense non-alphanumeric regions for simplified diff file
     pub fn simplify_alnum(&mut self, simplify: bool) -> &mut MergeOptions {
-        self.file_flag(raw::GIT_MERGE_FILE_SIMPLIFY_ALNUM, simplify)
+        self.file_flag(raw::GIT_MERGE_FILE_SIMPLIFY_ALNUM as u32, simplify)
     }
 
     /// Ignore all whitespace
     pub fn ignore_whitespace(&mut self, ignore: bool) -> &mut MergeOptions {
-        self.file_flag(raw::GIT_MERGE_FILE_IGNORE_WHITESPACE, ignore)
+        self.file_flag(raw::GIT_MERGE_FILE_IGNORE_WHITESPACE as u32, ignore)
     }
 
     /// Ignore changes in amount of whitespace
     pub fn ignore_whitespace_change(&mut self, ignore: bool) -> &mut MergeOptions {
-        self.file_flag(raw::GIT_MERGE_FILE_IGNORE_WHITESPACE_CHANGE, ignore)
+        self.file_flag(raw::GIT_MERGE_FILE_IGNORE_WHITESPACE_CHANGE as u32, ignore)
     }
 
     /// Ignore whitespace at end of line
     pub fn ignore_whitespace_eol(&mut self, ignore: bool) -> &mut MergeOptions {
-        self.file_flag(raw::GIT_MERGE_FILE_IGNORE_WHITESPACE_EOL, ignore)
+        self.file_flag(raw::GIT_MERGE_FILE_IGNORE_WHITESPACE_EOL as u32, ignore)
     }
 
     /// Use the "patience diff" algorithm
     pub fn patience(&mut self, patience: bool) -> &mut MergeOptions {
-        self.file_flag(raw::GIT_MERGE_FILE_DIFF_PATIENCE, patience)
+        self.file_flag(raw::GIT_MERGE_FILE_DIFF_PATIENCE as u32, patience)
     }
 
     /// Take extra time to find minimal diff
     pub fn minimal(&mut self, minimal: bool) -> &mut MergeOptions {
-        self.file_flag(raw::GIT_MERGE_FILE_DIFF_MINIMAL, minimal)
+        self.file_flag(raw::GIT_MERGE_FILE_DIFF_MINIMAL as u32, minimal)
     }
 
     /// Acquire a pointer to the underlying raw options.

--- a/src/odb.rs
+++ b/src/odb.rs
@@ -81,7 +81,7 @@ impl<'repo> Odb<'repo> {
             try_call!(raw::git_odb_open_wstream(
                 &mut out,
                 self.raw,
-                size as raw::git_off_t,
+                size as raw::git_object_size_t,
                 obj_type.raw()
             ));
             Ok(OdbWriter::from_raw(out))

--- a/src/stash.rs
+++ b/src/stash.rs
@@ -46,7 +46,7 @@ impl<'cb> StashApplyOptions<'cb> {
 
     /// Set stash application flag to GIT_STASH_APPLY_REINSTATE_INDEX
     pub fn reinstantiate_index(&mut self) -> &mut StashApplyOptions<'cb> {
-        self.raw_opts.flags = raw::GIT_STASH_APPLY_REINSTATE_INDEX;
+        self.raw_opts.flags = raw::GIT_STASH_APPLY_REINSTATE_INDEX as u32;
         self
     }
 

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -13,6 +13,7 @@ fn main() {
         .header("git2/sys/odb_backend.h")
         .header("git2/sys/mempack.h")
         .header("git2/sys/repository.h")
+        .header("git2/sys/cred.h")
         .header("git2/cred_helpers.h")
         .type_name(|s, _, _| s.to_string());
     cfg.field_name(|_, f| match f {


### PR DESCRIPTION
This updates the libgit2 submodule to latest master.

As several public struct members as well as some functions' parameters/return values have changed fundamental types (e.g from `git_off_t` which is an `int64_t` to `git_object_size_t` which is an `uint64_t`) I bumped the minor versions of both libgit2-sys and git2-rs (meaning it's equivalent to a major version bump for 0.x versions). As I'm not familiar with the version increment policy, let me know if that's wrong.