### PR TITLE
Make it possible to link in http_parser and pcre

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ If the `ssh` feature is enabled (and it is by default) then this library depends
 on libssh2 which depends on OpenSSL. To get OpenSSL working follow the
 [`openssl` crate's instructions](https://github.com/sfackler/rust-openssl#macos).
 
+## Linking to system libraries
+
+The underlying libgit2 library vendors two of its dependencies: pcre and
+http_parser`. By default, the libgit2-sys crate builds those two dependencies
+along with libgit2. If youd like to link them in instead, enable the
+`link_pcre` and / or `link_http_parser` features for the libgit2-sys crate.
+
 # License
 
 This project is licensed under either of

--- a/libgit2-sys/Cargo.toml
+++ b/libgit2-sys/Cargo.toml
@@ -32,3 +32,5 @@ openssl-sys = { version = "0.9", optional = true }
 ssh = ["libssh2-sys"]
 https = ["openssl-sys"]
 ssh_key_from_memory = []
+link_http_parser = []
+link_pcre = []


### PR DESCRIPTION
This adds features for using dynamically linked http_parser and pcre
libraries. This makes it possible to use git2-rs in a binary that
otherwise links those in already without duplicate linking issues.