### PR TITLE
Support libgit2 error message report when assertion failed

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -3553,18 +3553,22 @@ pub fn init() {
         openssl_init();
         ssh_init();
         let r = git_libgit2_init();
-        let git_error = git_error_last();
-        let mut error_msg: *mut c_char = ptr::null_mut();
-        if !git_error.is_null() {
-            error_msg = (*git_error).message;
-        }
-        if !error_msg.is_null() {
-            assert!(
-                r >= 0,
-                "couldn't initialize the libgit2 library: {}, error: {}",
-                r,
-                CStr::from_ptr(error_msg).to_string_lossy()
-            );
+        if r < 0 {
+            let git_error = git_error_last();
+            let mut error_msg: *mut c_char = ptr::null_mut();
+            if !git_error.is_null() {
+                error_msg = (*git_error).message;
+            }
+            if !error_msg.is_null() {
+                assert!(
+                    r >= 0,
+                    "couldn't initialize the libgit2 library: {}, error: {}",
+                    r,
+                    CStr::from_ptr(error_msg).to_string_lossy()
+                );
+            } else {
+                assert!(r >= 0, "couldn't initialize the libgit2 library: {}", r);
+            }
         } else {
             assert!(r >= 0, "couldn't initialize the libgit2 library: {}", r);
         }


### PR DESCRIPTION
Addresses #516 

Current libgit2-sys implementation does not call `git_error_last()` to get *git_error object* and reporting its *message member* contents.
E.g. cargo just complains the following error when `git_libgit2_init()` is failing with the current implementation:

```
$ ./cargo --version
thread 'main' panicked at 'couldn't initialize the libgit2 library: -1', /usr/src/debug/cargo-native/1.37.0-r0/rustc-1.37.0-src/vendor/libgit2-sys/lib.rs:3356:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```