### PR TITLE
Add bindings for git_merge_analysis_for_ref

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -3116,6 +3116,15 @@ extern "C" {
         their_heads_len: usize,
     ) -> c_int;
 
+    pub fn git_merge_analysis_for_ref(
+        analysis_out: *mut git_merge_analysis_t,
+        pref_out: *mut git_merge_preference_t,
+        repo: *mut git_repository,
+        git_reference: *mut git_reference,
+        their_heads: *mut *const git_annotated_commit,
+        their_heads_len: usize,
+    ) -> c_int;
+
     // notes
     pub fn git_note_author(note: *const git_note) -> *const git_signature;
     pub fn git_note_committer(note: *const git_note) -> *const git_signature;


### PR DESCRIPTION
This is a slightly generalised version of git_merge_analysis that allows
specifying the ref to analyse against instead of using the repository's
current HEAD.