### PR TITLE
Update libgit2 to fix misalignment issue on Windows arm64

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -473,6 +473,7 @@ git_enum! {
         GIT_CERT_SSH_MD5 = 1 << 0,
         GIT_CERT_SSH_SHA1 = 1 << 1,
         GIT_CERT_SSH_SHA256 = 1 << 2,
+        GIT_CERT_SSH_RAW = 1 << 3,
     }
 }
 


### PR DESCRIPTION
Also update `git_cert_ssh_t` to include lost value.

Closes #645 