### PR TITLE
Add support for zlib-ng

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ url = "2.0"
 bitflags = "1.1.0"
 libc = "0.2"
 log = "0.4.8"
-libgit2-sys = { path = "libgit2-sys", version = "0.12.9" }
+libgit2-sys = { path = "libgit2-sys", version = "0.12.10" }
 
 [target."cfg(all(unix, not(target_os = \"macos\")))".dependencies]
 openssl-sys = { version = "0.9.0", optional = true }
@@ -39,6 +39,7 @@ ssh = ["libgit2-sys/ssh"]
 https = ["libgit2-sys/https", "openssl-sys", "openssl-probe"]
 vendored-openssl = ["openssl-sys/vendored"]
 ssh_key_from_memory = ["libgit2-sys/ssh_key_from_memory"]
+zlib-ng-compat = ["libgit2-sys/zlib-ng-compat"]
 
 [workspace]
 members = ["systest", "git2-curl"]

--- a/git2-curl/Cargo.toml
+++ b/git2-curl/Cargo.toml
@@ -13,7 +13,7 @@ Intended to be used with the git2 crate.
 edition = "2018"
 
 [dependencies]
-curl = "0.4"
+curl = "0.4.33"
 url = "2.0"
 log = "0.4"
 git2 = { path = "..", version = "0.13", default-features = false }
@@ -23,6 +23,9 @@ civet = "0.11"
 conduit = "0.8"
 conduit-git-http-backend = "0.8"
 tempfile = "3.0"
+
+[features]
+zlib-ng-compat = ["git2/zlib-ng-compat", "curl/zlib-ng-compat"]
 
 [[test]]
 name = "all"

--- a/libgit2-sys/Cargo.toml
+++ b/libgit2-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libgit2-sys"
-version = "0.12.9+1.0.1"
+version = "0.12.10+1.0.1"
 authors = ["Josh Triplett <josh@joshtriplett.org>", "Alex Crichton <alex@alexcrichton.com>"]
 links = "git2"
 build = "build.rs"
@@ -18,8 +18,8 @@ path = "lib.rs"
 
 [dependencies]
 libc = "0.2"
-libssh2-sys = { version = "0.2.11", optional = true }
-libz-sys = "1.0.22"
+libssh2-sys = { version = "0.2.19", optional = true }
+libz-sys = { version = "1.1.0", default-features = false, features = ["libc"] }
 
 [build-dependencies]
 pkg-config = "0.3.7"
@@ -32,3 +32,9 @@ openssl-sys = { version = "0.9", optional = true }
 ssh = ["libssh2-sys"]
 https = ["openssl-sys"]
 ssh_key_from_memory = []
+# Cargo does not support requiring features on an optional dependency without
+# requiring the dependency. Rather than introduce additional complexity, we
+# just require libssh2 when using zlib-ng-compat. This will require building
+# libssh2, but it will not add code to the final binary without the "ssh"
+# feature enabled.
+zlib-ng-compat = ["libz-sys/zlib-ng", "libssh2-sys/zlib-ng-compat"]

--- a/libgit2-sys/build.rs
+++ b/libgit2-sys/build.rs
@@ -6,13 +6,17 @@ use std::process::Command;
 fn main() {
     let https = env::var("CARGO_FEATURE_HTTPS").is_ok();
     let ssh = env::var("CARGO_FEATURE_SSH").is_ok();
+    let zlib_ng_compat = env::var("CARGO_FEATURE_ZLIB_NG_COMPAT").is_ok();
 
-    let mut cfg = pkg_config::Config::new();
-    if let Ok(lib) = cfg.atleast_version("1.0.0").probe("libgit2") {
-        for include in &lib.include_paths {
-            println!("cargo:root={}", include.display());
+    // To use zlib-ng in zlib-compat mode, we have to build libgit2 ourselves.
+    if !zlib_ng_compat {
+        let mut cfg = pkg_config::Config::new();
+        if let Ok(lib) = cfg.atleast_version("1.0.0").probe("libgit2") {
+            for include in &lib.include_paths {
+                println!("cargo:root={}", include.display());
+            }
+            return;
         }
-        return;
     }
 
     if !Path::new("libgit2/.git").exists() {


### PR DESCRIPTION
Depend on libz-sys 1.1.0, and provide "zlib-ng-compat" features to opt
into zlib-ng. Use feature dependencies to ensure that either all C
libraries opt in or none do.

This provides a substantial performance boost when compressing or
decompressing objects in a git2 repository.

(This is blocked on https://github.com/alexcrichton/curl-rust/pull/351
and https://github.com/alexcrichton/ssh2-rs/pull/197 , and subsequent
publishes of both. CI won't pass until then.)