### PR TITLE
Expose the mempack backend in git2

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,7 @@ pub use crate::index::{
     Index, IndexConflict, IndexConflicts, IndexEntries, IndexEntry, IndexMatchedPath,
 };
 pub use crate::indexer::{IndexerProgress, Progress};
+pub use crate::mempack::Mempack;
 pub use crate::merge::{AnnotatedCommit, MergeOptions};
 pub use crate::message::{message_prettify, DEFAULT_COMMENT_CHAR};
 pub use crate::note::{Note, Notes};
@@ -654,6 +655,7 @@ mod diff;
 mod error;
 mod index;
 mod indexer;
+mod mempack;
 mod merge;
 mod message;
 mod note;

--- a/src/mempack.rs
+++ b/src/mempack.rs
@@ -1,0 +1,49 @@
+use std::marker;
+
+use crate::util::Binding;
+use crate::{raw, Buf, Error, Odb, Repository};
+
+/// A structure to represent a mempack backend for the object database. The
+/// Mempack is bound to the Odb that it was created from, and cannot outlive
+/// that Odb.
+pub struct Mempack<'odb> {
+    raw: *mut raw::git_odb_backend,
+    _marker: marker::PhantomData<&'odb Odb<'odb>>,
+}
+
+impl<'odb> Binding for Mempack<'odb> {
+    type Raw = *mut raw::git_odb_backend;
+
+    unsafe fn from_raw(raw: *mut raw::git_odb_backend) -> Mempack<'odb> {
+        Mempack {
+            raw: raw,
+            _marker: marker::PhantomData,
+        }
+    }
+
+    fn raw(&self) -> *mut raw::git_odb_backend {
+        self.raw
+    }
+}
+
+// We don't need to implement `Drop` for Mempack because it is owned by the
+// odb to which it is attached, and that will take care of freeing the mempack
+// and associated memory.
+
+impl<'odb> Mempack<'odb> {
+    /// Dumps the contents of the mempack into the provided buffer.
+    pub fn dump(&self, repo: &Repository, buf: &mut Buf) -> Result<(), Error> {
+        unsafe {
+            try_call!(raw::git_mempack_dump(buf.raw(), repo.raw(), self.raw));
+        }
+        Ok(())
+    }
+
+    /// Clears all data in the mempack.
+    pub fn reset(&self) -> Result<(), Error> {
+        unsafe {
+            try_call!(raw::git_mempack_reset(self.raw));
+        }
+        Ok(())
+    }
+}

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1054,6 +1054,14 @@ impl Repository {
         }
     }
 
+    /// Override the object database for this repository
+    pub fn set_odb(&self, odb: &Odb<'_>) -> Result<(), Error> {
+        unsafe {
+            try_call!(raw::git_repository_set_odb(self.raw(), odb.raw()));
+        }
+        Ok(())
+    }
+
     /// Create a new branch pointing at a target commit
     ///
     /// A new direct reference will be created pointing to this target commit.


### PR DESCRIPTION
This also adds a method to override the ODB on the repository, which is also
exposed by libgit2. This allows the user to create a new ODB which e.g. just
has a mempack backend, and set it on the repository.