### PR TITLE
Libgit2 has a new error class to represent HTTP errors. Add it to the…

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -230,6 +230,7 @@ git_enum! {
         GIT_ERROR_PATCH,
         GIT_ERROR_WORKTREE,
         GIT_ERROR_SHA1,
+        GIT_ERROR_HTTP,
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -156,6 +156,7 @@ impl Error {
             raw::GIT_ERROR_PATCH => super::ErrorClass::Patch,
             raw::GIT_ERROR_WORKTREE => super::ErrorClass::Worktree,
             raw::GIT_ERROR_SHA1 => super::ErrorClass::Sha1,
+            raw::GIT_ERROR_HTTP => super::ErrorClass::Http,
             _ => super::ErrorClass::None,
         }
     }
@@ -243,6 +244,7 @@ impl Error {
             GIT_ERROR_PATCH,
             GIT_ERROR_WORKTREE,
             GIT_ERROR_SHA1,
+            GIT_ERROR_HTTP,
         )
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,6 +261,8 @@ pub enum ErrorClass {
     Worktree,
     /// Hash library error or SHA-1 collision
     Sha1,
+    /// HTTP error
+    Http,
 }
 
 /// A listing of the possible states that a repository can be in.


### PR DESCRIPTION
… appropriate enums.