### PR TITLE
Add bindings for `git_remote_default_branch` (#572)

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -2049,6 +2049,7 @@ extern "C" {
         remote: *mut git_remote,
         callbacks: *const git_remote_callbacks,
     ) -> c_int;
+    pub fn git_remote_default_branch(out: *mut git_buf, remote: *mut git_remote) -> c_int;
 
     // refspec
     pub fn git_refspec_direction(spec: *const git_refspec) -> git_direction;


### PR DESCRIPTION
Add bindings for [`git_remote_default_branch()`](https://libgit2.org/libgit2/#HEAD/group/remote/git_remote_default_branch).  

This call requires the remote to have been connected at some point so it follows the lead of `Remote/RemoteConnection::list()`.

Closes #572 