### PR TITLE
Parse credential.helper command line using shell-words

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ url = "2.0"
 bitflags = "1.1.0"
 libc = "0.2"
 log = "0.4.8"
+shell-words = "1.0"
 libgit2-sys = { path = "libgit2-sys", version = "0.12.18" }
 
 [target."cfg(all(unix, not(target_os = \"macos\")))".dependencies]


### PR DESCRIPTION
Since `sh` is not available by default on Windows, git2-rs currently splits the credential
helper string by whitespace, which attempts to execute an invalid command line in the case
of the default credential helper on Windows.

The default git credential helper on Windows (Git Credential Manager Core) is set up as
 `C:/Program\ Files\ \(x86\)/Git\ Credential\ Manager\ Core/git-credential-manager-core.exe`

This change resolves the issue by parsing the command line using `shell_words`,
which follows the unix-style parsing rules used by sh. `shell-words` is a small crate that
does not have any additional dependencies.