### PR TITLE
Fix build.rs: only update libgit2 submodule (#574)

### DIFF
--- a/libgit2-sys/build.rs
+++ b/libgit2-sys/build.rs
@@ -17,7 +17,7 @@ fn main() {
 
     if !Path::new("libgit2/.git").exists() {
         let _ = Command::new("git")
-            .args(&["submodule", "update", "--init"])
+            .args(&["submodule", "update", "--init", "libgit2"])
             .status();
     }
 


### PR DESCRIPTION
If the user (for whatever reason) has their $CARGO_HOME
in a git repository, and libgit2-sys is built in there
(e.g. as a dependency of cargo), the build script will
erroneously update all submodules in our parent directories.

This wasn't intended - we only wish to update libgit2.

This commit corrects this by specifying the current directory
when calling git submodule update.

Closes #574 