### PR TITLE
Allow absolute paths for Repository::is_path_ignored.

### DIFF
--- a/src/repo.rs
+++ b/src/repo.rs
@@ -2597,7 +2597,7 @@ impl Repository {
 
     /// Test if the ignore rules apply to a given path.
     pub fn is_path_ignored<P: AsRef<Path>>(&self, path: P) -> Result<bool, Error> {
-        let path = path_to_repo_path(path.as_ref())?;
+        let path = util::cstring_to_repo_path(path.as_ref())?;
         let mut ignored: c_int = 0;
         unsafe {
             try_call!(raw::git_ignore_path_is_ignored(


### PR DESCRIPTION
Some users are passing absolute paths to `Repository::is_ignored_path`.  The changes from #549 cause these to be rejected.  I don't think it necessarily needs to take a principled stance of "no absolute paths", and also since this breaks existing usage, I think it should just allow absolute paths.
