### PR TITLE
test for the Repository::config() function

### DIFF
--- a/src/repo.rs
+++ b/src/repo.rs
@@ -3624,16 +3624,13 @@ mod tests {
 
     #[test]
     fn smoke_config_write_and_read() {
-        let td = TempDir::new().unwrap();
-        let path = td.path();
-
-        let repo = Repository::init(path).unwrap();
+        let (td, repo) = crate::test::repo_init();
 
         let mut config = repo.config().unwrap();
 
         config.set_bool("commit.gpgsign", false).unwrap();
 
-        let c = fs::read_to_string(path.join(".git").join("config")).unwrap();
+        let c = fs::read_to_string(td.path().join(".git").join("config")).unwrap();
 
         assert!(c.contains("[commit]"));
         assert!(c.contains("gpgsign = false"));

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -3621,4 +3621,25 @@ mod tests {
         // reverting twice restores `foo` file
         assert!(foo_file.exists());
     }
+
+    #[test]
+    fn smoke_config_write_and_read() {
+        let td = TempDir::new().unwrap();
+        let path = td.path();
+
+        let repo = Repository::init(path).unwrap();
+
+        let mut config = repo.config().unwrap();
+
+        config.set_bool("commit.gpgsign", false).unwrap();
+
+        let c = fs::read_to_string(path.join(".git").join("config")).unwrap();
+
+        assert!(c.contains("[commit]"));
+        assert!(c.contains("gpgsign = false"));
+
+        let config = repo.config().unwrap();
+
+        assert!(!config.get_bool("commit.gpgsign").unwrap());
+    }
 }


### PR DESCRIPTION
I was debugging a thing, and thought that I could just as well push the test I wrote for debugging upstream.

This test verifies that the Repository::config() function returns a config object that have the local repository as highest prio.