### PR TITLE
add accessor for internal remote wrapped in RemoteConnection

### DIFF
--- a/src/remote.rs
+++ b/src/remote.rs
@@ -634,6 +634,11 @@ impl<'repo, 'connection, 'cb> RemoteConnection<'repo, 'connection, 'cb> {
     pub fn default_branch(&self) -> Result<Buf, Error> {
         self.remote.default_branch()
     }
+
+    /// access remote bound to this connection
+    pub fn remote(&mut self) -> &mut Remote<'repo> {
+        self.remote
+    }
 }
 
 impl<'repo, 'connection, 'cb> Drop for RemoteConnection<'repo, 'connection, 'cb> {


### PR DESCRIPTION
the way `RemoteConnection` works right now it only exposes `list` and `default_branch` - with this new accessor we can use it more flexibly as long as we keep the Connection alive