### PR TITLE
Init before creating Odb with `new`

### DIFF
--- a/src/odb.rs
+++ b/src/odb.rs
@@ -41,6 +41,7 @@ impl<'repo> Drop for Odb<'repo> {
 impl<'repo> Odb<'repo> {
     /// Creates an object database without any backends.
     pub fn new<'a>() -> Result<Odb<'a>, Error> {
+        crate::init();
         unsafe {
             let mut out = ptr::null_mut();
             try_call!(raw::git_odb_new(&mut out));


### PR DESCRIPTION
This allows calling `Odb::new()` as first thing in a code base