### PR TITLE
Odb writepack support

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -85,7 +85,6 @@ pub enum git_packbuilder {}
 pub enum git_odb {}
 pub enum git_odb_stream {}
 pub enum git_odb_object {}
-pub enum git_odb_writepack {}
 pub enum git_worktree {}
 
 #[repr(C)]
@@ -402,7 +401,7 @@ pub type git_transport_message_cb = extern "C" fn(*const c_char, c_int, *mut c_v
 pub type git_cred_acquire_cb =
     extern "C" fn(*mut *mut git_cred, *const c_char, *const c_char, c_uint, *mut c_void) -> c_int;
 pub type git_transfer_progress_cb =
-    extern "C" fn(*const git_transfer_progress, *mut c_void) -> c_int;
+    extern "C" fn(*const git_indexer_progress, *mut c_void) -> c_int;
 pub type git_packbuilder_progress =
     extern "C" fn(git_packbuilder_stage_t, c_uint, c_uint, *mut c_void) -> c_int;
 pub type git_push_transfer_progress = extern "C" fn(c_uint, c_uint, size_t, *mut c_void) -> c_int;
@@ -1397,6 +1396,25 @@ pub struct git_odb_backend {
     pub freshen: Option<extern "C" fn(*mut git_odb_backend, *const git_oid) -> c_int>,
 
     pub free: Option<extern "C" fn(*mut git_odb_backend)>,
+}
+
+#[repr(C)]
+pub struct git_odb_writepack {
+    pub backend: *mut git_odb_backend,
+
+    pub append: Option<
+        extern "C" fn(
+            *mut git_odb_writepack,
+            *const c_void,
+            size_t,
+            *mut git_indexer_progress,
+        ) -> c_int,
+    >,
+
+    pub commit:
+        Option<unsafe extern "C" fn(*mut git_odb_writepack, *mut git_indexer_progress) -> c_int>,
+
+    pub free: Option<unsafe extern "C" fn(*mut git_odb_writepack)>,
 }
 
 #[repr(C)]
@@ -3352,6 +3370,13 @@ extern "C" {
         data: *const c_void,
         len: size_t,
         otype: git_object_t,
+    ) -> c_int;
+
+    pub fn git_odb_write_pack(
+        out: *mut *mut git_odb_writepack,
+        odb: *mut git_odb,
+        progress_cb: git_indexer_progress_cb,
+        progress_payload: *mut c_void,
     ) -> c_int;
 
     pub fn git_odb_hash(

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1,0 +1,96 @@
+use std::marker;
+
+use crate::raw;
+use crate::util::Binding;
+
+/// Struct representing the progress by an in-flight transfer.
+pub struct Progress<'a> {
+    pub(crate) raw: ProgressState,
+    pub(crate) _marker: marker::PhantomData<&'a raw::git_indexer_progress>,
+}
+
+pub(crate) enum ProgressState {
+    Borrowed(*const raw::git_indexer_progress),
+    Owned(raw::git_indexer_progress),
+}
+
+/// Callback to be invoked while indexing is in progress.
+///
+/// This callback will be periodically called with updates to the progress of
+/// the indexing so far. The return value indicates whether the indexing or
+/// transfer should continue. A return value of `false` will cancel the
+/// indexing or transfer.
+///
+/// * `progress` - the progress being made so far.
+pub type IndexerProgress<'a> = dyn FnMut(Progress<'_>) -> bool + 'a;
+
+impl<'a> Progress<'a> {
+    /// Number of objects in the packfile being downloaded
+    pub fn total_objects(&self) -> usize {
+        unsafe { (*self.raw()).total_objects as usize }
+    }
+    /// Received objects that have been hashed
+    pub fn indexed_objects(&self) -> usize {
+        unsafe { (*self.raw()).indexed_objects as usize }
+    }
+    /// Objects which have been downloaded
+    pub fn received_objects(&self) -> usize {
+        unsafe { (*self.raw()).received_objects as usize }
+    }
+    /// Locally-available objects that have been injected in order to fix a thin
+    /// pack.
+    pub fn local_objects(&self) -> usize {
+        unsafe { (*self.raw()).local_objects as usize }
+    }
+    /// Number of deltas in the packfile being downloaded
+    pub fn total_deltas(&self) -> usize {
+        unsafe { (*self.raw()).total_deltas as usize }
+    }
+    /// Received deltas that have been hashed.
+    pub fn indexed_deltas(&self) -> usize {
+        unsafe { (*self.raw()).indexed_deltas as usize }
+    }
+    /// Size of the packfile received up to now
+    pub fn received_bytes(&self) -> usize {
+        unsafe { (*self.raw()).received_bytes as usize }
+    }
+
+    /// Convert this to an owned version of `Progress`.
+    pub fn to_owned(&self) -> Progress<'static> {
+        Progress {
+            raw: ProgressState::Owned(unsafe { *self.raw() }),
+            _marker: marker::PhantomData,
+        }
+    }
+}
+
+impl<'a> Binding for Progress<'a> {
+    type Raw = *const raw::git_indexer_progress;
+    unsafe fn from_raw(raw: *const raw::git_indexer_progress) -> Progress<'a> {
+        Progress {
+            raw: ProgressState::Borrowed(raw),
+            _marker: marker::PhantomData,
+        }
+    }
+
+    fn raw(&self) -> *const raw::git_indexer_progress {
+        match self.raw {
+            ProgressState::Borrowed(raw) => raw,
+            ProgressState::Owned(ref raw) => raw as *const _,
+        }
+    }
+}
+
+/// Callback to be invoked while a transfer is in progress.
+///
+/// This callback will be periodically called with updates to the progress of
+/// the transfer so far. The return value indicates whether the transfer should
+/// continue. A return value of `false` will cancel the transfer.
+///
+/// * `progress` - the progress being made so far.
+#[deprecated(
+    since = "0.11.0",
+    note = "renamed to `IndexerProgress` to match upstream"
+)]
+#[allow(dead_code)]
+pub type TransportProgress<'a> = IndexerProgress<'a>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,7 @@ pub use crate::error::Error;
 pub use crate::index::{
     Index, IndexConflict, IndexConflicts, IndexEntries, IndexEntry, IndexMatchedPath,
 };
