### PR TITLE
Add missing error classes and error codes

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -187,6 +187,10 @@ git_enum! {
         GIT_EMERGECONFLICT = -24,
         GIT_PASSTHROUGH = -30,
         GIT_ITEROVER = -31,
+        GIT_RETRY = -32,
+        GIT_EMISMATCH = -33,
+        GIT_EINDEXDIRTY = -34,
+        GIT_EAPPLYFAIL = -35,
     }
 }
 
@@ -223,6 +227,9 @@ git_enum! {
         GIT_ERROR_DESCRIBE,
         GIT_ERROR_REBASE,
         GIT_ERROR_FILESYSTEM,
+        GIT_ERROR_PATCH,
+        GIT_ERROR_WORKTREE,
+        GIT_ERROR_SHA1,
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -153,6 +153,9 @@ impl Error {
             raw::GIT_ERROR_DESCRIBE => super::ErrorClass::Describe,
             raw::GIT_ERROR_REBASE => super::ErrorClass::Rebase,
             raw::GIT_ERROR_FILESYSTEM => super::ErrorClass::Filesystem,
+            raw::GIT_ERROR_PATCH => super::ErrorClass::Patch,
+            raw::GIT_ERROR_WORKTREE => super::ErrorClass::Worktree,
+            raw::GIT_ERROR_SHA1 => super::ErrorClass::Sha1,
             _ => super::ErrorClass::None,
         }
     }
@@ -190,6 +193,10 @@ impl Error {
             GIT_EUNCOMMITTED,
             GIT_PASSTHROUGH,
             GIT_ITEROVER,
+            GIT_RETRY,
+            GIT_EMISMATCH,
+            GIT_EINDEXDIRTY,
+            GIT_EAPPLYFAIL,
         )
     }
 
@@ -233,6 +240,9 @@ impl Error {
             GIT_ERROR_DESCRIBE,
             GIT_ERROR_REBASE,
             GIT_ERROR_FILESYSTEM,
+            GIT_ERROR_PATCH,
+            GIT_ERROR_WORKTREE,
+            GIT_ERROR_SHA1,
         )
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,6 +252,12 @@ pub enum ErrorClass {
     Rebase,
     /// Filesystem-related error
     Filesystem,
+    /// Invalid patch data
+    Patch,
+    /// Error involving worktrees
+    Worktree,
+    /// Hash library error or SHA-1 collision
+    Sha1,
 }
 
 /// A listing of the possible states that a repository can be in.


### PR DESCRIPTION
This makes the git2-rs error classes and error codes be in sync with libgit2's.