### PR TITLE
Add bindings for `git_branch_remote_name`

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -2577,6 +2577,11 @@ extern "C" {
         force: c_int,
     ) -> c_int;
     pub fn git_branch_name(out: *mut *const c_char, branch: *const git_reference) -> c_int;
+    pub fn git_branch_remote_name(
+        out: *mut git_buf,
+        repo: *mut git_repository,
+        refname: *const c_char,
+    ) -> c_int;
     pub fn git_branch_next(
         out: *mut *mut git_reference,
         out_type: *mut git_branch_t,

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -2668,6 +2668,16 @@ impl Repository {
         }
     }
 
+    /// Find the remote name of a remote-tracking branch
+    pub fn branch_remote_name(&self, refname: &str) -> Result<Buf, Error> {
+        let refname = CString::new(refname)?;
+        unsafe {
+            let buf = Buf::new();
+            try_call!(raw::git_branch_remote_name(buf.raw(), self.raw, refname));
+            Ok(buf)
+        }
+    }
+
     /// Retrieves the name of the reference supporting the remote tracking branch,
     /// given the name of a local branch reference.
     pub fn branch_upstream_name(&self, refname: &str) -> Result<Buf, Error> {


### PR DESCRIPTION
Hi,

I have a need for [git_branch_remote_name](https://libgit2.org/libgit2/#HEAD/group/branch/git_branch_remote_name). There was a related issue https://github.com/rust-lang/git2-rs/issues/469 which was closed by https://github.com/rust-lang/git2-rs/pull/488. However #488 did not add this method :D

I just oriented on #488 and tested it locally.