### PR TITLE
Support turning a FileMode into a u32

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1049,6 +1049,19 @@ pub enum FileMode {
     Commit,
 }
 
+impl From<FileMode> for u32 {
+    fn from(mode: FileMode) -> u32 {
+        match mode {
+            FileMode::Unreadable => raw::GIT_FILEMODE_UNREADABLE as u32,
+            FileMode::Tree => raw::GIT_FILEMODE_TREE as u32,
+            FileMode::Blob => raw::GIT_FILEMODE_BLOB as u32,
+            FileMode::BlobExecutable => raw::GIT_FILEMODE_BLOB_EXECUTABLE as u32,
+            FileMode::Link => raw::GIT_FILEMODE_LINK as u32,
+            FileMode::Commit => raw::GIT_FILEMODE_COMMIT as u32,
+        }
+    }
+}
+
 bitflags! {
     /// Return codes for submodule status.
     ///
@@ -1441,12 +1454,18 @@ impl Default for ReferenceFormat {
 
 #[cfg(test)]
 mod tests {
-    use super::ObjectType;
+    use super::{FileMode, ObjectType};
 
     #[test]
     fn convert() {
         assert_eq!(ObjectType::Blob.str(), "blob");
         assert_eq!(ObjectType::from_str("blob"), Some(ObjectType::Blob));
         assert!(ObjectType::Blob.is_loose());
+    }
+
+    #[test]
+    fn convert_filemode() {
+        assert_eq!(u32::from(FileMode::Blob), 0o100644);
+        assert_eq!(u32::from(FileMode::BlobExecutable), 0o100755);
     }
 }


### PR DESCRIPTION
Sometimes it's helpful to have the underlying numeric mode values,
rather than the FileMode enum. Provide a From instance to turn FileMode
into a u32.