### PR TITLE
Adding missing binding for git_remote_create_with_fetchspec

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -1810,6 +1810,13 @@ extern "C" {
         name: *const c_char,
         url: *const c_char,
     ) -> c_int;
+    pub fn git_remote_create_with_fetchspec(
+        out: *mut *mut git_remote,
+        repo: *mut git_repository,
+        name: *const c_char,
+        url: *const c_char,
+        fetch: *const c_char,
+    ) -> c_int;
     pub fn git_remote_lookup(
         out: *mut *mut git_remote,
         repo: *mut git_repository,

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -490,6 +490,19 @@ impl Repository {
         }
     }
 
+    /// Add a remote with the provided fetch refspec to the repository's
+    /// configuration.
+    pub fn remote_with_fetch(&self, name: &str, url: &str, fetch: &str) -> Result<Remote<'_>, Error> {
+        let mut ret = ptr::null_mut();
+        let name = CString::new(name)?;
+        let url = CString::new(url)?;
+        let fetch = CString::new(fetch)?;
+        unsafe {
+            try_call!(raw::git_remote_create_with_fetchspec(&mut ret, self.raw, name, url, fetch));
+            Ok(Binding::from_raw(ret))
+        }
+    }
+
     /// Create an anonymous remote
     ///
     /// Create a remote with the given url and refspec in memory. You can use

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -492,13 +492,20 @@ impl Repository {
 
     /// Add a remote with the provided fetch refspec to the repository's
     /// configuration.
-    pub fn remote_with_fetch(&self, name: &str, url: &str, fetch: &str) -> Result<Remote<'_>, Error> {
+    pub fn remote_with_fetch(
+        &self,
+        name: &str,
+        url: &str,
+        fetch: &str,
+    ) -> Result<Remote<'_>, Error> {
         let mut ret = ptr::null_mut();
         let name = CString::new(name)?;
         let url = CString::new(url)?;
         let fetch = CString::new(fetch)?;
         unsafe {
-            try_call!(raw::git_remote_create_with_fetchspec(&mut ret, self.raw, name, url, fetch));
+            try_call!(raw::git_remote_create_with_fetchspec(
+                &mut ret, self.raw, name, url, fetch
+            ));
             Ok(Binding::from_raw(ret))
         }
     }


### PR DESCRIPTION
Awesome project by the way. Just looking to add a missing binding that I needed to be able to clone a single branch rather than the entire repo.

Some references:
* https://github.com/libgit2/libgit2/issues/2924
* https://github.com/libgit2/libgit2/issues/1142

Example Usage:
```rust
let branch = "packages/pkgfile";
let mut builder = RepoBuilder::new();
builder.branch(branch);
builder.remote_create(|repo, name, url| {
    let refspec = format!("+refs/heads/{0:}:refs/remotes/origin/{0:}", branch);
    repo.remote_with_fetch(name, url, &refspec)
});
builder.clone("https://git.archlinux.org/svntogit/packages.git", Path::new("temp")).unwrap();
```