### PR TITLE
Exclude more files from the published package.

### DIFF
--- a/libgit2-sys/Cargo.toml
+++ b/libgit2-sys/Cargo.toml
@@ -8,6 +8,10 @@ repository = "https://github.com/rust-lang/git2-rs"
 license = "MIT/Apache-2.0"
 description = "Native bindings to the libgit2 library"
 exclude = [
+    "libgit2/ci/*",
+    "libgit2/docs/*",
+    "libgit2/examples/*",
+    "libgit2/fuzzers/*",
     "libgit2/tests/*",
 ]
 edition = "2018"


### PR DESCRIPTION
This cuts about 3.5MB from the uncompressed package (11MB down to 7.5).