+pub use crate::indexer::{IndexerProgress, Progress};
 pub use crate::merge::{AnnotatedCommit, MergeOptions};
 pub use crate::message::{message_prettify, DEFAULT_COMMENT_CHAR};
 pub use crate::note::{Note, Notes};
@@ -111,8 +112,8 @@ pub use crate::refspec::Refspec;
 pub use crate::remote::{
     FetchOptions, PushOptions, Refspecs, Remote, RemoteConnection, RemoteHead,
 };
-pub use crate::remote_callbacks::{Credentials, RemoteCallbacks, TransferProgress};
-pub use crate::remote_callbacks::{Progress, TransportMessage, UpdateTips};
+pub use crate::remote_callbacks::{Credentials, RemoteCallbacks};
+pub use crate::remote_callbacks::{TransportMessage, UpdateTips};
 pub use crate::repo::{Repository, RepositoryInitOptions};
 pub use crate::revspec::Revspec;
 pub use crate::revwalk::Revwalk;
@@ -631,6 +632,7 @@ mod describe;
 mod diff;
 mod error;
 mod index;
+mod indexer;
 mod merge;
 mod message;
 mod note;

--- a/src/remote_callbacks.rs
+++ b/src/remote_callbacks.rs
@@ -1,6 +1,5 @@
 use libc::{c_char, c_int, c_uint, c_void};
 use std::ffi::{CStr, CString};
-use std::marker;
 use std::mem;
 use std::ptr;
 use std::slice;
@@ -8,7 +7,7 @@ use std::str;
 
 use crate::cert::Cert;
 use crate::util::Binding;
-use crate::{panic, raw, Cred, CredentialType, Error, Oid};
+use crate::{panic, raw, Cred, CredentialType, Error, IndexerProgress, Oid, Progress};
 
 /// A structure to contain the callbacks which are invoked when a repository is
 /// being updated or downloaded.
@@ -16,23 +15,12 @@ use crate::{panic, raw, Cred, CredentialType, Error, Oid};
 /// These callbacks are used to manage facilities such as authentication,
 /// transfer progress, etc.
 pub struct RemoteCallbacks<'a> {
-    progress: Option<Box<TransferProgress<'a>>>,
+    progress: Option<Box<IndexerProgress<'a>>>,
     credentials: Option<Box<Credentials<'a>>>,
     sideband_progress: Option<Box<TransportMessage<'a>>>,
     update_tips: Option<Box<UpdateTips<'a>>>,
     certificate_check: Option<Box<CertificateCheck<'a>>>,
     push_update_reference: Option<Box<PushUpdateReference<'a>>>,
-}
-
-/// Struct representing the progress by an in-flight transfer.
-pub struct Progress<'a> {
-    raw: ProgressState,
-    _marker: marker::PhantomData<&'a raw::git_transfer_progress>,
-}
-
-enum ProgressState {
-    Borrowed(*const raw::git_transfer_progress),
-    Owned(raw::git_transfer_progress),
 }
 
 /// Callback used to acquire credentials for when a remote is fetched.
