### PR TITLE
Update to libgit2 v1.1 and use `main` branch for tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ version of Rust known to pass tests.
 
 ## Version of libgit2
 
-Currently this library requires libgit2 1.0.0. The source for libgit2 is
+Currently this library requires libgit2 1.1.0. The source for libgit2 is
 included in the libgit2-sys crate so there's no need to pre-install the libgit2
 library, the libgit2-sys crate will figure that and/or build that for you.
 

--- a/src/branch.rs
+++ b/src/branch.rs
@@ -169,7 +169,7 @@ mod tests {
         let mut b1 = b1.rename("bar", false).unwrap();
         assert_eq!(b1.name().unwrap(), Some("bar"));
         assert!(b1.upstream().is_err());
-        b1.set_upstream(Some("master")).unwrap();
+        b1.set_upstream(Some("main")).unwrap();
         b1.upstream().unwrap();
         b1.set_upstream(None).unwrap();
 

--- a/src/build.rs
+++ b/src/build.rs
@@ -714,7 +714,9 @@ mod tests {
         let cd = TempDir::new().unwrap();
 
         {
-            let repo = Repository::init(&td.path()).unwrap();
+            let mut opts = crate::RepositoryInitOptions::new();
+            opts.initial_head("main");
+            let repo = Repository::init_opts(&td.path(), &opts).unwrap();
 
             let mut config = repo.config().unwrap();
             config.set_str("user.name", "name").unwrap();
@@ -735,7 +737,7 @@ mod tests {
 
         let repo = Repository::open_bare(&td.path().join(".git")).unwrap();
         let tree = repo
-            .revparse_single(&"master")
+            .revparse_single(&"main")
             .unwrap()
             .peel_to_tree()
             .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1419,7 +1419,7 @@ bitflags! {
         /// components (e.g., `foo/*/bar` but not `foo/bar*`).
         const REFSPEC_PATTERN = raw::GIT_REFERENCE_FORMAT_REFSPEC_PATTERN as u32;
         /// Interpret the name as part of a refspec in shorthand form so the
-        /// `ALLOW_ONELEVEL` naming rules aren't enforced and `master` becomes a
+        /// `ALLOW_ONELEVEL` naming rules aren't enforced and `main` becomes a
         /// valid name.
         const REFSPEC_SHORTHAND = raw::GIT_REFERENCE_FORMAT_REFSPEC_SHORTHAND as u32;
     }

--- a/src/rebase.rs
+++ b/src/rebase.rs
@@ -349,21 +349,21 @@ mod tests {
         // We just want to see the iteration work so we can create commits with
         // no changes
         let c1 = repo
-            .commit(Some("refs/heads/master"), &sig, &sig, "foo", &tree, &[&tip])
+            .commit(Some("refs/heads/main"), &sig, &sig, "foo", &tree, &[&tip])
             .unwrap();
         let c1 = repo.find_commit(c1).unwrap();
         let c2 = repo
-            .commit(Some("refs/heads/master"), &sig, &sig, "foo", &tree, &[&c1])
+            .commit(Some("refs/heads/main"), &sig, &sig, "foo", &tree, &[&c1])
             .unwrap();
 
-        let head = repo.find_reference("refs/heads/master").unwrap();
+        let head = repo.find_reference("refs/heads/main").unwrap();
         let branch = repo.reference_to_annotated_commit(&head).unwrap();
         let upstream = repo.find_annotated_commit(tip.id()).unwrap();
         let mut rebase = repo
             .rebase(Some(&branch), Some(&upstream), None, None)
             .unwrap();
 
-        assert_eq!(Some("refs/heads/master"), rebase.orig_head_name());
+        assert_eq!(Some("refs/heads/main"), rebase.orig_head_name());
         assert_eq!(Some(c2), rebase.orig_head_id());
 
         assert_eq!(rebase.len(), 2);
@@ -397,7 +397,7 @@ mod tests {
         let tree_id_a = index.write_tree().unwrap();
         let tree_a = repo.find_tree(tree_id_a).unwrap();
         let c1 = repo
-            .commit(Some("refs/heads/master"), &sig, &sig, "A", &tree_a, &[&tip])
+            .commit(Some("refs/heads/main"), &sig, &sig, "A", &tree_a, &[&tip])
             .unwrap();
         let c1 = repo.find_commit(c1).unwrap();
 
@@ -407,7 +407,7 @@ mod tests {
         let tree_id_b = index.write_tree().unwrap();
         let tree_b = repo.find_tree(tree_id_b).unwrap();
         let c2 = repo
-            .commit(Some("refs/heads/master"), &sig, &sig, "B", &tree_b, &[&c1])
+            .commit(Some("refs/heads/main"), &sig, &sig, "B", &tree_b, &[&c1])
             .unwrap();
 
         let branch = repo.find_annotated_commit(c2).unwrap();

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -48,10 +48,10 @@ impl<'repo> Reference<'repo> {
     /// use git2::Reference;
     ///
     /// assert!(Reference::is_valid_name("HEAD"));
-    /// assert!(Reference::is_valid_name("refs/heads/master"));
+    /// assert!(Reference::is_valid_name("refs/heads/main"));
     ///
     /// // But:
-    /// assert!(!Reference::is_valid_name("master"));
+    /// assert!(!Reference::is_valid_name("main"));
     /// assert!(!Reference::is_valid_name("refs/heads/*"));
     /// assert!(!Reference::is_valid_name("foo//bar"));
     /// ```
@@ -78,7 +78,7 @@ impl<'repo> Reference<'repo> {
     ///    only when combined with [`ReferenceFormat::ALLOW_ONELEVEL`]. If
     ///    it is given, "shorthand" branch names (i.e. those not prefixed by
     ///    `refs/`, but consisting of a single word without `/` separators)
-    ///    become valid. For example, "master" would be accepted.
+    ///    become valid. For example, "main" would be accepted.
     /// 3. If [`ReferenceFormat::REFSPEC_PATTERN`] is given, the name may
     ///    contain a single `*` in place of a full pathname component (e.g.
     ///    `foo/*/bar`, `foo/bar*`).
@@ -121,11 +121,11 @@ impl<'repo> Reference<'repo> {
     ///
     /// assert_eq!(
     ///     Reference::normalize_name(
-    ///         "master",
+    ///         "main",
     ///         ReferenceFormat::ALLOW_ONELEVEL | ReferenceFormat::REFSPEC_SHORTHAND
     ///     )
     ///     .unwrap(),
-    ///     "master".to_owned()
+    ///     "main".to_owned()
     /// );
     /// ```
     ///
@@ -482,18 +482,18 @@ mod tests {
         assert_eq!(head.kind().unwrap(), ReferenceType::Direct);
 
         assert!(head == repo.head().unwrap());
-        assert_eq!(head.name(), Some("refs/heads/master"));
+        assert_eq!(head.name(), Some("refs/heads/main"));
 
-        assert!(head == repo.find_reference("refs/heads/master").unwrap());
+        assert!(head == repo.find_reference("refs/heads/main").unwrap());
         assert_eq!(
-            repo.refname_to_id("refs/heads/master").unwrap(),
+            repo.refname_to_id("refs/heads/main").unwrap(),
             head.target().unwrap()
         );
 
         assert!(head.symbolic_target().is_none());
         assert!(head.target_peel().is_none());
 
-        assert_eq!(head.shorthand(), Some("master"));
+        assert_eq!(head.shorthand(), Some("main"));
         assert!(head.resolve().unwrap() == head);
 
         let mut tag1 = repo
@@ -509,7 +509,7 @@ mod tests {
         tag1.delete().unwrap();
 
         let mut sym1 = repo
-            .reference_symbolic("refs/tags/tag1", "refs/heads/master", false, "test")
+            .reference_symbolic("refs/tags/tag1", "refs/heads/main", false, "test")
             .unwrap();
         assert_eq!(sym1.kind().unwrap(), ReferenceType::Symbolic);
         sym1.delete().unwrap();
@@ -519,7 +519,7 @@ mod tests {
             assert!(repo.references().unwrap().next().unwrap().unwrap() == head);
             let mut names = repo.references().unwrap();
             let mut names = names.names();
-            assert_eq!(names.next().unwrap().unwrap(), "refs/heads/master");
+            assert_eq!(names.next().unwrap().unwrap(), "refs/heads/main");
             assert!(names.next().is_none());
             assert!(repo.references_glob("foo").unwrap().count() == 0);
             assert!(repo.references_glob("refs/heads/*").unwrap().count() == 1);

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -231,15 +231,15 @@ impl<'repo> Remote<'repo> {
     ///
     /// # Examples
     ///
-    /// Example of functionality similar to `git fetch origin/master`:
+    /// Example of functionality similar to `git fetch origin/main`:
     ///
     /// ```no_run
-    /// fn fetch_origin_master(repo: git2::Repository) -> Result<(), git2::Error> {
-    ///     repo.find_remote("origin")?.fetch(&["master"], None, None)
+    /// fn fetch_origin_main(repo: git2::Repository) -> Result<(), git2::Error> {
+    ///     repo.find_remote("origin")?.fetch(&["main"], None, None)
     /// }
     ///
     /// let repo = git2::Repository::discover("rust").unwrap();
-    /// fetch_origin_master(repo).unwrap();
+    /// fetch_origin_main(repo).unwrap();
     /// ```
     pub fn fetch<Str: AsRef<str> + crate::IntoCString + Clone>(
         &mut self,
@@ -757,7 +757,7 @@ mod tests {
             assert_eq!(list.len(), 2);
             assert_eq!(list[0].name(), "HEAD");
             assert!(!list[0].is_local());
-            assert_eq!(list[1].name(), "refs/heads/master");
+            assert_eq!(list[1].name(), "refs/heads/main");
             assert!(!list[1].is_local());
         }
         assert!(progress_hit.get());
@@ -790,7 +790,7 @@ mod tests {
             assert_eq!(list.len(), 2);
             assert_eq!(list[0].name(), "HEAD");
             assert!(!list[0].is_local());
-            assert_eq!(list[1].name(), "refs/heads/master");
+            assert_eq!(list[1].name(), "refs/heads/main");
             assert!(!list[1].is_local());
         }
         assert!(!origin.connected());
@@ -803,7 +803,10 @@ mod tests {
         let td3 = TempDir::new().unwrap();
         let url = crate::test::path2url(&td2.path());
 
-        Repository::init_bare(td2.path()).unwrap();
+        let mut opts = crate::RepositoryInitOptions::new();
+        opts.bare(true);
+        opts.initial_head("main");
+        Repository::init_opts(td2.path(), &opts).unwrap();
         // git push
         let mut remote = repo.remote("origin", &url).unwrap();
         let mut updated = false;
@@ -811,14 +814,14 @@ mod tests {
             let mut callbacks = RemoteCallbacks::new();
             callbacks.push_update_reference(|refname, status| {
                 updated = true;
-                assert_eq!(refname, "refs/heads/master");
+                assert_eq!(refname, "refs/heads/main");
                 assert_eq!(status, None);
                 Ok(())
             });
             let mut options = PushOptions::new();
             options.remote_callbacks(callbacks);
             remote
-                .push(&["refs/heads/master"], Some(&mut options))
+                .push(&["refs/heads/main"], Some(&mut options))
                 .unwrap();
         }
         assert!(updated);

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1463,7 +1463,7 @@ impl Repository {
 
     /// Lookup a reference to one of the objects in a repository.
     /// `Repository::find_reference` with teeth; give the method your reference in
-    /// human-readable format e.g. 'master' instead of 'refs/heads/master', and it
+    /// human-readable format e.g. 'main' instead of 'refs/heads/main', and it
     /// will do-what-you-mean, returning the `Reference`.
     pub fn resolve_reference_from_short_name(&self, refname: &str) -> Result<Reference<'_>, Error> {
         let refname = CString::new(refname)?;
@@ -2929,9 +2929,9 @@ impl RepositoryInitOptions {
 
     /// The name of the head to point HEAD at.
     ///
-    /// If not configured, this will be treated as `master` and the HEAD ref
-    /// will be set to `refs/heads/master`. If this begins with `refs/` it will
-    /// be used verbatim; otherwise `refs/heads/` will be prefixed
+    /// If not configured, this will be taken from your git configuration.
+    /// If this begins with `refs/` it will be used verbatim;
+    /// otherwise `refs/heads/` will be prefixed
     pub fn initial_head(&mut self, head: &str) -> &mut RepositoryInitOptions {
         self.initial_head = Some(CString::new(head).unwrap());
         self
@@ -3160,11 +3160,11 @@ mod tests {
         let (_td, repo) = crate::test::repo_init();
 
         assert_eq!(repo.reference_has_log("HEAD").unwrap(), true);
-        assert_eq!(repo.reference_has_log("refs/heads/master").unwrap(), true);
+        assert_eq!(repo.reference_has_log("refs/heads/main").unwrap(), true);
         assert_eq!(repo.reference_has_log("NOT_HEAD").unwrap(), false);
-        let master_oid = repo.revparse_single("master").unwrap().id();
+        let main_oid = repo.revparse_single("main").unwrap().id();
         assert!(repo
-            .reference("NOT_HEAD", master_oid, false, "creating a new branch")
+            .reference("NOT_HEAD", main_oid, false, "creating a new branch")
             .is_ok());
         assert_eq!(repo.reference_has_log("NOT_HEAD").unwrap(), false);
         assert!(repo.reference_ensure_log("NOT_HEAD").is_ok());
@@ -3178,7 +3178,7 @@ mod tests {
         assert!(repo.set_head("refs/heads/does-not-exist").is_ok());
         assert!(repo.head().is_err());
 
-        assert!(repo.set_head("refs/heads/master").is_ok());
+        assert!(repo.set_head("refs/heads/main").is_ok());
         assert!(repo.head().is_ok());
 
         assert!(repo.set_head("*").is_err());
@@ -3191,9 +3191,9 @@ mod tests {
         let void_oid = Oid::from_bytes(b"00000000000000000000").unwrap();
         assert!(repo.set_head_detached(void_oid).is_err());
 
-        let master_oid = repo.revparse_single("master").unwrap().id();
-        assert!(repo.set_head_detached(master_oid).is_ok());
-        assert_eq!(repo.head().unwrap().target().unwrap(), master_oid);
+        let main_oid = repo.revparse_single("main").unwrap().id();
+        assert!(repo.set_head_detached(main_oid).is_ok());
+        assert_eq!(repo.head().unwrap().target().unwrap(), main_oid);
     }
 
     /// create the following:
@@ -3425,8 +3425,8 @@ mod tests {
         let (_td, repo) = graph_repo_init();
 
         {
-            let short_refname = "master";
-            let expected_refname = "refs/heads/master";
+            let short_refname = "main";
+            let expected_refname = "refs/heads/main";
             let (obj, reference) = repo.revparse_ext(short_refname).unwrap();
             let expected_obj = repo.revparse_single(expected_refname).unwrap();
             assert_eq!(obj.id(), expected_obj.id());

--- a/src/stash.rs
+++ b/src/stash.rs
@@ -184,7 +184,7 @@ mod tests {
         repo.stash_foreach(|index, name, _oid| {
             count += 1;
             assert!(index == 0);
-            assert!(name == "On master: msg1");
+            assert!(name == "On main: msg1");
             true
         })
         .unwrap();
@@ -256,6 +256,6 @@ mod tests {
         })
         .unwrap();
 
-        assert!(stash_name.starts_with("WIP on master:"));
+        assert!(stash_name.starts_with("WIP on main:"));
     }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -6,7 +6,7 @@ use std::ptr;
 use tempfile::TempDir;
 use url::Url;
 
-use crate::{Oid, Repository};
+use crate::{Oid, Repository, RepositoryInitOptions};
 
 macro_rules! t {
     ($e:expr) => {
@@ -19,7 +19,9 @@ macro_rules! t {
 
 pub fn repo_init() -> (TempDir, Repository) {
     let td = TempDir::new().unwrap();
-    let repo = Repository::init(td.path()).unwrap();
+    let mut opts = RepositoryInitOptions::new();
+    opts.initial_head("main");
+    let repo = Repository::init_opts(td.path(), &opts).unwrap();
     {
         let mut config = repo.config().unwrap();
         config.set_str("user.name", "name").unwrap();

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -404,7 +404,7 @@ mod tests {
 
         let mut origin = t!(repo.find_remote("origin"));
 
-        match origin.fetch(&["master"], None, None) {
+        match origin.fetch(&["main"], None, None) {
             Ok(()) => unreachable!(),
             Err(e) => assert_eq!(e, dummy_error()),
         }


### PR DESCRIPTION
This PR updates the `libgit2` submodule to the `v1.1.0` tag. It also updates the unit tests to use a fixed name for the HEAD of created test repositories.

Since libgit2 1.1.0, the gitconfig of the environment can change the name of the default branch. If the test do not specify a fixed name for the initial HEAD, they will fail on some systems with different configuration.

To make sure I didn't miss anything, I ran the tests this with `init.defaultBranch` in my gitconfig set to a value different from both `master` and `main`.

As a bonus, this PR also replaces `master` with `main` in documentation and examples of the `git2` crate.

This should automatically address rust-lang/cargo/issues/8588 once cargo updates the dependency on this crate.