### PR TITLE
oid: Add ShortOid, a length-aware oid prefex

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ pub use merge::{AnnotatedCommit, MergeOptions};
 pub use message::{message_prettify, DEFAULT_COMMENT_CHAR};
 pub use note::{Note, Notes};
 pub use object::Object;
-pub use oid::Oid;
+pub use oid::{Oid, ShortOid};
 pub use packbuilder::{PackBuilder, PackBuilderStage};
 pub use pathspec::{Pathspec, PathspecMatchList, PathspecFailedEntries};
 pub use pathspec::{PathspecDiffEntries, PathspecEntries};


### PR DESCRIPTION
I'm not the author of this, just trying to push it through:

This adds a `ShortOid` type that's aware of its length. A regular `Oid`
is convertible to a `ShortOid`. The `Odb::exists_prefix` method is
changed to take `impl Into<ShortOid>` and no length parameter.

The limit of one, and can hinder readability by, eg,
disallowing extra space between top-level items.

BREAKING CHANGES:
- `Odb::exists_prefix` no longer takes a length parameter.

replaces #295
this closes #293, the issue has been closed but it has not been resolved nor has the feature been added