### PR TITLE
Add bindings for `git_attr_value()`

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -1,0 +1,174 @@
+use crate::raw;
+use std::convert::TryFrom;
+use std::ptr;
+use std::str::{self, Utf8Error};
+
+macro_rules! define_inspector {
+    ($enum_name:ident, $enum_doc:literal, $fn_name:ident, $fn_doc:literal, $s:ty) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        #[doc = $enum_doc]
+        pub enum $enum_name<'string> {
+            /// The attribute is set to true.
+            True,
+            /// The attribute is unset (set to false).
+            False,
+            /// The attribute is set to a string.
+            String(&'string $s),
+            /// The attribute is not specified.
+            Unspecified,
+        }
+
+        #[doc = $fn_doc]
+        pub fn $fn_name(attr_value: Option<&$s>) -> $enum_name<'_> {
+            match unsafe {
+                raw::git_attr_value(attr_value.map_or(ptr::null(), |v| v.as_ptr().cast()))
+            } {
+                raw::GIT_ATTR_VALUE_TRUE => $enum_name::True,
+                raw::GIT_ATTR_VALUE_FALSE => $enum_name::False,
+                raw::GIT_ATTR_VALUE_STRING => $enum_name::String(attr_value.unwrap()),
+                raw::GIT_ATTR_VALUE_UNSPECIFIED => $enum_name::Unspecified,
+                _ => unreachable!(),
+            }
+        }
+    };
+}
+
+define_inspector!(
+    AttrValue,
+    "All possible states of an attribute, using [`prim@str`] to represent the string.\n\n\
+     This enum is returned by [`attr_value`].",
+    attr_value,
+    "Returns the state of an attribute by inspecting its [value](crate::Repository::get_attr) \
+     by a [string](prim@str).",
+    str
+);
+
+/// Converts [`AttrValueBytes`] to [`AttrValue`]. If the attribute is [set to a string](`AttrValueBytes::String`),
+/// this implementation will use [`str::from_utf8`] to perform the conversion.
+impl<'string> TryFrom<AttrValueBytes<'string>> for AttrValue<'string> {
+    type Error = Utf8Error;
+
+    fn try_from(value: AttrValueBytes<'string>) -> Result<Self, Self::Error> {
+        match value {
+            AttrValueBytes::True => Ok(Self::True),
+            AttrValueBytes::False => Ok(Self::False),
+            AttrValueBytes::String(s) => Ok(Self::String(str::from_utf8(s)?)),
+            AttrValueBytes::Unspecified => Ok(Self::Unspecified),
+        }
+    }
+}
+
+define_inspector!(
+    AttrValueBytes,
+    "All possible states of an attribute, using a [byte](u8) [slice] to represent the string.\n\n\
+     This enum is returned by [`attr_value_bytes`].",
+    attr_value_bytes,
+    "Returns the state of an attribute by inspecting its [value](crate::Repository::get_attr_bytes) \
+     by a [byte](u8) [slice].",
+    [u8]
+);
+
+/// Converts [`AttrValue`] to [`AttrValueBytes`]. This implementation will convert the
+/// [string slice](prim@str) to a [byte](u8) [slice] when the attribute is
+/// [set to a string](`AttrValue::String`).
+impl<'string> From<AttrValue<'string>> for AttrValueBytes<'string> {
+    fn from(value: AttrValue<'string>) -> Self {
+        match value {
+            AttrValue::True => Self::True,
+            AttrValue::False => Self::False,
+            AttrValue::String(s) => Self::String(s.as_ref()),
+            AttrValue::Unspecified => Self::Unspecified,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AttrValue, AttrValueBytes};
+    use std::convert::{TryFrom, TryInto};
+    use std::ffi::CStr;
+    use std::os::raw::c_char;
+
+    extern "C" {
+        // libgit2 defines them as mutable, so they are also declared mutable here.
+        // However, libgit2 never mutates them, thus it's always safe to access them in Rust.
+        static mut git_attr__true: *const c_char;
+        static mut git_attr__false: *const c_char;
+        static mut git_attr__unset: *const c_char;
+    }
+
+    macro_rules! define_test {
+        ($enum_name:ident, $fn_name:ident) => {
+            #[test]
+            fn $fn_name() {
+                let attr_true = unsafe { CStr::from_ptr(git_attr__true) }.to_str().unwrap();
+                let attr_false = unsafe { CStr::from_ptr(git_attr__false) }.to_str().unwrap();
+                let attr_unset = unsafe { CStr::from_ptr(git_attr__unset) }.to_str().unwrap();
+                assert_eq!(
+                    super::$fn_name(Some(attr_true.to_owned().as_ref())),
+                    $enum_name::String(attr_true.as_ref())
+                );
+                assert_eq!(
+                    super::$fn_name(Some(attr_false.to_owned().as_ref())),
+                    $enum_name::String(attr_false.as_ref())
+                );
+                assert_eq!(
+                    super::$fn_name(Some(attr_unset.to_owned().as_ref())),
+                    $enum_name::String(attr_unset.as_ref())
+                );
+                assert_eq!(
+                    super::$fn_name(Some("foo".as_ref())),
+                    $enum_name::String("foo".as_ref())
+                );
+                assert_eq!(
+                    super::$fn_name(Some("bar".as_ref())),
+                    $enum_name::String("bar".as_ref())
+                );
+                assert_eq!(super::$fn_name(Some(attr_true.as_ref())), $enum_name::True);
+                assert_eq!(
+                    super::$fn_name(Some(attr_false.as_ref())),
+                    $enum_name::False
+                );
+                assert_eq!(
+                    super::$fn_name(Some(attr_unset.as_ref())),
+                    $enum_name::Unspecified
+                );
+                assert_eq!(super::$fn_name(None), $enum_name::Unspecified);
+            }
+        };
+    }
+
+    define_test!(AttrValue, attr_value);
+    define_test!(AttrValueBytes, attr_value_bytes);
+
+    #[test]
+    fn attr_value_from_attr_value_bytes() {
+        assert_eq!(AttrValue::True, AttrValueBytes::True.try_into().unwrap());
+        assert_eq!(AttrValue::False, AttrValueBytes::False.try_into().unwrap());
+        assert_eq!(
+            AttrValue::String("foo"),
+            AttrValueBytes::String(b"foo").try_into().unwrap()
+        );
+        assert_eq!(
+            AttrValue::try_from(AttrValueBytes::String(b"bar\xff"))
+                .unwrap_err()
+                .valid_up_to(),
+            3
+        );
+        assert_eq!(
+            AttrValue::Unspecified,
+            AttrValueBytes::Unspecified.try_into().unwrap()
+        );
+    }
+
+    #[test]
+    fn attr_value_bytes_from_attr_value() {
+        assert_eq!(AttrValueBytes::True, AttrValue::True.into());
+        assert_eq!(AttrValueBytes::False, AttrValue::False.into());
+        assert_eq!(
+            AttrValueBytes::String(b"foo"),
+            AttrValue::String("foo").into()
+        );
+        assert_eq!(AttrValueBytes::Unspecified, AttrValue::Unspecified.into());
+    }
+}

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -1,93 +1,84 @@
 use crate::raw;
