### PR TITLE
Allow creating detached remotes

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -2030,10 +2030,7 @@ extern "C" {
         repo: *mut git_repository,
         url: *const c_char,
     ) -> c_int;
-    pub fn git_remote_create_detached(
-        out: *mut *mut git_remote,
-        url: *const c_char,
-    ) -> c_int;
+    pub fn git_remote_create_detached(out: *mut *mut git_remote, url: *const c_char) -> c_int;
     pub fn git_remote_delete(repo: *mut git_repository, name: *const c_char) -> c_int;
     pub fn git_remote_free(remote: *mut git_remote);
     pub fn git_remote_name(remote: *const git_remote) -> *const c_char;

--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -2030,6 +2030,10 @@ extern "C" {
         repo: *mut git_repository,
         url: *const c_char,
     ) -> c_int;
+    pub fn git_remote_create_detached(
+        out: *mut *mut git_remote,
+        url: *const c_char,
+    ) -> c_int;
     pub fn git_remote_delete(repo: *mut git_repository, name: *const c_char) -> c_int;
     pub fn git_remote_free(remote: *mut git_remote);
     pub fn git_remote_name(remote: *const git_remote) -> *const c_char;

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -73,6 +73,21 @@ impl<'repo> Remote<'repo> {
         unsafe { raw::git_remote_is_valid_name(remote_name.as_ptr()) == 1 }
     }
 
+    /// Create a detached remote
+    ///
+    /// Create a remote with the given url in-memory. You can use this
+    /// when you have a URL instead of a remote's name.
+    /// Contrasted with an anonymous remote, a detached remote will not
+    /// consider any repo configuration values.
+    pub fn create_detached(url: &str) -> Result<Remote<'_>, Error> {
+        let mut ret = ptr::null_mut();
+        let url = CString::new(url)?;
+        unsafe {
+            try_call!(raw::git_remote_create_detached(&mut ret, url));
+            Ok(Binding::from_raw(ret))
+        }
+    }
+
     /// Get the remote's name.
     ///
     /// Returns `None` if this remote has not yet been named or if the name is

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -80,6 +80,7 @@ impl<'repo> Remote<'repo> {
     /// Contrasted with an anonymous remote, a detached remote will not
     /// consider any repo configuration values.
     pub fn create_detached(url: &str) -> Result<Remote<'_>, Error> {
+        crate::init();
         let mut ret = ptr::null_mut();
         let url = CString::new(url)?;
         unsafe {


### PR DESCRIPTION
This PR introduces an associated function on `Remote` type to allow creating detached remotes.

With this change, it's simple to implement `git ls-remote` doing something like this:

```rust
fn ls_remote(url: &str) -> Result<(), git2::Error> {
    let mut remote = Remote::create_detached(url)?;

    remote.connect(Direction::Fetch)?;

    for remote_ref in remote.list()? {
        println!("{}", remote_ref.name());
    }

    remote.disconnect()?;

    Ok(())
}
```

This also addresses #461.