### PR TITLE
Migrate examples from docopt to structopt.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,7 @@ openssl-sys = { version = "0.9.0", optional = true }
 openssl-probe = { version = "0.1", optional = true }
 
 [dev-dependencies]
-docopt = "1.0"
-serde = "1.0"
-serde_derive = "1.0"
+structopt = "0.3"
 time = "0.1.39"
 tempfile = "3.1.0"
 thread-id = "3.3.0" # remove when we work with minimal-versions without it

--- a/examples/add.rs
+++ b/examples/add.rs
@@ -15,16 +15,22 @@
 #![deny(warnings)]
 #![allow(trivial_casts)]
 
-use docopt::Docopt;
 use git2::Repository;
-use serde_derive::Deserialize;
 use std::path::Path;
+use structopt::StructOpt;
 
-#[derive(Deserialize)]
+#[derive(StructOpt)]
 struct Args {
+    #[structopt(name = "spec")]
     arg_spec: Vec<String>,
+    #[structopt(name = "dry_run", short = "n", long)]
+    /// dry run
     flag_dry_run: bool,
+    #[structopt(name = "verbose", short, long)]
+    /// be verbose
     flag_verbose: bool,
+    #[structopt(name = "update", short, long)]
+    /// update tracked files
     flag_update: bool,
 }
 
