### PR TITLE
Add git_libgit2_opts binding for get/set search path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ bitflags = "1.1.0"
 libc = "0.2"
 log = "0.4.8"
 libgit2-sys = { path = "libgit2-sys", version = "0.12.17" }
+once_cell = "1.5"
 
 [target."cfg(all(unix, not(target_os = \"macos\")))".dependencies]
 openssl-sys = { version = "0.9.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ bitflags = "1.1.0"
 libc = "0.2"
 log = "0.4.8"
 libgit2-sys = { path = "libgit2-sys", version = "0.12.17" }
-once_cell = "1.5"
 
 [target."cfg(all(unix, not(target_os = \"macos\")))".dependencies]
 openssl-sys = { version = "0.9.0", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -363,7 +363,7 @@ pub enum BranchType {
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
 pub enum ConfigLevel {
     /// System-wide on Windows, for compatibility with portable git
-    ProgramData,
+    ProgramData = 1,
     /// System-wide configuration file, e.g. /etc/gitconfig
     System,
     /// XDG-compatible configuration file, e.g. ~/.config/git/config
@@ -375,7 +375,7 @@ pub enum ConfigLevel {
     /// Application specific configuration file
     App,
     /// Highest level available
-    Highest,
+    Highest = -1,
 }
 
 /// Merge file favor options for `MergeOptions` instruct the file-level

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -96,8 +96,34 @@ pub fn strict_hash_verification(enabled: bool) {
 
 #[cfg(test)]
 mod test {
+    use super::*;
+    use std::env::join_paths;
+
     #[test]
     fn smoke() {
-        super::strict_hash_verification(false);
+        strict_hash_verification(false);
+    }
+
+    #[test]
+    fn search_path() -> Result<(), Box<dyn std::error::Error>> {
+        let path = "fake_path";
+        let original = get_search_path(ConfigLevel::Global);
+        assert_ne!(original, Ok(path.into()));
+
+        // Set
+        set_search_path(ConfigLevel::Global, &path)?;
+        assert_eq!(get_search_path(ConfigLevel::Global), Ok(path.into()));
+
+        // Append
+        let paths = join_paths(["$PATH", path].iter())?;
+        let expected_paths = join_paths([path, path].iter())?.into_string().unwrap();
+        set_search_path(ConfigLevel::Global, paths)?;
+        assert_eq!(get_search_path(ConfigLevel::Global), Ok(expected_paths));
+
+        // Reset
+        reset_search_path(ConfigLevel::Global)?;
+        assert_eq!(get_search_path(ConfigLevel::Global), original);
+
+        Ok(())
     }
 }

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -102,45 +102,9 @@ pub fn strict_hash_verification(enabled: bool) {
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::env::join_paths;
 
     #[test]
     fn smoke() {
         strict_hash_verification(false);
-    }
-
-    #[test]
-    fn search_path() -> Result<(), Box<dyn std::error::Error>> {
-        let path = "fake_path";
-        let original = unsafe { get_search_path(ConfigLevel::Global) };
-        assert_ne!(original, Ok(path.into_c_string()?));
-
-        // Set
-        unsafe {
-            set_search_path(ConfigLevel::Global, &path)?;
-        }
-        assert_eq!(
-            unsafe { get_search_path(ConfigLevel::Global) },
-            Ok(path.into_c_string()?)
-        );
-
-        // Append
-        let paths = join_paths(["$PATH", path].iter())?;
-        let expected_paths = join_paths([path, path].iter())?.into_c_string()?;
-        unsafe {
-            set_search_path(ConfigLevel::Global, paths)?;
-        }
-        assert_eq!(
-            unsafe { get_search_path(ConfigLevel::Global) },
-            Ok(expected_paths)
-        );
-
-        // Reset
-        unsafe {
-            reset_search_path(ConfigLevel::Global)?;
-        }
-        assert_eq!(unsafe { get_search_path(ConfigLevel::Global) }, original);
-
-        Ok(())
     }
 }

--- a/tests/global_state.rs
+++ b/tests/global_state.rs
@@ -1,0 +1,47 @@
+//! Test for some global state set up by libgit2's `git_libgit2_init` function
+//! that need to be synchronized within a single process.
+
+use git2::opts;
+use git2::{ConfigLevel, IntoCString};
+
+// Test for mutating configuration file search path which is set during
+// initialization in libgit2's `git_sysdir_global_init` function.
+#[test]
+fn search_path() -> Result<(), Box<dyn std::error::Error>> {
+    use std::env::join_paths;
+
+    let path = "fake_path";
+    let original = unsafe { opts::get_search_path(ConfigLevel::Global) };
+    assert_ne!(original, Ok(path.into_c_string()?));
+
+    // Set
+    unsafe {
+        opts::set_search_path(ConfigLevel::Global, &path)?;
+    }
+    assert_eq!(
+        unsafe { opts::get_search_path(ConfigLevel::Global) },
+        Ok(path.into_c_string()?)
+    );
+
+    // Append
+    let paths = join_paths(["$PATH", path].iter())?;
+    let expected_paths = join_paths([path, path].iter())?.into_c_string()?;
+    unsafe {
+        opts::set_search_path(ConfigLevel::Global, paths)?;
+    }
+    assert_eq!(
+        unsafe { opts::get_search_path(ConfigLevel::Global) },
+        Ok(expected_paths)
+    );
+
+    // Reset
+    unsafe {
+        opts::reset_search_path(ConfigLevel::Global)?;
+    }
+    assert_eq!(
+        unsafe { opts::get_search_path(ConfigLevel::Global) },
+        original
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Prepare these bindings in order to fix https://github.com/rust-lang/cargo/issues/8863.

Due to the same reason mentioned https://github.com/rust-lang/git2-rs/pull/126#discussion_r57835890 , the bindings do not split strings to paths and leave the work for callers to call `std::env::join_paths` themselves.

