### PR TITLE
Add modifiers for error code and class (#576)

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -16,6 +16,18 @@ pub struct Error {
 }
 
 impl Error {
+    /// Creates a new error.
+    ///
+    /// This is mainly intended for implementors of custom transports or
+    /// database backends, where it is desirable to propagate an [`Error`]
+    /// through `libgit2`.
+    pub fn new<S: AsRef<str>>(code: ErrorCode, class: ErrorClass, message: S) -> Self {
+        let mut err = Error::from_str(message.as_ref());
+        err.set_code(code);
+        err.set_class(class);
+        err
+    }
+
     /// Returns the last error that happened with the code specified by `code`.
     ///
     /// The `code` argument typically comes from the return value of a function
@@ -119,7 +131,7 @@ impl Error {
     ///
     /// This is mainly intended to be used by implementors of custom transports
     /// or database backends, and should be used with care.
-    pub fn set_code(mut self, code: ErrorCode) -> Self {
+    pub fn set_code(&mut self, code: ErrorCode) {
         self.code = match code {
             ErrorCode::GenericError => raw::GIT_ERROR,
             ErrorCode::NotFound => raw::GIT_ENOTFOUND,
@@ -144,7 +156,6 @@ impl Error {
             ErrorCode::Uncommitted => raw::GIT_EUNCOMMITTED,
             ErrorCode::Directory => raw::GIT_EDIRECTORY,
         };
-        self
     }
 
     /// Return the error class associated with this error.
@@ -197,7 +208,7 @@ impl Error {
     ///
     /// This is mainly intended to be used by implementors of custom transports
     /// or database backends, and should be used with care.
-    pub fn set_class(mut self, class: ErrorClass) -> Self {
+    pub fn set_class(&mut self, class: ErrorClass) {
         self.klass = match class {
             ErrorClass::None => raw::GIT_ERROR_NONE,
             ErrorClass::NoMemory => raw::GIT_ERROR_NOMEMORY,
@@ -235,7 +246,6 @@ impl Error {
             ErrorClass::Sha1 => raw::GIT_ERROR_SHA1,
             ErrorClass::Http => raw::GIT_ERROR_HTTP,
         } as c_int;
-        self
     }
 
     /// Return the raw error code associated with this error.

--- a/src/error.rs
+++ b/src/error.rs
@@ -159,6 +159,10 @@ impl Error {
             ErrorCode::Invalid => raw::GIT_EINVALID,
             ErrorCode::Uncommitted => raw::GIT_EUNCOMMITTED,
             ErrorCode::Directory => raw::GIT_EDIRECTORY,
+            ErrorCode::MergeConflict => raw::GIT_EMERGECONFLICT,
+            ErrorCode::HashsumMismatch => raw::GIT_EMISMATCH,
+            ErrorCode::IndexDirty => raw::GIT_EINDEXDIRTY,
+            ErrorCode::ApplyFail => raw::GIT_EAPPLYFAIL,
         };
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -115,6 +115,38 @@ impl Error {
         }
     }
 
+    /// Modify the error code associated with this error.
+    ///
+    /// This is mainly intended to be used by implementors of custom transports
+    /// or database backends, and should be used with care.
+    pub fn set_code(mut self, code: ErrorCode) -> Self {
+        self.code = match code {
+            ErrorCode::GenericError => raw::GIT_ERROR,
+            ErrorCode::NotFound => raw::GIT_ENOTFOUND,
+            ErrorCode::Exists => raw::GIT_EEXISTS,
+            ErrorCode::Ambiguous => raw::GIT_EAMBIGUOUS,
+            ErrorCode::BufSize => raw::GIT_EBUFS,
+            ErrorCode::User => raw::GIT_EUSER,
+            ErrorCode::BareRepo => raw::GIT_EBAREREPO,
+            ErrorCode::UnbornBranch => raw::GIT_EUNBORNBRANCH,
+            ErrorCode::Unmerged => raw::GIT_EUNMERGED,
+            ErrorCode::NotFastForward => raw::GIT_ENONFASTFORWARD,
+            ErrorCode::InvalidSpec => raw::GIT_EINVALIDSPEC,
+            ErrorCode::Conflict => raw::GIT_ECONFLICT,
+            ErrorCode::Locked => raw::GIT_ELOCKED,
+            ErrorCode::Modified => raw::GIT_EMODIFIED,
+            ErrorCode::Auth => raw::GIT_EAUTH,
+            ErrorCode::Certificate => raw::GIT_ECERTIFICATE,
+            ErrorCode::Applied => raw::GIT_EAPPLIED,
+            ErrorCode::Peel => raw::GIT_EPEEL,
+            ErrorCode::Eof => raw::GIT_EEOF,
+            ErrorCode::Invalid => raw::GIT_EINVALID,
+            ErrorCode::Uncommitted => raw::GIT_EUNCOMMITTED,
+            ErrorCode::Directory => raw::GIT_EDIRECTORY,
+        };
+        self
+    }
+
     /// Return the error class associated with this error.
     ///
     /// Error classes are in general mostly just informative. For example the
@@ -159,6 +191,51 @@ impl Error {
             raw::GIT_ERROR_HTTP => super::ErrorClass::Http,
             _ => super::ErrorClass::None,
         }
+    }
+
+    /// Modify the error class associated with this error.
+    ///
+    /// This is mainly intended to be used by implementors of custom transports
+    /// or database backends, and should be used with care.
+    pub fn set_class(mut self, class: ErrorClass) -> Self {
+        self.klass = match class {
+            ErrorClass::None => raw::GIT_ERROR_NONE,
+            ErrorClass::NoMemory => raw::GIT_ERROR_NOMEMORY,
+            ErrorClass::Os => raw::GIT_ERROR_OS,
+            ErrorClass::Invalid => raw::GIT_ERROR_INVALID,
+            ErrorClass::Reference => raw::GIT_ERROR_REFERENCE,
+            ErrorClass::Zlib => raw::GIT_ERROR_ZLIB,
+            ErrorClass::Repository => raw::GIT_ERROR_REPOSITORY,
+            ErrorClass::Config => raw::GIT_ERROR_CONFIG,
+            ErrorClass::Regex => raw::GIT_ERROR_REGEX,
+            ErrorClass::Odb => raw::GIT_ERROR_ODB,
+            ErrorClass::Index => raw::GIT_ERROR_INDEX,
+            ErrorClass::Object => raw::GIT_ERROR_OBJECT,
+            ErrorClass::Net => raw::GIT_ERROR_NET,
+            ErrorClass::Tag => raw::GIT_ERROR_TAG,
+            ErrorClass::Tree => raw::GIT_ERROR_TREE,
+            ErrorClass::Indexer => raw::GIT_ERROR_INDEXER,
+            ErrorClass::Ssl => raw::GIT_ERROR_SSL,
+            ErrorClass::Submodule => raw::GIT_ERROR_SUBMODULE,
+            ErrorClass::Thread => raw::GIT_ERROR_THREAD,
+            ErrorClass::Stash => raw::GIT_ERROR_STASH,
+            ErrorClass::Checkout => raw::GIT_ERROR_CHECKOUT,
+            ErrorClass::FetchHead => raw::GIT_ERROR_FETCHHEAD,
+            ErrorClass::Merge => raw::GIT_ERROR_MERGE,
+            ErrorClass::Ssh => raw::GIT_ERROR_SSH,
+            ErrorClass::Filter => raw::GIT_ERROR_FILTER,
+            ErrorClass::Revert => raw::GIT_ERROR_REVERT,
+            ErrorClass::Callback => raw::GIT_ERROR_CALLBACK,
+            ErrorClass::CherryPick => raw::GIT_ERROR_CHERRYPICK,
+            ErrorClass::Describe => raw::GIT_ERROR_DESCRIBE,
+            ErrorClass::Rebase => raw::GIT_ERROR_REBASE,
+            ErrorClass::Filesystem => raw::GIT_ERROR_FILESYSTEM,
+            ErrorClass::Patch => raw::GIT_ERROR_PATCH,
+            ErrorClass::Worktree => raw::GIT_ERROR_WORKTREE,
+            ErrorClass::Sha1 => raw::GIT_ERROR_SHA1,
+            ErrorClass::Http => raw::GIT_ERROR_HTTP,
+        } as c_int;
+        self
     }
 
     /// Return the raw error code associated with this error.

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -367,13 +367,18 @@ mod tests {
 
     struct DummyTransport;
 
+    // in lieu of lazy_static
+    fn dummy_error() -> Error {
+        Error::new(ErrorCode::Ambiguous, ErrorClass::Net, "bleh")
+    }
+
     impl SmartSubtransport for DummyTransport {
         fn action(
             &self,
             _url: &str,
             _service: Service,
         ) -> Result<Box<dyn SmartSubtransportStream>, Error> {
-            Err(Error::from_str("bleh"))
+            Err(dummy_error())
         }
 
         fn close(&self) -> Result<(), Error> {
@@ -401,11 +406,7 @@ mod tests {
 
         match origin.fetch(&["master"], None, None) {
             Ok(()) => unreachable!(),
-            Err(e) => {
-                assert_eq!(e.message(), "bleh");
-                assert_eq!(e.code(), ErrorCode::GenericError);
-                assert_eq!(e.class(), ErrorClass::None);
-            }
+            Err(e) => assert_eq!(e, dummy_error()),
         }
     }
 }


### PR DESCRIPTION
Arguably the most naive / liberal way to allow for custom errors. There might be reasons to only allow a subset of the error codes / classes, but I can't make up my mind which ones that should be. If that's the case, perhaps a set of specialised constructors would be preferrable, otherwise I'd lean towards amending this to define a `new` constructor which takes the code and class directly.

Aside: I noticed that the `ErrorCode` enum is missing some possible values from the binding. I'll submit that separately. 