### PR TITLE
Add bindings for `git_refspec_transform()` and `git_refspec_rtransform()`

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -2059,6 +2059,16 @@ extern "C" {
     pub fn git_refspec_src_matches(spec: *const git_refspec, refname: *const c_char) -> c_int;
     pub fn git_refspec_force(spec: *const git_refspec) -> c_int;
     pub fn git_refspec_string(spec: *const git_refspec) -> *const c_char;
+    pub fn git_refspec_transform(
+        out: *mut git_buf,
+        spec: *const git_refspec,
+        name: *const c_char,
+    ) -> c_int;
+    pub fn git_refspec_rtransform(
+        out: *mut git_buf,
+        spec: *const git_refspec,
+        name: *const c_char,
+    ) -> c_int;
 
     // strarray
     pub fn git_strarray_free(array: *mut git_strarray);

--- a/src/refspec.rs
+++ b/src/refspec.rs
@@ -3,7 +3,7 @@ use std::marker;
 use std::str;
 
 use crate::util::Binding;
-use crate::{raw, Direction};
+use crate::{raw, Buf, Direction, Error};
 
 /// A structure to represent a git [refspec][1].
 ///
@@ -76,6 +76,34 @@ impl<'remote> Refspec<'remote> {
     /// Get the refspec's string as a byte array
     pub fn bytes(&self) -> &[u8] {
         unsafe { crate::opt_bytes(self, raw::git_refspec_string(self.raw)).unwrap() }
+    }
+
+    /// Transform a reference to its target following the refspec's rules
+    pub fn transform(&self, name: &str) -> Result<Buf, Error> {
+        let name = CString::new(name).unwrap();
+        unsafe {
+            let buf = Buf::new();
+            try_call!(raw::git_refspec_transform(
+                buf.raw(),
+                self.raw,
+                name.as_ptr()
+            ));
+            Ok(buf)
+        }
+    }
+
+    /// Transform a target reference to its source reference following the refspec's rules
+    pub fn rtransform(&self, name: &str) -> Result<Buf, Error> {
+        let name = CString::new(name).unwrap();
+        unsafe {
+            let buf = Buf::new();
+            try_call!(raw::git_refspec_rtransform(
+                buf.raw(),
+                self.raw,
+                name.as_ptr()
+            ));
+            Ok(buf)
+        }
     }
 }
 


### PR DESCRIPTION
Transform source reference names into target names and vice-versa.