### PR TITLE
attempt to use pkg-config to get include path for dependencies if not provided in env

### DIFF
--- a/libgit2-sys/build.rs
+++ b/libgit2-sys/build.rs
@@ -123,6 +123,10 @@ fn main() {
     if ssh {
         if let Some(path) = env::var_os("DEP_SSH2_INCLUDE") {
             cfg.include(path);
+        } else if let Ok(lib) = pkg_config::find_library("libssh2") {
+            for path in &lib.include_paths {
+                cfg.include(path);
+            }
         }
         features.push_str("#define GIT_SSH 1\n");
         features.push_str("#define GIT_SSH_MEMORY_CREDENTIALS 1\n");
@@ -138,6 +142,10 @@ fn main() {
             features.push_str("#define GIT_OPENSSL 1\n");
             if let Some(path) = env::var_os("DEP_OPENSSL_INCLUDE") {
                 cfg.include(path);
+            } else if let Ok(lib) = pkg_config::find_library("openssl") {
+                for path in &lib.include_paths {
+                    cfg.include(path);
+                }
             }
         }
     }
@@ -153,6 +161,10 @@ fn main() {
 
     if let Some(path) = env::var_os("DEP_Z_INCLUDE") {
         cfg.include(path);
+    } else if let Ok(lib) = pkg_config::find_library("zlib") {
+        for path in &lib.include_paths {
+            cfg.include(path);
+        }
     }
 
     if target.contains("apple") {


### PR DESCRIPTION
This is similar to https://github.com/alexcrichton/ssh2-rs/pull/170 and solves issue in https://github.com/rust-lang/rust/issues/69552

If dependencies include paths are not provided in environment (`DEP_SSH2_INCLUDE`, `DEP_OPENSSL_INCLUDE` and `DEP_Z_INCLUDE`) then the script attempts to use `pkg_config` to find system-provided versions in order to build `libgit2`.