### PR TITLE
Use cc 1.0.43 or later

### DIFF
--- a/libgit2-sys/Cargo.toml
+++ b/libgit2-sys/Cargo.toml
@@ -23,7 +23,7 @@ libz-sys = "1.0.22"
 
 [build-dependencies]
 pkg-config = "0.3.7"
-cc = { version = "1.0.42", features = ['parallel'] }
+cc = { version = "1.0.43", features = ['parallel'] }
 
 [target.'cfg(unix)'.dependencies]
 openssl-sys = { version = "0.9", optional = true }


### PR DESCRIPTION
cc-1.0.42 should not be used as minimal dependency verison, because it could hang on some environment during the build.

I use `cargo +nightly update -Z minimal-versions` on CI to generate Cargo.lock for minimal depnedency versions and check if Cargo.toml is OK.
However, I confirmed that compilation using cc 1.0.42 hangs on rust:latest docker (maybe Debian?).
I think this is https://github.com/alexcrichton/cc-rs/issues/440, and this version should be avoided.