@@ -67,19 +73,7 @@ fn run(args: &Args) -> Result<(), git2::Error> {
 }
 
 fn main() {
-    const USAGE: &str = "
-usage: add [options] [--] [<spec>..]
-
-Options:
-    -n, --dry-run       dry run
-    -v, --verbose       be verbose
-    -u, --update        update tracked files
-    -h, --help          show this message
-";
-
-    let args = Docopt::new(USAGE)
-        .and_then(|d| d.deserialize())
-        .unwrap_or_else(|e| e.exit());
+    let args = Args::from_args();
     match run(&args) {
         Ok(()) => {}
         Err(e) => println!("error: {}", e),

--- a/examples/blame.rs
+++ b/examples/blame.rs
@@ -12,19 +12,28 @@
  * <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
 
-use docopt::Docopt;
+#![deny(warnings)]
+
 use git2::{BlameOptions, Repository};
-use serde_derive::Deserialize;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
+use structopt::StructOpt;
 
-#[derive(Deserialize)]
+#[derive(StructOpt)]
 #[allow(non_snake_case)]
 struct Args {
+    #[structopt(name = "path")]
     arg_path: String,
+    #[structopt(name = "spec")]
     arg_spec: Option<String>,
+    #[structopt(short = "M")]
+    /// find line moves within and across files
     flag_M: bool,
+    #[structopt(short = "C")]
+    /// find line copies within and across files
     flag_C: bool,
+    #[structopt(short = "F")]
+    /// follow only the first parent commits
     flag_F: bool,
 }
 
@@ -87,18 +96,7 @@ fn run(args: &Args) -> Result<(), git2::Error> {
 }
 
 fn main() {
-    const USAGE: &str = "
-usage: blame [options] [<spec>] <path>
-
-Options:
-    -M                  find line moves within and across files
-    -C                  find line copies within and across files
-    -F                  follow only the first parent commits
-";
-
-    let args = Docopt::new(USAGE)
-        .and_then(|d| d.deserialize())
-        .unwrap_or_else(|e| e.exit());
+    let args = Args::from_args();
     match run(&args) {
         Ok(()) => {}
         Err(e) => println!("error: {}", e),

--- a/examples/cat-file.rs
+++ b/examples/cat-file.rs
@@ -16,19 +16,32 @@
 
 use std::io::{self, Write};
 
-use docopt::Docopt;
 use git2::{Blob, Commit, ObjectType, Repository, Signature, Tag, Tree};
-use serde_derive::Deserialize;
+use structopt::StructOpt;
 
-#[derive(Deserialize)]
+#[derive(StructOpt)]
 struct Args {
+    #[structopt(name = "object")]
     arg_object: String,
+    #[structopt(short = "t")]
+    /// show the object type
     flag_t: bool,
+    #[structopt(short = "s")]
+    /// show the object size
     flag_s: bool,
+    #[structopt(short = "e")]
+    /// suppress all output
     flag_e: bool,
+    #[structopt(short = "p")]
+    /// pretty print the contents of the object
     flag_p: bool,
+    #[structopt(name = "quiet", short, long)]
+    /// suppress output
     flag_q: bool,
+    #[structopt(name = "verbose", short, long)]
     flag_v: bool,
+    #[structopt(name = "dir", long = "git-dir")]
+    /// use the specified directory as the base directory
     flag_git_dir: Option<String>,
 }
 
@@ -128,23 +141,7 @@ fn show_sig(header: &str, sig: Option<Signature>) {
 }
 
 fn main() {
-    const USAGE: &str = "
-usage: cat-file (-t | -s | -e | -p) [options] <object>
-
-Options:
-    -t                  show the object type
-    -s                  show the object size
-    -e                  suppress all output
-    -p                  pretty print the contents of the object
-    -q                  suppress output
-    -v                  use verbose output
-    --git-dir <dir>     use the specified directory as the base directory
-    -h, --help          show this message
-";
-
-    let args = Docopt::new(USAGE)
-        .and_then(|d| d.deserialize())
-        .unwrap_or_else(|e| e.exit());
+    let args = Args::from_args();
     match run(&args) {
         Ok(()) => {}
         Err(e) => println!("error: {}", e),

--- a/examples/clone.rs
+++ b/examples/clone.rs
@@ -14,17 +14,18 @@
 
 #![deny(warnings)]
 
-use docopt::Docopt;
 use git2::build::{CheckoutBuilder, RepoBuilder};
 use git2::{FetchOptions, Progress, RemoteCallbacks};
-use serde_derive::Deserialize;
 use std::cell::RefCell;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
+use structopt::StructOpt;
 
-#[derive(Deserialize)]
+#[derive(StructOpt)]
 struct Args {
+    #[structopt(name = "url")]
     arg_url: String,
+    #[structopt(name = "path")]
     arg_path: String,
 }
 
@@ -117,16 +118,7 @@ fn run(args: &Args) -> Result<(), git2::Error> {
 }
 
 fn main() {
-    const USAGE: &str = "
-usage: add [options] <url> <path>
-
-Options:
-    -h, --help          show this message
-";
-
-    let args = Docopt::new(USAGE)
-        .and_then(|d| d.deserialize())
-        .unwrap_or_else(|e| e.exit());
+    let args = Args::from_args();
     match run(&args) {
         Ok(()) => {}
         Err(e) => println!("error: {}", e),

--- a/examples/fetch.rs
+++ b/examples/fetch.rs
@@ -14,14 +14,14 @@
 
 #![deny(warnings)]
 
-use docopt::Docopt;
 use git2::{AutotagOption, FetchOptions, RemoteCallbacks, Repository};
-use serde_derive::Deserialize;
 use std::io::{self, Write};
 use std::str;
+use structopt::StructOpt;
 
-#[derive(Deserialize)]
+#[derive(StructOpt)]
 struct Args {
+    #[structopt(name = "remote")]
     arg_remote: Option<String>,
 }
 
@@ -119,16 +119,7 @@ fn run(args: &Args) -> Result<(), git2::Error> {
 }
 
 fn main() {
-    const USAGE: &str = "
-usage: fetch [options] [<remote>]
-
-Options:
-    -h, --help          show this message
-";
-
-    let args = Docopt::new(USAGE)
-        .and_then(|d| d.deserialize())
-        .unwrap_or_else(|e| e.exit());
+    let args = Args::from_args();
     match run(&args) {
         Ok(()) => {}
         Err(e) => println!("error: {}", e),

--- a/examples/init.rs
+++ b/examples/init.rs
@@ -14,19 +14,31 @@
 
 #![deny(warnings)]
 
-use docopt::Docopt;
 use git2::{Error, Repository, RepositoryInitMode, RepositoryInitOptions};
-use serde_derive::Deserialize;
 use std::path::{Path, PathBuf};
+use structopt::StructOpt;
 
-#[derive(Deserialize)]
+#[derive(StructOpt)]
 struct Args {
+    #[structopt(name = "directory")]
     arg_directory: String,
+    #[structopt(name = "quiet", short, long)]
+    /// don't print information to stdout
     flag_quiet: bool,
+    #[structopt(name = "bare", long)]
+    /// initialize a new bare repository
     flag_bare: bool,
+    #[structopt(name = "dir", long = "template")]
+    /// use <dir> as an initialization template
     flag_template: Option<String>,
+    #[structopt(name = "separate-git-dir", long)]
+    /// use <dir> as the .git directory
     flag_separate_git_dir: Option<String>,
+    #[structopt(name = "initial-commit", long)]
+    /// create an initial empty commit
     flag_initial_commit: bool,
+    #[structopt(name = "perms", long = "shared")]
+    /// permissions to create the repository with
     flag_shared: Option<String>,
 }
 
@@ -125,21 +137,7 @@ fn parse_shared(shared: &str) -> Result<RepositoryInitMode, Error> {
 }
 
 fn main() {
-    const USAGE: &str = "
-usage: init [options] <directory>
-
-Options:
-    -q, --quiet                 don't print information to stdout
-    --bare                      initialize a new bare repository
-    --template <dir>            use <dir> as an initialization template
-    --separate-git-dir <dir>    use <dir> as the .git directory
-    --initial-commit            create an initial empty commit
-    --shared <perms>            permissions to create the repository with
-";
-
-    let args = Docopt::new(USAGE)
-        .and_then(|d| d.deserialize())
-        .unwrap_or_else(|e| e.exit());
+    let args = Args::from_args();
     match run(&args) {
         Ok(()) => {}
         Err(e) => println!("error: {}", e),

--- a/examples/log.rs
+++ b/examples/log.rs
@@ -14,32 +14,65 @@
 
 #![deny(warnings)]
 
-use docopt::Docopt;
 use git2::{Commit, DiffOptions, ObjectType, Repository, Signature, Time};
 use git2::{DiffFormat, Error, Pathspec};
-use serde_derive::Deserialize;
 use std::str;
+use structopt::StructOpt;
 
-#[derive(Deserialize)]
+#[derive(StructOpt)]
 struct Args {
-    arg_commit: Vec<String>,
-    arg_spec: Vec<String>,
+    #[structopt(name = "topo-order", long)]
+    /// sort commits in topological order
     flag_topo_order: bool,
+    #[structopt(name = "date-order", long)]
+    /// sort commits in date order
     flag_date_order: bool,
+    #[structopt(name = "reverse", long)]
+    /// sort commits in reverse
     flag_reverse: bool,
+    #[structopt(name = "author", long)]
+    /// author to sort by
     flag_author: Option<String>,
+    #[structopt(name = "committer", long)]
+    /// committer to sort by
     flag_committer: Option<String>,
+    #[structopt(name = "pat", long = "grep")]
+    /// pattern to filter commit messages by
     flag_grep: Option<String>,
+    #[structopt(name = "dir", long = "git-dir")]
+    /// alternative git directory to use
     flag_git_dir: Option<String>,
+    #[structopt(name = "skip", long)]
+    /// number of commits to skip
     flag_skip: Option<usize>,
+    #[structopt(name = "max-count", short = "n", long)]
+    /// maximum number of commits to show
     flag_max_count: Option<usize>,
+    #[structopt(name = "merges", long)]
+    /// only show merge commits
     flag_merges: bool,
+    #[structopt(name = "no-merges", long)]
+    /// don't show merge commits
     flag_no_merges: bool,
+    #[structopt(name = "no-min-parents", long)]
+    /// don't require a minimum number of parents
     flag_no_min_parents: bool,
+    #[structopt(name = "no-max-parents", long)]
+    /// don't require a maximum number of parents
     flag_no_max_parents: bool,
+    #[structopt(name = "max-parents")]
+    /// specify a maximum number of parents for a commit
     flag_max_parents: Option<usize>,
+    #[structopt(name = "min-parents")]
+    /// specify a minimum number of parents for a commit
     flag_min_parents: Option<usize>,
+    #[structopt(name = "patch", long, short)]
+    /// show commit diff
     flag_patch: bool,
+    #[structopt(name = "commit")]
+    arg_commit: Vec<String>,
+    #[structopt(name = "spec", last = true)]
+    arg_spec: Vec<String>,
 }
 
 fn run(args: &Args) -> Result<(), Error> {
@@ -269,32 +302,7 @@ impl Args {
 }
 
 fn main() {
-    const USAGE: &str = "
-usage: log [options] [<commit>..] [--] [<spec>..]
-
-Options:
-    --topo-order            sort commits in topological order
-    --date-order            sort commits in date order
-    --reverse               sort commits in reverse
-    --author <user>         author to sort by
-    --committer <user>      committer to sort by
-    --grep <pat>            pattern to filter commit messages by
-    --git-dir <dir>         alternative git directory to use
-    --skip <n>              number of commits to skip
-    -n, --max-count <n>     maximum number of commits to show
-    --merges                only show merge commits
-    --no-merges             don't show merge commits
-    --no-min-parents        don't require a minimum number of parents
-    --no-max-parents        don't require a maximum number of parents
-    --max-parents <n>       specify a maximum number of parents for a commit
-    --min-parents <n>       specify a minimum number of parents for a commit
-    -p, --patch             show commit diff
-    -h, --help              show this message
-";
-
-    let args = Docopt::new(USAGE)
-        .and_then(|d| d.deserialize())
-        .unwrap_or_else(|e| e.exit());
+    let args = Args::from_args();
     match run(&args) {
         Ok(()) => {}
         Err(e) => println!("error: {}", e),

--- a/examples/ls-remote.rs
+++ b/examples/ls-remote.rs
@@ -14,12 +14,12 @@
 
 #![deny(warnings)]
 
-use docopt::Docopt;
 use git2::{Direction, Repository};
-use serde_derive::Deserialize;
+use structopt::StructOpt;
 
-#[derive(Deserialize)]
+#[derive(StructOpt)]
 struct Args {
+    #[structopt(name = "remote")]
     arg_remote: String,
 }
 
@@ -43,16 +43,7 @@ fn run(args: &Args) -> Result<(), git2::Error> {
 }
 
 fn main() {
-    const USAGE: &str = "
-usage: ls-remote [option] <remote>
-
-Options:
-    -h, --help          show this message
-";
-
-    let args = Docopt::new(USAGE)
-        .and_then(|d| d.deserialize())
-        .unwrap_or_else(|e| e.exit());
+    let args = Args::from_args();
     match run(&args) {
         Ok(()) => {}
         Err(e) => println!("error: {}", e),

--- a/examples/rev-list.rs
+++ b/examples/rev-list.rs
@@ -15,17 +15,25 @@
 
 #![deny(warnings)]
 
-use docopt::Docopt;
 use git2::{Error, Oid, Repository, Revwalk};
-use serde_derive::Deserialize;
+use structopt::StructOpt;
 
-#[derive(Deserialize)]
+#[derive(StructOpt)]
 struct Args {
-    arg_spec: Vec<String>,
+    #[structopt(name = "topo-order", long)]
+    /// sort commits in topological order
     flag_topo_order: bool,
+    #[structopt(name = "date-order", long)]
+    /// sort commits in date order
     flag_date_order: bool,
+    #[structopt(name = "reverse", long)]
+    /// sort commits in reverse
     flag_reverse: bool,
+    #[structopt(name = "not")]
+    /// don't show <spec>
     flag_not: Vec<String>,
+    #[structopt(name = "spec", last = true)]
+    arg_spec: Vec<String>,
 }
 
 fn run(args: &Args) -> Result<(), git2::Error> {
@@ -89,20 +97,7 @@ fn push(revwalk: &mut Revwalk, id: Oid, hide: bool) -> Result<(), Error> {
 }
 
 fn main() {
-    const USAGE: &str = "
-usage: rev-list [options] [--] <spec>...
-
-Options:
-    --topo-order        sort commits in topological order
-    --date-order        sort commits in date order
-    --reverse           sort commits in reverse
-    --not <spec>        don't show <spec>
-    -h, --help          show this message
-";
-
-    let args = Docopt::new(USAGE)
-        .and_then(|d| d.deserialize())
-        .unwrap_or_else(|e| e.exit());
+    let args = Args::from_args();
     match run(&args) {
         Ok(()) => {}
         Err(e) => println!("error: {}", e),

--- a/examples/rev-parse.rs
+++ b/examples/rev-parse.rs
@@ -14,13 +14,15 @@
 
 #![deny(warnings)]
 
-use docopt::Docopt;
 use git2::Repository;
-use serde_derive::Deserialize;
+use structopt::StructOpt;
 
-#[derive(Deserialize)]
+#[derive(StructOpt)]
 struct Args {
+    #[structopt(name = "spec")]
     arg_spec: String,
+    #[structopt(name = "dir", long = "git-dir")]
+    /// directory of the git repository to check
     flag_git_dir: Option<String>,
 }
 
@@ -50,16 +52,7 @@ fn run(args: &Args) -> Result<(), git2::Error> {
 }
 
 fn main() {
-    const USAGE: &str = "
-usage: rev-parse [options] <spec>
-
-Options:
-    --git-dir <dir>     directory of the git repository to check
-";
-
-    let args = Docopt::new(USAGE)
-        .and_then(|d| d.deserialize())
-        .unwrap_or_else(|e| e.exit());
+    let args = Args::from_args();
     match run(&args) {
         Ok(()) => {}
         Err(e) => println!("error: {}", e),

--- a/examples/status.rs
+++ b/examples/status.rs
@@ -14,24 +14,46 @@
 
 #![deny(warnings)]
 
-use docopt::Docopt;
 use git2::{Error, ErrorCode, Repository, StatusOptions, SubmoduleIgnore};
-use serde_derive::Deserialize;
 use std::str;
 use std::time::Duration;
+use structopt::StructOpt;
 
-#[derive(Deserialize)]
+#[derive(StructOpt)]
 struct Args {
     arg_spec: Vec<String>,
+    #[structopt(name = "long", long)]
+    /// show longer statuses (default)
+    _flag_long: bool,
+    /// show short statuses
+    #[structopt(name = "short", long)]
     flag_short: bool,
+    #[structopt(name = "porcelain", long)]
+    /// ??
     flag_porcelain: bool,
+    #[structopt(name = "branch", short, long)]
+    /// show branch information
     flag_branch: bool,
+    #[structopt(name = "z", short)]
+    /// ??
     flag_z: bool,
+    #[structopt(name = "ignored", long)]
+    /// show ignored files as well
     flag_ignored: bool,
+    #[structopt(name = "opt-modules", long = "untracked-files")]
+    /// setting for showing untracked files [no|normal|all]
     flag_untracked_files: Option<String>,
+    #[structopt(name = "opt-files", long = "ignore-submodules")]
+    /// setting for ignoring submodules [all]
     flag_ignore_submodules: Option<String>,
+    #[structopt(name = "dir", long = "git-dir")]
+    /// git directory to analyze
     flag_git_dir: Option<String>,
+    #[structopt(name = "repeat", long)]
+    /// repeatedly show status, sleeping inbetween
     flag_repeat: bool,
+    #[structopt(name = "list-submodules", long)]
+    /// show submodules
     flag_list_submodules: bool,
 }
 
@@ -411,27 +433,7 @@ impl Args {
 }
 
 fn main() {
-    const USAGE: &str = "
-usage: status [options] [--] [<spec>..]
-
-Options:
-    -s, --short                 show short statuses
-    --long                      show longer statuses (default)
-    --porcelain                 ??
-    -b, --branch                show branch information
-    -z                          ??
-    --ignored                   show ignored files as well
-    --untracked-files <opt>     setting for showing untracked files [no|normal|all]
-    --ignore-submodules <opt>   setting for ignoring submodules [all]
-    --git-dir <dir>             git directory to analyze
-    --repeat                    repeatedly show status, sleeping inbetween
-    --list-submodules           show submodules
-    -h, --help                  show this message
-";
-
-    let args = Docopt::new(USAGE)
-        .and_then(|d| d.deserialize())
-        .unwrap_or_else(|e| e.exit());
+    let args = Args::from_args();
     match run(&args) {
         Ok(()) => {}
         Err(e) => println!("error: {}", e),

--- a/examples/tag.rs
+++ b/examples/tag.rs
@@ -14,20 +14,29 @@
 
 #![deny(warnings)]
 
-use docopt::Docopt;
 use git2::{Commit, Error, Repository, Tag};
-use serde_derive::Deserialize;
 use std::str;
+use structopt::StructOpt;
 
-#[derive(Deserialize)]
+#[derive(StructOpt)]
 struct Args {
     arg_tagname: Option<String>,
     arg_object: Option<String>,
     arg_pattern: Option<String>,
+    #[structopt(name = "n", short)]
+    /// specify number of lines from the annotation to print
     flag_n: Option<u32>,
+    #[structopt(name = "force", short, long)]
+    /// replace an existing tag with the given name
     flag_force: bool,
+    #[structopt(name = "list", short, long)]
+    /// list tags with names matching the pattern given
     flag_list: bool,
+    #[structopt(name = "tag", short, long = "delete")]
+    /// delete the tag specified
     flag_delete: Option<String>,
+    #[structopt(name = "msg", short, long = "message")]
+    /// message for a new tag
     flag_message: Option<String>,
 }
 
@@ -110,24 +119,7 @@ fn print_list_lines(message: Option<&str>, args: &Args) {
 }
 
 fn main() {
-    const USAGE: &str = "
-usage:
-    tag [-a] [-f] [-m <msg>] <tagname> [<object>]
-    tag -d <tag>
-    tag [-n <n>] -l [<pattern>]
-
-Options:
-    -n <n>                  specify number of lines from the annotation to print
-    -f, --force             replace an existing tag with the given name
-    -l, --list              list tags with names matching the pattern given
-    -d, --delete <tag>      delete the tag specified
-    -m, --message <msg>     message for a new tag
-    -h, --help              show this message
-";
-
-    let args = Docopt::new(USAGE)
-        .and_then(|d| d.deserialize())
-        .unwrap_or_else(|e| e.exit());
+    let args = Args::from_args();
     match run(&args) {
         Ok(()) => {}
         Err(e) => println!("error: {}", e),


### PR DESCRIPTION
Looking at the examples, I noticed that according to the docopt README, "This crate is unlikely to see significant future evolution.", as well as "Consider using clap or possibly structopt instead."

It didn't seem like it'd be difficult to do, so I figured i might as well go ahead and cold-call it.
However this has only undegone light testing.

Notes:
* log.rs: had to reorder struct members to get the multiple varargs working.
* various: --foo <n> --bar<n> I'd tried using a name="n" long="foo", this worked, unless there were 2 things wanting to be named n.  So I partially backed that, but only in the places where e.g. <n> occurred multiple times.
* all: rather than rename struct members from `flag_...` and `arg_...` naming convention, I used the name = "...", this lead to a much cleaner patch.  I could do a search/replace over `s/flag_//` and remove the corresponding `name="..."` in a follow up if this patch is wanted and that is preferred.


