### PR TITLE
feature: enable building git2-curl with vendored openssl

### DIFF
--- a/git2-curl/Cargo.toml
+++ b/git2-curl/Cargo.toml
@@ -25,7 +25,7 @@ conduit-git-http-backend = "0.8"
 tempfile = "3.0"
 
 [features]
-vendored-openssl = ["git2/vendored"]
+vendored-openssl = ["git2/vendored-openssl"]
 default = []
 
 [[test]]

--- a/git2-curl/Cargo.toml
+++ b/git2-curl/Cargo.toml
@@ -24,6 +24,10 @@ conduit = "0.8"
 conduit-git-http-backend = "0.8"
 tempfile = "3.0"
 
+[features]
+vendored-openssl = ["git2/vendored"]
+default = []
+
 [[test]]
 name = "all"
 harness = false


### PR DESCRIPTION
the main crate can be build with vendored ssl git2-curl can not. This adds that feature