### PR TITLE
Remove trailing semicolon from internal `err!` macro

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -204,7 +204,7 @@ pub fn c_cmp_to_ordering(cmp: c_int) -> Ordering {
 pub fn path_to_repo_path(path: &Path) -> Result<CString, Error> {
     macro_rules! err {
         ($msg:literal, $path:expr) => {
-            return Err(Error::from_str(&format!($msg, $path.display())));
+            return Err(Error::from_str(&format!($msg, $path.display())))
         };
     }
     match path.components().next() {


### PR DESCRIPTION
This will allow this crate to continue to compile if
https://github.com/rust-lang/rust/issues/33953 is fixed