-use std::convert::TryFrom;
 use std::ptr;
-use std::str::{self, Utf8Error};
+use std::str;
 
-macro_rules! define_inspector {
-    ($enum_name:ident, $enum_doc:literal, $fn_doc:literal, $s:ty) => {
-        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-        #[doc = $enum_doc]
-        pub enum $enum_name<'string> {
-            /// The attribute is set to true.
-            True,
-            /// The attribute is unset (set to false).
-            False,
-            /// The attribute is set to a string.
-            String(&'string $s),
-            /// The attribute is not specified.
-            Unspecified,
-        }
-
-        impl<'string> $enum_name<'string> {
-            #[doc = $fn_doc]
-            pub fn new(attr_value: Option<&'string $s>) -> Self {
-                match unsafe {
-                    raw::git_attr_value(attr_value.map_or(ptr::null(), |v| v.as_ptr().cast()))
-                } {
-                    raw::GIT_ATTR_VALUE_TRUE => $enum_name::True,
-                    raw::GIT_ATTR_VALUE_FALSE => $enum_name::False,
-                    raw::GIT_ATTR_VALUE_STRING => $enum_name::String(attr_value.unwrap()),
-                    raw::GIT_ATTR_VALUE_UNSPECIFIED => $enum_name::Unspecified,
-                    _ => unreachable!(),
-                }
-            }
-        }
-    };
+/// All possible states of an attribute.
+///
+/// This enum is used to interpret the value returned by
+/// [`Repository::get_attr`](crate::Repository::get_attr) and
+/// [`Repository::get_attr_bytes`](crate::Repository::get_attr_bytes).
+#[derive(Debug, Clone, Copy, Eq)]
+pub enum AttrValue<'string> {
+    /// The attribute is set to true.
+    True,
+    /// The attribute is unset (set to false).
+    False,
+    /// The attribute is set to a [valid UTF-8 string](prim@str).
+    String(&'string str),
+    /// The attribute is set to a non-UTF-8 string.
+    Bytes(&'string [u8]),
+    /// The attribute is not specified.
+    Unspecified,
 }
 
-define_inspector!(
-    AttrValue,
-    "All possible states of an attribute, using [`prim@str`] to represent the string.\n\n\
-     This enum is used to interpret the value returned by \
-     [`Repository::get_attr`](crate::Repository::get_attr).",
-    "Returns the state of an attribute by inspecting its [value](crate::Repository::get_attr) \
-     by a [string](prim@str).",
-    str
-);
+impl<'string> AttrValue<'string> {
+    /// Returns the state of an attribute by inspecting its [value](crate::Repository::get_attr)
+    /// by a [string](prim@str).
+    ///
+    /// As [`str`](prim@str) is guaranteed to contain only valid UTF-8, this function never returns
+    /// [`AttrValue::Bytes`].
+    pub fn from_string(value: Option<&'string str>) -> Self {
+        match unsafe { raw::git_attr_value(value.map_or(ptr::null(), |v| v.as_ptr().cast())) } {
+            raw::GIT_ATTR_VALUE_TRUE => Self::True,
+            raw::GIT_ATTR_VALUE_FALSE => Self::False,
+            raw::GIT_ATTR_VALUE_STRING => Self::String(value.unwrap()),
+            raw::GIT_ATTR_VALUE_UNSPECIFIED => Self::Unspecified,
+            _ => unreachable!(),
+        }
+    }
 
-/// Converts [`AttrValueBytes`] to [`AttrValue`]. If the attribute is [set to a string](`AttrValueBytes::String`),
-/// this implementation will use [`str::from_utf8`] to perform the conversion.
-impl<'string> TryFrom<AttrValueBytes<'string>> for AttrValue<'string> {
-    type Error = Utf8Error;
-
-    fn try_from(value: AttrValueBytes<'string>) -> Result<Self, Self::Error> {
-        match value {
-            AttrValueBytes::True => Ok(Self::True),
-            AttrValueBytes::False => Ok(Self::False),
-            AttrValueBytes::String(s) => Ok(Self::String(str::from_utf8(s)?)),
-            AttrValueBytes::Unspecified => Ok(Self::Unspecified),
+    /// Returns the state of an attribute by inspecting its [value](crate::Repository::get_attr_bytes)
+    /// by a [byte](u8) [slice].
+    pub fn from_bytes(value: Option<&'string [u8]>) -> Self {
+        match unsafe { raw::git_attr_value(value.map_or(ptr::null(), |v| v.as_ptr().cast())) } {
+            raw::GIT_ATTR_VALUE_TRUE => Self::True,
+            raw::GIT_ATTR_VALUE_FALSE => Self::False,
+            raw::GIT_ATTR_VALUE_STRING => {
+                let value = value.unwrap();
+                if let Ok(string) = str::from_utf8(value) {
+                    Self::String(string)
+                } else {
+                    Self::Bytes(value)
+                }
+            }
+            raw::GIT_ATTR_VALUE_UNSPECIFIED => Self::Unspecified,
+            _ => unreachable!(),
         }
     }
 }
 
-define_inspector!(
-    AttrValueBytes,
-    "All possible states of an attribute, using a [byte](u8) [slice] to represent the string.\n\n\
-     This enum is used to interpret the value returned by \
-     [`Repository::get_attr_bytes`](crate::Repository::get_attr_bytes).",
-    "Returns the state of an attribute by inspecting its [value](crate::Repository::get_attr_bytes) \
-     by a [byte](u8) [slice].",
-    [u8]
-);
-
-/// Converts [`AttrValue`] to [`AttrValueBytes`]. This implementation will convert the
-/// [string slice](prim@str) to a [byte](u8) [slice] when the attribute is
-/// [set to a string](`AttrValue::String`).
-impl<'string> From<AttrValue<'string>> for AttrValueBytes<'string> {
-    fn from(value: AttrValue<'string>) -> Self {
-        match value {
-            AttrValue::True => Self::True,
-            AttrValue::False => Self::False,
-            AttrValue::String(s) => Self::String(s.as_ref()),
-            AttrValue::Unspecified => Self::Unspecified,
+/// Compare two [`AttrValue`]s.
+///
+/// Note that this implementation does not differentiate [`AttrValue::String`] and
+/// [`AttrValue::Bytes`].
+impl PartialEq for AttrValue<'_> {
+    fn eq(&self, other: &AttrValue<'_>) -> bool {
+        match (self, other) {
+            (Self::True, AttrValue::True)
+            | (Self::False, AttrValue::False)
+            | (Self::Unspecified, AttrValue::Unspecified) => true,
+            (AttrValue::String(string), AttrValue::Bytes(bytes))
+            | (Self::Bytes(bytes), AttrValue::String(string)) => string.as_bytes() == *bytes,
+            (Self::String(left), AttrValue::String(right)) => left == right,
+            (Self::Bytes(left), AttrValue::Bytes(right)) => left == right,
+            _ => false,
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{AttrValue, AttrValueBytes};
-    use std::convert::{TryFrom, TryInto};
+    use super::AttrValue;
     use std::ffi::CStr;
     use std::os::raw::c_char;
 
@@ -99,76 +90,76 @@ mod tests {
         static mut git_attr__unset: *const c_char;
     }
 
-    macro_rules! test_enum {
-        ($name:ident) => {
+    macro_rules! test_attr_value_from {
+        ($function:ident, $variant:ident) => {
             let attr_true = unsafe { CStr::from_ptr(git_attr__true) }.to_str().unwrap();
             let attr_false = unsafe { CStr::from_ptr(git_attr__false) }.to_str().unwrap();
             let attr_unset = unsafe { CStr::from_ptr(git_attr__unset) }.to_str().unwrap();
             assert_eq!(
-                $name::new(Some(attr_true.to_owned().as_ref())),
-                $name::String(attr_true.as_ref())
+                AttrValue::$function(Some(attr_true.to_owned().as_ref())),
+                AttrValue::$variant(attr_true.as_ref())
             );
             assert_eq!(
-                $name::new(Some(attr_false.to_owned().as_ref())),
-                $name::String(attr_false.as_ref())
+                AttrValue::$function(Some(attr_false.to_owned().as_ref())),
+                AttrValue::$variant(attr_false.as_ref())
             );
             assert_eq!(
-                $name::new(Some(attr_unset.to_owned().as_ref())),
-                $name::String(attr_unset.as_ref())
+                AttrValue::$function(Some(attr_unset.to_owned().as_ref())),
+                AttrValue::$variant(attr_unset.as_ref())
             );
             assert_eq!(
-                $name::new(Some("foo".as_ref())),
-                $name::String("foo".as_ref())
+                AttrValue::$function(Some("foo".as_ref())),
+                AttrValue::$variant("foo".as_ref())
             );
             assert_eq!(
-                $name::new(Some("bar".as_ref())),
-                $name::String("bar".as_ref())
+                AttrValue::$function(Some("bar".as_ref())),
+                AttrValue::$variant("bar".as_ref())
             );
-            assert_eq!($name::new(Some(attr_true.as_ref())), $name::True);
-            assert_eq!($name::new(Some(attr_false.as_ref())), $name::False);
-            assert_eq!($name::new(Some(attr_unset.as_ref())), $name::Unspecified);
-            assert_eq!($name::new(None), $name::Unspecified);
+            assert_eq!(
+                AttrValue::$function(Some(attr_true.as_ref())),
+                AttrValue::True
+            );
+            assert_eq!(
+                AttrValue::$function(Some(attr_false.as_ref())),
+                AttrValue::False
+            );
+            assert_eq!(
+                AttrValue::$function(Some(attr_unset.as_ref())),
+                AttrValue::Unspecified
+            );
+            assert_eq!(AttrValue::$function(None), AttrValue::Unspecified);
         };
     }
 
     #[test]
-    fn attr_value() {
-        test_enum!(AttrValue);
+    fn attr_value_from_string() {
+        test_attr_value_from!(from_string, String);
     }
 
     #[test]
-    fn attr_value_bytes() {
-        test_enum!(AttrValueBytes);
+    fn attr_value_from_bytes() {
+        test_attr_value_from!(from_bytes, Bytes);
     }
 
     #[test]
-    fn attr_value_from_attr_value_bytes() {
-        assert_eq!(AttrValue::True, AttrValueBytes::True.try_into().unwrap());
-        assert_eq!(AttrValue::False, AttrValueBytes::False.try_into().unwrap());
-        assert_eq!(
-            AttrValue::String("foo"),
-            AttrValueBytes::String(b"foo").try_into().unwrap()
-        );
-        assert_eq!(
-            AttrValue::try_from(AttrValueBytes::String(b"bar\xff"))
-                .unwrap_err()
-                .valid_up_to(),
-            3
-        );
-        assert_eq!(
-            AttrValue::Unspecified,
-            AttrValueBytes::Unspecified.try_into().unwrap()
-        );
-    }
-
-    #[test]
-    fn attr_value_bytes_from_attr_value() {
-        assert_eq!(AttrValueBytes::True, AttrValue::True.into());
-        assert_eq!(AttrValueBytes::False, AttrValue::False.into());
-        assert_eq!(
-            AttrValueBytes::String(b"foo"),
-            AttrValue::String("foo").into()
-        );
-        assert_eq!(AttrValueBytes::Unspecified, AttrValue::Unspecified.into());
+    fn attr_value_partial_eq() {
+        assert_eq!(AttrValue::True, AttrValue::True);
+        assert_eq!(AttrValue::False, AttrValue::False);
+        assert_eq!(AttrValue::String("foo"), AttrValue::String("foo"));
+        assert_eq!(AttrValue::Bytes(b"foo"), AttrValue::Bytes(b"foo"));
+        assert_eq!(AttrValue::String("bar"), AttrValue::Bytes(b"bar"));
+        assert_eq!(AttrValue::Bytes(b"bar"), AttrValue::String("bar"));
+        assert_eq!(AttrValue::Unspecified, AttrValue::Unspecified);
+        assert_ne!(AttrValue::True, AttrValue::False);
+        assert_ne!(AttrValue::False, AttrValue::Unspecified);
+        assert_ne!(AttrValue::Unspecified, AttrValue::True);
+        assert_ne!(AttrValue::True, AttrValue::String("true"));
+        assert_ne!(AttrValue::Unspecified, AttrValue::Bytes(b"unspecified"));
+        assert_ne!(AttrValue::Bytes(b"false"), AttrValue::False);
+        assert_ne!(AttrValue::String("unspecified"), AttrValue::Unspecified);
+        assert_ne!(AttrValue::String("foo"), AttrValue::String("bar"));
+        assert_ne!(AttrValue::Bytes(b"foo"), AttrValue::Bytes(b"bar"));
+        assert_ne!(AttrValue::String("foo"), AttrValue::Bytes(b"bar"));
+        assert_ne!(AttrValue::Bytes(b"foo"), AttrValue::String("bar"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,14 +74,13 @@
 use bitflags::bitflags;
 use libgit2_sys as raw;
 
-use std::convert::TryFrom;
 use std::ffi::{CStr, CString};
 use std::fmt;
-use std::ptr;
-use std::str::{self, Utf8Error};
+use std::str;
 use std::sync::Once;
 
 pub use crate::apply::{ApplyLocation, ApplyOptions};
+pub use crate::attr::{attr_value, attr_value_bytes, AttrValue, AttrValueBytes};
 pub use crate::blame::{Blame, BlameHunk, BlameIter, BlameOptions};
 pub use crate::blob::{Blob, BlobWriter};
 pub use crate::branch::{Branch, Branches};
@@ -635,6 +634,7 @@ impl MergePreference {
 mod test;
 #[macro_use]
 mod panic;
+mod attr;
 mod call;
 mod util;
 
@@ -1392,85 +1392,6 @@ impl Default for StashFlags {
     }
 }
 
-macro_rules! define_attr_inspector {
-    ($enum_name:ident, $enum_doc:literal, $fn_name:ident, $fn_doc:literal, $s:ty) => {
-        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-        #[doc = $enum_doc]
-        pub enum $enum_name<'string> {
-            /// The attribute is set to true.
-            True,
-            /// The attribute is unset (set to false).
-            False,
-            /// The attribute is set to a string.
-            String(&'string $s),
-            /// The attribute is not specified.
-            Unspecified,
-        }
-
-        #[doc = $fn_doc]
-        pub fn $fn_name(attr_value: Option<&$s>) -> $enum_name<'_> {
-            match unsafe {
-                raw::git_attr_value(attr_value.map_or(ptr::null(), |v| v.as_ptr().cast()))
-            } {
-                raw::GIT_ATTR_VALUE_TRUE => $enum_name::True,
-                raw::GIT_ATTR_VALUE_FALSE => $enum_name::False,
-                raw::GIT_ATTR_VALUE_STRING => $enum_name::String(attr_value.unwrap()),
-                raw::GIT_ATTR_VALUE_UNSPECIFIED => $enum_name::Unspecified,
-                _ => unreachable!(),
-            }
-        }
-    };
-}
-
-define_attr_inspector!(
-    AttrValue,
-    "All possible states of an attribute, using [`prim@str`] to represent the string.\n\n\
-     This enum is returned by [`attr_value`].",
-    attr_value,
-    "Returns the state of an attribute by inspecting its [value](Repository::get_attr) \
-     by a [string](prim@str).",
-    str
-);
-
-/// Converts [`AttrValueBytes`] to [`AttrValue`]. If the attribute is [set to a string](`AttrValueBytes::String`),
-/// this implementation will use [`str::from_utf8`] to perform the conversion.
-impl<'string> TryFrom<AttrValueBytes<'string>> for AttrValue<'string> {
-    type Error = Utf8Error;
-
-    fn try_from(value: AttrValueBytes<'string>) -> Result<Self, Self::Error> {
-        match value {
-            AttrValueBytes::True => Ok(Self::True),
-            AttrValueBytes::False => Ok(Self::False),
-            AttrValueBytes::String(s) => Ok(Self::String(str::from_utf8(s)?)),
-            AttrValueBytes::Unspecified => Ok(Self::Unspecified),
-        }
-    }
-}
-
-define_attr_inspector!(
-    AttrValueBytes,
-    "All possible states of an attribute, using a [byte](u8) [slice] to represent the string.\n\n\
-     This enum is returned by [`attr_value_bytes`].",
-    attr_value_bytes,
-    "Returns the state of an attribute by inspecting its [value](Repository::get_attr_bytes) \
-     by a [byte](u8) [slice].",
-    [u8]
-);
-
-/// Converts [`AttrValue`] to [`AttrValueBytes`]. This implementation will convert the
-/// [string slice](prim@str) to a [byte](u8) [slice] when the attribute is
-/// [set to a string](`AttrValue::String`).
-impl<'string> From<AttrValue<'string>> for AttrValueBytes<'string> {
-    fn from(value: AttrValue<'string>) -> Self {
-        match value {
-            AttrValue::True => Self::True,
-            AttrValue::False => Self::False,
-            AttrValue::String(s) => Self::String(s.as_ref()),
-            AttrValue::Unspecified => Self::Unspecified,
-        }
-    }
-}
-
 bitflags! {
     #[allow(missing_docs)]
     pub struct AttrCheckFlags: u32 {
@@ -1548,93 +1469,7 @@ impl Default for ReferenceFormat {
 
 #[cfg(test)]
 mod tests {
-    use super::{AttrValue, AttrValueBytes, FileMode, ObjectType};
-    use std::convert::{TryFrom, TryInto};
-    use std::ffi::CStr;
-    use std::os::raw::c_char;
-
-    extern "C" {
-        // libgit2 defines them as mutable, so they are also declared mutable here.
-        // However, libgit2 never mutates them, thus it's always safe to access them in Rust.
-        static mut git_attr__true: *const c_char;
-        static mut git_attr__false: *const c_char;
-        static mut git_attr__unset: *const c_char;
-    }
-
-    macro_rules! define_attr_value_test {
-        ($enum_name:ident, $fn_name:ident) => {
-            #[test]
-            fn $fn_name() {
-                let attr_true = unsafe { CStr::from_ptr(git_attr__true) }.to_str().unwrap();
-                let attr_false = unsafe { CStr::from_ptr(git_attr__false) }.to_str().unwrap();
-                let attr_unset = unsafe { CStr::from_ptr(git_attr__unset) }.to_str().unwrap();
-                assert_eq!(
-                    super::$fn_name(Some(attr_true.to_owned().as_ref())),
-                    $enum_name::String(attr_true.as_ref())
-                );
-                assert_eq!(
-                    super::$fn_name(Some(attr_false.to_owned().as_ref())),
-                    $enum_name::String(attr_false.as_ref())
-                );
-                assert_eq!(
-                    super::$fn_name(Some(attr_unset.to_owned().as_ref())),
-                    $enum_name::String(attr_unset.as_ref())
-                );
-                assert_eq!(
-                    super::$fn_name(Some("foo".as_ref())),
-                    $enum_name::String("foo".as_ref())
-                );
-                assert_eq!(
-                    super::$fn_name(Some("bar".as_ref())),
-                    $enum_name::String("bar".as_ref())
-                );
-                assert_eq!(super::$fn_name(Some(attr_true.as_ref())), $enum_name::True);
-                assert_eq!(
-                    super::$fn_name(Some(attr_false.as_ref())),
-                    $enum_name::False
-                );
-                assert_eq!(
-                    super::$fn_name(Some(attr_unset.as_ref())),
-                    $enum_name::Unspecified
-                );
-                assert_eq!(super::$fn_name(None), $enum_name::Unspecified);
-            }
-        };
-    }
-
-    define_attr_value_test!(AttrValue, attr_value);
-    define_attr_value_test!(AttrValueBytes, attr_value_bytes);
-
-    #[test]
-    fn attr_value_from_attr_value_bytes() {
-        assert_eq!(AttrValue::True, AttrValueBytes::True.try_into().unwrap());
-        assert_eq!(AttrValue::False, AttrValueBytes::False.try_into().unwrap());
-        assert_eq!(
-            AttrValue::String("foo"),
-            AttrValueBytes::String(b"foo").try_into().unwrap()
-        );
-        assert_eq!(
-            AttrValue::try_from(AttrValueBytes::String(b"bar\xff"))
-                .unwrap_err()
-                .valid_up_to(),
-            3
-        );
-        assert_eq!(
-            AttrValue::Unspecified,
-            AttrValueBytes::Unspecified.try_into().unwrap()
-        );
-    }
-
-    #[test]
-    fn attr_value_bytes_from_attr_value() {
-        assert_eq!(AttrValueBytes::True, AttrValue::True.into());
-        assert_eq!(AttrValueBytes::False, AttrValue::False.into());
-        assert_eq!(
-            AttrValueBytes::String(b"foo"),
-            AttrValue::String("foo").into()
-        );
-        assert_eq!(AttrValueBytes::Unspecified, AttrValue::Unspecified.into());
-    }
+    use super::{FileMode, ObjectType};
 
     #[test]
     fn convert() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ use std::str;
 use std::sync::Once;
 
 pub use crate::apply::{ApplyLocation, ApplyOptions};
-pub use crate::attr::{attr_value, attr_value_bytes, AttrValue, AttrValueBytes};
+pub use crate::attr::{AttrValue, AttrValueBytes};
 pub use crate::blame::{Blame, BlameHunk, BlameIter, BlameOptions};
 pub use crate::blob::{Blob, BlobWriter};
 pub use crate::branch::{Branch, Branches};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,9 +74,11 @@
 use bitflags::bitflags;
 use libgit2_sys as raw;
 
+use std::convert::TryFrom;
 use std::ffi::{CStr, CString};
 use std::fmt;
-use std::str;
+use std::ptr;
+use std::str::{self, Utf8Error};
 use std::sync::Once;
 
 pub use crate::apply::{ApplyLocation, ApplyOptions};
@@ -1390,6 +1392,85 @@ impl Default for StashFlags {
     }
 }
 
+macro_rules! define_attr_inspector {
+    ($enum_name:ident, $enum_doc:literal, $fn_name:ident, $fn_doc:literal, $s:ty) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        #[doc = $enum_doc]
+        pub enum $enum_name<'string> {
+            /// The attribute is set to true.
+            True,
+            /// The attribute is unset (set to false).
+            False,
+            /// The attribute is set to a string.
+            String(&'string $s),
+            /// The attribute is not specified.
+            Unspecified,
+        }
+
+        #[doc = $fn_doc]
+        pub fn $fn_name(attr_value: Option<&$s>) -> $enum_name<'_> {
+            match unsafe {
+                raw::git_attr_value(attr_value.map_or(ptr::null(), |v| v.as_ptr().cast()))
+            } {
+                raw::GIT_ATTR_VALUE_TRUE => $enum_name::True,
+                raw::GIT_ATTR_VALUE_FALSE => $enum_name::False,
+                raw::GIT_ATTR_VALUE_STRING => $enum_name::String(attr_value.unwrap()),
+                raw::GIT_ATTR_VALUE_UNSPECIFIED => $enum_name::Unspecified,
+                _ => unreachable!(),
+            }
+        }
+    };
+}
+
+define_attr_inspector!(
+    AttrValue,
+    "All possible states of an attribute, using [`prim@str`] to represent the string.\n\n\
+     This enum is returned by [`attr_value`].",
+    attr_value,
+    "Returns the state of an attribute by inspecting its [value](Repository::get_attr) \
+     by a [string](prim@str).",
+    str
+);
+
+/// Converts [`AttrValueBytes`] to [`AttrValue`]. If the attribute is [set to a string](`AttrValueBytes::String`),
+/// this implementation will use [`str::from_utf8`] to perform the conversion.
+impl<'string> TryFrom<AttrValueBytes<'string>> for AttrValue<'string> {
+    type Error = Utf8Error;
+
+    fn try_from(value: AttrValueBytes<'string>) -> Result<Self, Self::Error> {
+        match value {
+            AttrValueBytes::True => Ok(Self::True),
+            AttrValueBytes::False => Ok(Self::False),
+            AttrValueBytes::String(s) => Ok(Self::String(str::from_utf8(s)?)),
+            AttrValueBytes::Unspecified => Ok(Self::Unspecified),
+        }
+    }
+}
+
+define_attr_inspector!(
+    AttrValueBytes,
+    "All possible states of an attribute, using a [byte](u8) [slice] to represent the string.\n\n\
+     This enum is returned by [`attr_value_bytes`].",
+    attr_value_bytes,
+    "Returns the state of an attribute by inspecting its [value](Repository::get_attr_bytes) \
+     by a [byte](u8) [slice].",
+    [u8]
+);
+
+/// Converts [`AttrValue`] to [`AttrValueBytes`]. This implementation will convert the
+/// [string slice](prim@str) to a [byte](u8) [slice] when the attribute is
+/// [set to a string](`AttrValue::String`).
+impl<'string> From<AttrValue<'string>> for AttrValueBytes<'string> {
+    fn from(value: AttrValue<'string>) -> Self {
+        match value {
+            AttrValue::True => Self::True,
+            AttrValue::False => Self::False,
+            AttrValue::String(s) => Self::String(s.as_ref()),
+            AttrValue::Unspecified => Self::Unspecified,
+        }
+    }
+}
+
 bitflags! {
     #[allow(missing_docs)]
     pub struct AttrCheckFlags: u32 {
@@ -1467,7 +1548,93 @@ impl Default for ReferenceFormat {
 
 #[cfg(test)]
 mod tests {
-    use super::{FileMode, ObjectType};
+    use super::{AttrValue, AttrValueBytes, FileMode, ObjectType};
+    use std::convert::{TryFrom, TryInto};
+    use std::ffi::CStr;
+    use std::os::raw::c_char;
+
+    extern "C" {
+        // libgit2 defines them as mutable, so they are also declared mutable here.
+        // However, libgit2 never mutates them, thus it's always safe to access them in Rust.
+        static mut git_attr__true: *const c_char;
+        static mut git_attr__false: *const c_char;
+        static mut git_attr__unset: *const c_char;
+    }
+
+    macro_rules! define_attr_value_test {
+        ($enum_name:ident, $fn_name:ident) => {
+            #[test]
+            fn $fn_name() {
+                let attr_true = unsafe { CStr::from_ptr(git_attr__true) }.to_str().unwrap();
+                let attr_false = unsafe { CStr::from_ptr(git_attr__false) }.to_str().unwrap();
+                let attr_unset = unsafe { CStr::from_ptr(git_attr__unset) }.to_str().unwrap();
+                assert_eq!(
+                    super::$fn_name(Some(attr_true.to_owned().as_ref())),
+                    $enum_name::String(attr_true.as_ref())
+                );
+                assert_eq!(
+                    super::$fn_name(Some(attr_false.to_owned().as_ref())),
+                    $enum_name::String(attr_false.as_ref())
+                );
+                assert_eq!(
+                    super::$fn_name(Some(attr_unset.to_owned().as_ref())),
+                    $enum_name::String(attr_unset.as_ref())
+                );
+                assert_eq!(
+                    super::$fn_name(Some("foo".as_ref())),
+                    $enum_name::String("foo".as_ref())
+                );
+                assert_eq!(
+                    super::$fn_name(Some("bar".as_ref())),
+                    $enum_name::String("bar".as_ref())
+                );
+                assert_eq!(super::$fn_name(Some(attr_true.as_ref())), $enum_name::True);
+                assert_eq!(
+                    super::$fn_name(Some(attr_false.as_ref())),
+                    $enum_name::False
+                );
+                assert_eq!(
+                    super::$fn_name(Some(attr_unset.as_ref())),
+                    $enum_name::Unspecified
+                );
+                assert_eq!(super::$fn_name(None), $enum_name::Unspecified);
+            }
+        };
+    }
+
+    define_attr_value_test!(AttrValue, attr_value);
+    define_attr_value_test!(AttrValueBytes, attr_value_bytes);
+
+    #[test]
+    fn attr_value_from_attr_value_bytes() {
+        assert_eq!(AttrValue::True, AttrValueBytes::True.try_into().unwrap());
+        assert_eq!(AttrValue::False, AttrValueBytes::False.try_into().unwrap());
+        assert_eq!(
+            AttrValue::String("foo"),
+            AttrValueBytes::String(b"foo").try_into().unwrap()
+        );
+        assert_eq!(
+            AttrValue::try_from(AttrValueBytes::String(b"bar\xff"))
+                .unwrap_err()
+                .valid_up_to(),
+            3
+        );
+        assert_eq!(
+            AttrValue::Unspecified,
+            AttrValueBytes::Unspecified.try_into().unwrap()
+        );
+    }
+
+    #[test]
+    fn attr_value_bytes_from_attr_value() {
+        assert_eq!(AttrValueBytes::True, AttrValue::True.into());
+        assert_eq!(AttrValueBytes::False, AttrValue::False.into());
+        assert_eq!(
+            AttrValueBytes::String(b"foo"),
+            AttrValue::String("foo").into()
+        );
+        assert_eq!(AttrValueBytes::Unspecified, AttrValue::Unspecified.into());
+    }
 
     #[test]
     fn convert() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ use std::str;
 use std::sync::Once;
 
 pub use crate::apply::{ApplyLocation, ApplyOptions};
-pub use crate::attr::{AttrValue, AttrValueBytes};
+pub use crate::attr::AttrValue;
 pub use crate::blame::{Blame, BlameHunk, BlameIter, BlameOptions};
 pub use crate::blob::{Blob, BlobWriter};
 pub use crate::branch::{Branch, Branches};

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -955,8 +955,8 @@ impl Repository {
     ///
     /// This function will return a special string if the attribute is set to a special value.
     /// Interpreting the special string is discouraged. You should always use
-    /// [`AttrValue::new`](crate::AttrValue::new) to interpret the return value and avoid the
-    /// special string.
+    /// [`AttrValue::from_string`](crate::AttrValue::from_string) to interpret the return value
+    /// and avoid the special string.
     ///
     /// As such, the return type of this function will probably be changed in the next major version
     /// to prevent interpreting the returned string without checking whether it's special.
@@ -975,8 +975,8 @@ impl Repository {
     ///
     /// This function will return a special byte slice if the attribute is set to a special value.
     /// Interpreting the special byte slice is discouraged. You should always use
-    /// [`AttrValueBytes::new`](crate::AttrValueBytes::new) to interpret the return value and avoid
-    /// the special string.
+    /// [`AttrValue::from_bytes`](crate::AttrValue::from_bytes) to interpret the return value and
+    /// avoid the special string.
     ///
     /// As such, the return type of this function will probably be changed in the next major version
     /// to prevent interpreting the returned byte slice without checking whether it's special.

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -954,9 +954,9 @@ impl Repository {
     /// Get the value of a git attribute for a path as a string.
     ///
     /// This function will return a special string if the attribute is set to a special value.
-    /// Interpreting the special string is discouraged. You should always use the
-    /// [`attr_value`](crate::attr_value) function to determine whether the returned string is
-    /// special and use the [`AttrValue`](crate::AttrValue) enum to access the value.
+    /// Interpreting the special string is discouraged. You should always use
+    /// [`AttrValue::new`](crate::AttrValue::new) to interpret the return value and avoid the
+    /// special string.
     ///
     /// As such, the return type of this function will probably be changed in the next major version
     /// to prevent interpreting the returned string without checking whether it's special.
@@ -974,10 +974,9 @@ impl Repository {
     /// Get the value of a git attribute for a path as a byte slice.
     ///
     /// This function will return a special byte slice if the attribute is set to a special value.
-    /// Interpreting the special byte slice is discouraged. You should always use the
-    /// [`attr_value_bytes`](crate::attr_value_bytes) function to determine whether the returned
-    /// byte slice is special and use the [`AttrValueBytes`](crate::AttrValueBytes) enum to access
-    /// the value.
+    /// Interpreting the special byte slice is discouraged. You should always use
+    /// [`AttrValueBytes::new`](crate::AttrValueBytes::new) to interpret the return value and avoid
+    /// the special string.
     ///
     /// As such, the return type of this function will probably be changed in the next major version
     /// to prevent interpreting the returned byte slice without checking whether it's special.

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -952,6 +952,14 @@ impl Repository {
     }
 
     /// Get the value of a git attribute for a path as a string.
+    ///
+    /// This function will return a special string if the attribute is set to a special value.
+    /// Interpreting the special string is discouraged. You should always use the
+    /// [`attr_value`](crate::attr_value) function to determine whether the returned string is
+    /// special and use the [`AttrValue`](crate::AttrValue) enum to access the value.
+    ///
+    /// As such, the return type of this function will probably be changed in the next major version
+    /// to prevent interpreting the returned string without checking whether it's special.
     pub fn get_attr(
         &self,
         path: &Path,
@@ -964,6 +972,15 @@ impl Repository {
     }
 
     /// Get the value of a git attribute for a path as a byte slice.
+    ///
+    /// This function will return a special byte slice if the attribute is set to a special value.
+    /// Interpreting the special byte slice is discouraged. You should always use the
+    /// [`attr_value_bytes`](crate::attr_value_bytes) function to determine whether the returned
+    /// byte slice is special and use the [`AttrValueBytes`](crate::AttrValueBytes) enum to access
+    /// the value.
+    ///
+    /// As such, the return type of this function will probably be changed in the next major version
+    /// to prevent interpreting the returned byte slice without checking whether it's special.
     pub fn get_attr_bytes(
         &self,
         path: &Path,


### PR DESCRIPTION
#### New public APIs
```rust
#[derive(Debug, Clone, Copy, PartialEq, Eq)]
pub enum AttrValue<'string> {
    True,
    False,
    String(&'string str),
    Bytes(&'string [u8]),
    Unspecified,
}

impl<'string> AttrValue<'string> {
    pub fn from_string(_: Option<&'string str>) -> Self;
    pub fn from_bytes(_: Option<&'string [u8]>) -> Self;
}
```

#### Summary
- Adds some new public APIs as described above.
- States that the return types of `Repository::get_attr` and `Repository::get_attr_bytes` will probably be changed in the next major version in their documentations.

Wrapping the return value of `Repository::get_attr(_bytes)` in a new type is probably better, but that's a breaking change, so it's probably not desirable unless it's ready to bump to 0.14.

Resolves #670.