### PR TITLE
rebase: Add orig_head_name and orig_head_id

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -3596,6 +3596,8 @@ extern "C" {
         rebase: *mut git_rebase,
         idx: size_t,
     ) -> *mut git_rebase_operation;
+    pub fn git_rebase_orig_head_id(rebase: *mut git_rebase) -> *const git_oid;
+    pub fn git_rebase_orig_head_name(rebase: *mut git_rebase) -> *const c_char;
     pub fn git_rebase_next(
         operation: *mut *mut git_rebase_operation,
         rebase: *mut git_rebase,


### PR DESCRIPTION
Add methods `orig_head_name` and `orig_head_id` to `git2::Rebase`. These
are Rust-level surface for libgit2's [`git_rebase_orig_head_name`][1]
and [`git_rebase_orig_head_id`][2].

  [1]: https://libgit2.org/libgit2/#HEAD/group/rebase/git_rebase_orig_head_name
  [2]: https://libgit2.org/libgit2/#HEAD/group/rebase/git_rebase_orig_head_id

`rebase_head_name` needs the rebase head to have a name; just a commit
won't do. To test it, use `refs/heads/master` as the head instead of the
head commit.

Additionally, since these operations are valid only on merge rebases,
switch the test to on-disk from in-memory.