### PR TITLE
Correct library version on Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ libgit2 bindings for Rust
 
 ```toml
 [dependencies]
-git2 = "0.10"
+git2 = "0.13"
 ```
 
 ## Rust version requirements


### PR DESCRIPTION
The newest version of git2-rs is `0.13` but version in readme is `0.10`. This PR is to fix this issue.