### PR TITLE
Implement Diff::from_buffer for parsing patch files

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -3153,6 +3153,11 @@ extern "C" {
         line_cb: git_diff_line_cb,
         payload: *mut c_void,
     ) -> c_int;
+    pub fn git_diff_from_buffer(
+        diff: *mut *mut git_diff,
+        content: *const c_char,
+        content_len: size_t,
+    ) -> c_int;
     pub fn git_diff_find_similar(
         diff: *mut git_diff,
         options: *const git_diff_find_options,

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -255,7 +255,11 @@ impl Diff<'static> {
         let mut diff: *mut raw::git_diff = std::ptr::null_mut();
         unsafe {
             // NOTE: Doesn't depend on repo, so lifetime can be 'static
-            try_call!(raw::git_diff_from_buffer(&mut diff, buffer.as_ptr(), buffer.len()));
+            try_call!(raw::git_diff_from_buffer(
+                &mut diff,
+                buffer.as_ptr() as *const c_char,
+                buffer.len()
+            ));
             Ok(Diff::from_raw(diff))
         }
     }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -243,6 +243,23 @@ impl<'repo> Diff<'repo> {
 
     // TODO: num_deltas_of_type, format_email, find_similar
 }
+impl Diff<'static> {
+    /// Read the contents of a git patch file into a `git_diff` object.
+    ///
+    /// The diff object produced is similar to the one that would be
+    /// produced if you actually produced it computationally by comparing
+    /// two trees, however there may be subtle differences. For example,
+    /// a patch file likely contains abbreviated object IDs, so the
+    /// object IDs parsed by this function will also be abreviated.
+    pub fn from_buffer(buffer: &[u8]) -> Result<Diff<'static>, Error> {
+        let mut diff: *mut raw::git_diff = std::ptr::null_mut();
+        unsafe {
+            // NOTE: Doesn't depend on repo, so lifetime can be 'static
+            try_call!(raw::git_diff_from_buffer(&mut diff, buffer.as_ptr(), buffer.len()));
+            Ok(Diff::from_raw(diff))
+        }
+    }
+}
 
 pub extern "C" fn print_cb(
     delta: *const raw::git_diff_delta,


### PR DESCRIPTION
I question the decision to make diff live for 'static.
Libgit2 doesn't require that it's dependent on a repository
but it seems inconsitent with all the other methods of
creating diffs.