@@ -43,15 +31,6 @@ enum ProgressState {
 /// * `allowed_types` - a bitmask stating which cred types are ok to return.
 pub type Credentials<'a> =
     dyn FnMut(&str, Option<&str>, CredentialType) -> Result<Cred, Error> + 'a;
-
-/// Callback to be invoked while a transfer is in progress.
-///
-/// This callback will be periodically called with updates to the progress of
-/// the transfer so far. The return value indicates whether the transfer should
-/// continue. A return value of `false` will cancel the transfer.
-///
-/// * `progress` - the progress being made so far.
-pub type TransferProgress<'a> = dyn FnMut(Progress<'_>) -> bool + 'a;
 
 /// Callback for receiving messages delivered by the transport.
 ///
@@ -110,7 +89,7 @@ impl<'a> RemoteCallbacks<'a> {
     where
         F: FnMut(Progress<'_>) -> bool + 'a,
     {
-        self.progress = Some(Box::new(cb) as Box<TransferProgress<'a>>);
+        self.progress = Some(Box::new(cb) as Box<IndexerProgress<'a>>);
         self
     }
 
@@ -175,7 +154,7 @@ impl<'a> Binding for RemoteCallbacks<'a> {
                 0
             );
             if self.progress.is_some() {
-                let f: raw::git_transfer_progress_cb = transfer_progress_cb;
+                let f: raw::git_indexer_progress_cb = transfer_progress_cb;
                 callbacks.transfer_progress = Some(f);
             }
             if self.credentials.is_some() {
@@ -205,63 +184,6 @@ impl<'a> Binding for RemoteCallbacks<'a> {
             }
             callbacks.payload = self as *const _ as *mut _;
             callbacks
-        }
-    }
-}
-
-impl<'a> Progress<'a> {
-    /// Number of objects in the packfile being downloaded
-    pub fn total_objects(&self) -> usize {
-        unsafe { (*self.raw()).total_objects as usize }
-    }
-    /// Received objects that have been hashed
-    pub fn indexed_objects(&self) -> usize {
-        unsafe { (*self.raw()).indexed_objects as usize }
-    }
-    /// Objects which have been downloaded
-    pub fn received_objects(&self) -> usize {
-        unsafe { (*self.raw()).received_objects as usize }
-    }
-    /// Locally-available objects that have been injected in order to fix a thin
-    /// pack.
-    pub fn local_objects(&self) -> usize {
-        unsafe { (*self.raw()).local_objects as usize }
-    }
-    /// Number of deltas in the packfile being downloaded
-    pub fn total_deltas(&self) -> usize {
-        unsafe { (*self.raw()).total_deltas as usize }
-    }
-    /// Received deltas that have been hashed.
-    pub fn indexed_deltas(&self) -> usize {
-        unsafe { (*self.raw()).indexed_deltas as usize }
-    }
-    /// Size of the packfile received up to now
-    pub fn received_bytes(&self) -> usize {
-        unsafe { (*self.raw()).received_bytes as usize }
-    }
-
-    /// Convert this to an owned version of `Progress`.
-    pub fn to_owned(&self) -> Progress<'static> {
-        Progress {
-            raw: ProgressState::Owned(unsafe { *self.raw() }),
-            _marker: marker::PhantomData,
-        }
-    }
-}
-
-impl<'a> Binding for Progress<'a> {
-    type Raw = *const raw::git_transfer_progress;
-    unsafe fn from_raw(raw: *const raw::git_transfer_progress) -> Progress<'a> {
-        Progress {
-            raw: ProgressState::Borrowed(raw),
-            _marker: marker::PhantomData,
-        }
-    }
-
-    fn raw(&self) -> *const raw::git_transfer_progress {
-        match self.raw {
-            ProgressState::Borrowed(raw) => raw,
-            ProgressState::Owned(ref raw) => raw as *const _,
         }
     }
 }
@@ -316,7 +238,7 @@ extern "C" fn credentials_cb(
 }
 
 extern "C" fn transfer_progress_cb(
-    stats: *const raw::git_transfer_progress,
+    stats: *const raw::git_indexer_progress,
     payload: *mut c_void,
 ) -> c_int {
     let ok = panic::wrap(|| unsafe {


### PR DESCRIPTION
Adds support for [`git_odb_write_pack`](https://libgit2.org/libgit2/#HEAD/group/odb/git_odb_write_pack) and [`git_odb_writepack`](https://libgit2.org/libgit2/#HEAD/type/git_odb_writepack).

Does not support defining a progress callback yet, would be open to add that if deemed necessary for this PR or in a follow-up PR. Some work on this is already in https://github.com/stoically/git2-rs/commit/79df856d2de5e9b8c6b63b1562e6e7b3e3cd4e0b which renames `git_transfer_progress` to `git_indexer_progress` to match an upstream refactoring.