### PR TITLE
Add optional CI workflow for clippy and cross-compilation tests

### DIFF
--- a/examples/diff.rs
+++ b/examples/diff.rs
@@ -17,6 +17,7 @@
 use git2::{Blob, Diff, DiffOptions, Error, Object, ObjectType, Oid, Repository};
 use git2::{DiffDelta, DiffFindOptions, DiffFormat, DiffHunk, DiffLine};
 use std::str;
+use std::str::FromStr;
 use structopt::StructOpt;
 
 #[derive(StructOpt)]

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -88,6 +88,7 @@ extern "C" fn hunk_cb_c(hunk: *const raw::git_diff_hunk, data: *mut c_void) -> c
 
 impl<'cb> ApplyOptions<'cb> {
     /// Creates a new set of empty options (zeroed).
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         let mut opts = Self {
             raw: unsafe { mem::zeroed() },

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -144,6 +144,10 @@ impl<'cb> ApplyOptions<'cb> {
     }
 
     /// Pointer to a raw git_stash_apply_options
+    ///
+    /// # Safety
+    /// This function is unsafe as it is not guaranteed that `raw` is a valid
+    /// pointer.
     pub unsafe fn raw(&mut self) -> *const raw::git_apply_options {
         &self.raw as *const _
     }

--- a/src/blame.rs
+++ b/src/blame.rs
@@ -247,7 +247,7 @@ impl<'repo> Binding for Blame<'repo> {
 
     unsafe fn from_raw(raw: *mut raw::git_blame) -> Blame<'repo> {
         Blame {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }
@@ -268,7 +268,7 @@ impl<'blame> Binding for BlameHunk<'blame> {
 
     unsafe fn from_raw(raw: *mut raw::git_blame_hunk) -> BlameHunk<'blame> {
         BlameHunk {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -56,7 +56,7 @@ impl<'repo> Binding for Blob<'repo> {
 
     unsafe fn from_raw(raw: *mut raw::git_blob) -> Blob<'repo> {
         Blob {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }
@@ -110,7 +110,7 @@ impl<'repo> Binding for BlobWriter<'repo> {
 
     unsafe fn from_raw(raw: *mut raw::git_writestream) -> BlobWriter<'repo> {
         BlobWriter {
-            raw: raw,
+            raw,
             need_cleanup: true,
             _marker: marker::PhantomData,
         }

--- a/src/branch.rs
+++ b/src/branch.rs
@@ -116,6 +116,7 @@ impl<'repo> Branch<'repo> {
 impl<'repo> Branches<'repo> {
     /// Creates a new iterator from the raw pointer given.
     ///
+    /// # Safety
     /// This function is unsafe as it is not guaranteed that `raw` is a valid
     /// pointer.
     pub unsafe fn from_raw(raw: *mut raw::git_branch_iterator) -> Branches<'repo> {

--- a/src/branch.rs
+++ b/src/branch.rs
@@ -120,7 +120,7 @@ impl<'repo> Branches<'repo> {
     /// pointer.
     pub unsafe fn from_raw(raw: *mut raw::git_branch_iterator) -> Branches<'repo> {
         Branches {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/build.rs
+++ b/src/build.rs
@@ -572,6 +572,7 @@ impl<'cb> CheckoutBuilder<'cb> {
 
     /// Configure a raw checkout options based on this configuration.
     ///
+    /// # Safety
     /// This method is unsafe as there is no guarantee that this structure will
     /// outlive the provided checkout options.
     pub unsafe fn configure(&mut self, opts: &mut raw::git_checkout_options) {

--- a/src/build.rs
+++ b/src/build.rs
@@ -116,6 +116,7 @@ impl<'cb> Default for RepoBuilder<'cb> {
 }
 
 /// Options that can be passed to `RepoBuilder::clone_local`.
+#[allow(clippy::manual_non_exhaustive)]
 #[derive(Clone, Copy)]
 pub enum CloneLocal {
     /// Auto-detect (default)

--- a/src/call.rs
+++ b/src/call.rs
@@ -1,5 +1,4 @@
 #![macro_use]
-use libc;
 
 use crate::Error;
 
@@ -53,8 +52,6 @@ pub fn last_error(code: libc::c_int) -> Error {
 mod impls {
     use std::ffi::CString;
     use std::ptr;
-
-    use libc;
 
     use crate::call::Convert;
     use crate::{raw, BranchType, ConfigLevel, Direction, ObjectType, ResetType};

--- a/src/cert.rs
+++ b/src/cert.rs
@@ -100,7 +100,7 @@ impl<'a> Binding for Cert<'a> {
     type Raw = *mut raw::git_cert;
     unsafe fn from_raw(raw: *mut raw::git_cert) -> Cert<'a> {
         Cert {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/cherrypick.rs
+++ b/src/cherrypick.rs
@@ -14,6 +14,7 @@ pub struct CherrypickOptions<'cb> {
 
 impl<'cb> CherrypickOptions<'cb> {
     /// Creates a default set of cherrypick options
+    #[allow(clippy::new_without_default)]
     pub fn new() -> CherrypickOptions<'cb> {
         CherrypickOptions {
             mainline: 0,

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -392,6 +392,8 @@ impl<'repo> Drop for Commit<'repo> {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     #[test]
     fn smoke() {
         let (_td, repo) = crate::test::repo_init();

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -1,4 +1,3 @@
-use libc;
 use std::marker;
 use std::mem;
 use std::ops::Range;
@@ -313,7 +312,7 @@ impl<'repo> Binding for Commit<'repo> {
     type Raw = *mut raw::git_commit;
     unsafe fn from_raw(raw: *mut raw::git_commit) -> Commit<'repo> {
         Commit {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,3 @@
-use libc;
 use std::ffi::CString;
 use std::marker;
 use std::path::{Path, PathBuf};
@@ -465,7 +464,7 @@ impl Config {
 impl Binding for Config {
     type Raw = *mut raw::git_config;
     unsafe fn from_raw(raw: *mut raw::git_config) -> Config {
-        Config { raw: raw }
+        Config { raw }
     }
     fn raw(&self) -> *mut raw::git_config {
         self.raw
@@ -534,7 +533,7 @@ impl<'cfg> Binding for ConfigEntry<'cfg> {
 
     unsafe fn from_raw(raw: *mut raw::git_config_entry) -> ConfigEntry<'cfg> {
         ConfigEntry {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
             owned: true,
         }
@@ -549,7 +548,7 @@ impl<'cfg> Binding for ConfigEntries<'cfg> {
 
     unsafe fn from_raw(raw: *mut raw::git_config_iterator) -> ConfigEntries<'cfg> {
         ConfigEntries {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }
@@ -571,7 +570,7 @@ impl<'cfg, 'b> Iterator for &'b ConfigEntries<'cfg> {
             try_call_iter!(raw::git_config_next(&mut raw, self.raw));
             Some(Ok(ConfigEntry {
                 owned: false,
-                raw: raw,
+                raw,
                 _marker: marker::PhantomData,
             }))
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -165,6 +165,7 @@ impl Config {
     /// level. A higher level means a higher priority. The first occurrence of
     /// the variable will be returned here.
     pub fn get_bool(&self, name: &str) -> Result<bool, Error> {
+        #[allow(clippy::unnecessary_cast)]
         let mut out = 0 as libc::c_int;
         let name = CString::new(name)?;
         unsafe {

--- a/src/cred.rs
+++ b/src/cred.rs
@@ -161,7 +161,7 @@ impl Cred {
     }
 
     /// Unwrap access to the underlying raw pointer, canceling the destructor
-    pub unsafe fn unwrap(mut self) -> *mut raw::git_cred {
+    pub fn unwrap(mut self) -> *mut raw::git_cred {
         mem::replace(&mut self.raw, ptr::null_mut())
     }
 }

--- a/src/cred.rs
+++ b/src/cred.rs
@@ -171,7 +171,7 @@ impl Binding for Cred {
     type Raw = *mut raw::git_cred;
 
     unsafe fn from_raw(raw: *mut raw::git_cred) -> Cred {
-        Cred { raw: raw }
+        Cred { raw }
     }
     fn raw(&self) -> *mut raw::git_cred {
         self.raw

--- a/src/describe.rs
+++ b/src/describe.rs
@@ -44,7 +44,7 @@ impl<'repo> Binding for Describe<'repo> {
 
     unsafe fn from_raw(raw: *mut raw::git_describe_result) -> Describe<'repo> {
         Describe {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -446,7 +446,7 @@ impl<'repo> Binding for Diff<'repo> {
     type Raw = *mut raw::git_diff;
     unsafe fn from_raw(raw: *mut raw::git_diff) -> Diff<'repo> {
         Diff {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }
@@ -544,7 +544,7 @@ impl<'a> Binding for DiffDelta<'a> {
     type Raw = *mut raw::git_diff_delta;
     unsafe fn from_raw(raw: *mut raw::git_diff_delta) -> DiffDelta<'a> {
         DiffDelta {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }
@@ -629,7 +629,7 @@ impl<'a> Binding for DiffFile<'a> {
     type Raw = *const raw::git_diff_file;
     unsafe fn from_raw(raw: *const raw::git_diff_file) -> DiffFile<'a> {
         DiffFile {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }
@@ -1080,7 +1080,7 @@ impl<'a> Binding for DiffLine<'a> {
     type Raw = *const raw::git_diff_line;
     unsafe fn from_raw(raw: *const raw::git_diff_line) -> DiffLine<'a> {
         DiffLine {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }
@@ -1142,7 +1142,7 @@ impl<'a> Binding for DiffHunk<'a> {
     type Raw = *const raw::git_diff_hunk;
     unsafe fn from_raw(raw: *const raw::git_diff_hunk) -> DiffHunk<'a> {
         DiffHunk {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }
@@ -1198,7 +1198,7 @@ impl Binding for DiffStats {
     type Raw = *mut raw::git_diff_stats;
 
     unsafe fn from_raw(raw: *mut raw::git_diff_stats) -> DiffStats {
-        DiffStats { raw: raw }
+        DiffStats { raw }
     }
     fn raw(&self) -> *mut raw::git_diff_stats {
         self.raw
@@ -1247,7 +1247,7 @@ impl<'a> Binding for DiffBinary<'a> {
     type Raw = *const raw::git_diff_binary;
     unsafe fn from_raw(raw: *const raw::git_diff_binary) -> DiffBinary<'a> {
         DiffBinary {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }
@@ -1279,7 +1279,7 @@ impl<'a> Binding for DiffBinaryFile<'a> {
     type Raw = *const raw::git_diff_binary_file;
     unsafe fn from_raw(raw: *const raw::git_diff_binary_file) -> DiffBinaryFile<'a> {
         DiffBinaryFile {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -914,6 +914,7 @@ impl DiffOptions {
 
     /// Acquire a pointer to the underlying raw options.
     ///
+    /// # Safety
     /// This function is unsafe as the pointer is only valid so long as this
     /// structure is not moved, modified, or used elsewhere.
     pub unsafe fn raw(&mut self) -> *const raw::git_diff_options {

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1517,6 +1517,7 @@ impl DiffFormatEmailOptions {
 impl DiffPatchidOptions {
     /// Creates a new set of patchid options,
     /// initialized to the default values
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         let mut opts = DiffPatchidOptions {
             raw: unsafe { mem::zeroed() },

--- a/src/error.rs
+++ b/src/error.rs
@@ -72,7 +72,7 @@ impl Error {
         let msg = CStr::from_ptr((*ptr).message as *const _).to_bytes();
         let msg = String::from_utf8_lossy(msg).into_owned();
         Error {
-            code: code,
+            code,
             klass: (*ptr).klass,
             message: msg,
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -82,6 +82,7 @@ impl Error {
     ///
     /// The error returned will have the code `GIT_ERROR` and the class
     /// `GIT_ERROR_NONE`.
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Error {
         Error {
             code: raw::GIT_ERROR as c_int,

--- a/src/index.rs
+++ b/src/index.rs
@@ -166,7 +166,7 @@ impl Index {
                 gid: entry.gid,
                 file_size: entry.file_size,
                 id: *entry.id.raw(),
-                flags: flags,
+                flags,
                 flags_extended: entry.flags_extended,
                 path: path.as_ptr(),
                 mtime: raw::git_index_time {
@@ -223,7 +223,7 @@ impl Index {
                 gid: entry.gid,
                 file_size: entry.file_size,
                 id: *entry.id.raw(),
-                flags: flags,
+                flags,
                 flags_extended: entry.flags_extended,
                 path: path.as_ptr(),
                 mtime: raw::git_index_time {
@@ -600,7 +600,7 @@ impl Index {
 impl Binding for Index {
     type Raw = *mut raw::git_index;
     unsafe fn from_raw(raw: *mut raw::git_index) -> Index {
-        Index { raw: raw }
+        Index { raw }
     }
     fn raw(&self) -> *mut raw::git_index {
         self.raw
@@ -718,15 +718,15 @@ impl Binding for IndexEntry {
         let path = slice::from_raw_parts(path as *const u8, pathlen);
 
         IndexEntry {
-            dev: dev,
-            ino: ino,
-            mode: mode,
-            uid: uid,
-            gid: gid,
-            file_size: file_size,
+            dev,
+            ino,
+            mode,
+            uid,
+            gid,
+            file_size,
             id: Binding::from_raw(&id as *const _),
-            flags: flags,
-            flags_extended: flags_extended,
+            flags,
+            flags_extended,
             path: path.to_vec(),
             mtime: Binding::from_raw(mtime),
             ctime: Binding::from_raw(ctime),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -882,6 +882,7 @@ impl ObjectType {
     }
 
     /// Convert a string object type representation to its object type.
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Option<ObjectType> {
         let raw = unsafe { call!(raw::git_object_string2type(CString::new(s).unwrap())) };
         ObjectType::from_raw(raw)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -834,7 +834,7 @@ fn openssl_env_init() {
 ))]
 fn openssl_env_init() {}
 
-unsafe fn opt_bytes<'a, T>(_anchor: &'a T, c: *const libc::c_char) -> Option<&'a [u8]> {
+unsafe fn opt_bytes<T>(_anchor: &T, c: *const libc::c_char) -> Option<&[u8]> {
     if c.is_null() {
         None
     } else {

--- a/src/mempack.rs
+++ b/src/mempack.rs
@@ -16,7 +16,7 @@ impl<'odb> Binding for Mempack<'odb> {
 
     unsafe fn from_raw(raw: *mut raw::git_odb_backend) -> Mempack<'odb> {
         Mempack {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -178,7 +178,7 @@ impl<'repo> Binding for AnnotatedCommit<'repo> {
     type Raw = *mut raw::git_annotated_commit;
     unsafe fn from_raw(raw: *mut raw::git_annotated_commit) -> AnnotatedCommit<'repo> {
         AnnotatedCommit {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -169,7 +169,7 @@ impl MergeOptions {
     }
 
     /// Acquire a pointer to the underlying raw options.
-    pub unsafe fn raw(&self) -> *const raw::git_merge_options {
+    pub fn raw(&self) -> *const raw::git_merge_options {
         &self.raw as *const _
     }
 }

--- a/src/note.rs
+++ b/src/note.rs
@@ -53,7 +53,7 @@ impl<'repo> Binding for Note<'repo> {
     type Raw = *mut raw::git_note;
     unsafe fn from_raw(raw: *mut raw::git_note) -> Note<'repo> {
         Note {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }
@@ -80,7 +80,7 @@ impl<'repo> Binding for Notes<'repo> {
     type Raw = *mut raw::git_note_iterator;
     unsafe fn from_raw(raw: *mut raw::git_note_iterator) -> Notes<'repo> {
         Notes {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/object.rs
+++ b/src/object.rs
@@ -232,7 +232,7 @@ impl<'repo> Binding for Object<'repo> {
 
     unsafe fn from_raw(raw: *mut raw::git_object) -> Object<'repo> {
         Object {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/odb.rs
+++ b/src/odb.rs
@@ -23,7 +23,7 @@ impl<'repo> Binding for Odb<'repo> {
 
     unsafe fn from_raw(raw: *mut raw::git_odb) -> Odb<'repo> {
         Odb {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }
@@ -273,7 +273,7 @@ impl<'a> Binding for OdbObject<'a> {
 
     unsafe fn from_raw(raw: *mut raw::git_odb_object) -> OdbObject<'a> {
         OdbObject {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }
@@ -327,7 +327,7 @@ impl<'repo> Binding for OdbReader<'repo> {
 
     unsafe fn from_raw(raw: *mut raw::git_odb_stream) -> OdbReader<'repo> {
         OdbReader {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }
@@ -386,7 +386,7 @@ impl<'repo> Binding for OdbWriter<'repo> {
 
     unsafe fn from_raw(raw: *mut raw::git_odb_stream) -> OdbWriter<'repo> {
         OdbWriter {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -52,7 +52,7 @@ impl Oid {
             unsafe {
                 try_call!(raw::git_oid_fromraw(&mut raw, bytes.as_ptr()));
             }
-            Ok(Oid { raw: raw })
+            Ok(Oid { raw })
         }
     }
 

--- a/src/oid_array.rs
+++ b/src/oid_array.rs
@@ -32,7 +32,7 @@ impl Deref for OidArray {
 impl Binding for OidArray {
     type Raw = raw::git_oidarray;
     unsafe fn from_raw(raw: raw::git_oidarray) -> OidArray {
-        OidArray { raw: raw }
+        OidArray { raw }
     }
     fn raw(&self) -> raw::git_oidarray {
         self.raw

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -15,6 +15,7 @@ use crate::{raw, Buf, ConfigLevel, Error, IntoCString};
 /// Use magic path `$PATH` to include the old value of the path
 /// (if you want to prepend or append, for instance).
 ///
+/// # Safety
 /// This function is unsafe as it mutates the global state but cannot guarantee
 /// thread-safety. It needs to be externally synchronized with calls to access
 /// the global state.
@@ -37,6 +38,7 @@ where
 /// `level` must be one of [`ConfigLevel::System`], [`ConfigLevel::Global`],
 /// [`ConfigLevel::XDG`], [`ConfigLevel::ProgramData`].
 ///
+/// # Safety
 /// This function is unsafe as it mutates the global state but cannot guarantee
 /// thread-safety. It needs to be externally synchronized with calls to access
 /// the global state.
@@ -55,6 +57,7 @@ pub unsafe fn reset_search_path(level: ConfigLevel) -> Result<(), Error> {
 /// `level` must be one of [`ConfigLevel::System`], [`ConfigLevel::Global`],
 /// [`ConfigLevel::XDG`], [`ConfigLevel::ProgramData`].
 ///
+/// # Safety
 /// This function is unsafe as it mutates the global state but cannot guarantee
 /// thread-safety. It needs to be externally synchronized with calls to access
 /// the global state.

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -213,7 +213,7 @@ impl<'buffers> Patch<'buffers> {
     }
 
     /// Get the Patch text as a Buf.
-    pub fn to_buf(&mut self) -> Result<Buf, Error> {
+    pub fn to_buf(&self) -> Result<Buf, Error> {
         let buf = Buf::new();
         unsafe {
             try_call!(raw::git_patch_to_buf(buf.raw(), self.raw));

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -21,7 +21,7 @@ impl<'buffers> Binding for Patch<'buffers> {
     type Raw = *mut raw::git_patch;
     unsafe fn from_raw(raw: Self::Raw) -> Self {
         Patch {
-            raw: raw,
+            raw,
             buffers: PhantomData,
         }
     }

--- a/src/pathspec.rs
+++ b/src/pathspec.rs
@@ -168,7 +168,7 @@ impl Binding for Pathspec {
     type Raw = *mut raw::git_pathspec;
 
     unsafe fn from_raw(raw: *mut raw::git_pathspec) -> Pathspec {
-        Pathspec { raw: raw }
+        Pathspec { raw }
     }
     fn raw(&self) -> *mut raw::git_pathspec {
         self.raw
@@ -268,7 +268,7 @@ impl<'ps> Binding for PathspecMatchList<'ps> {
 
     unsafe fn from_raw(raw: *mut raw::git_pathspec_match_list) -> PathspecMatchList<'ps> {
         PathspecMatchList {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/rebase.rs
+++ b/src/rebase.rs
@@ -112,6 +112,11 @@ impl<'repo> Rebase<'repo> {
         unsafe { raw::git_rebase_operation_entrycount(self.raw) }
     }
 
+    /// Return `true` if there is no operation
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Gets the original `HEAD` ref name for merge rebases.
     pub fn orig_head_name(&self) -> Option<&str> {
         let name_bytes =

--- a/src/rebase.rs
+++ b/src/rebase.rs
@@ -230,7 +230,7 @@ impl<'repo> Binding for Rebase<'repo> {
     type Raw = *mut raw::git_rebase;
     unsafe fn from_raw(raw: *mut raw::git_rebase) -> Rebase<'repo> {
         Rebase {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }
@@ -324,7 +324,7 @@ impl<'rebase> Binding for RebaseOperation<'rebase> {
     type Raw = *const raw::git_rebase_operation;
     unsafe fn from_raw(raw: *const raw::git_rebase_operation) -> RebaseOperation<'rebase> {
         RebaseOperation {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -387,7 +387,7 @@ impl<'repo> Binding for Reference<'repo> {
     type Raw = *mut raw::git_reference;
     unsafe fn from_raw(raw: *mut raw::git_reference) -> Reference<'repo> {
         Reference {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }
@@ -419,7 +419,7 @@ impl<'repo> Binding for References<'repo> {
     type Raw = *mut raw::git_reference_iterator;
     unsafe fn from_raw(raw: *mut raw::git_reference_iterator) -> References<'repo> {
         References {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/reflog.rs
+++ b/src/reflog.rs
@@ -103,7 +103,7 @@ impl Binding for Reflog {
     type Raw = *mut raw::git_reflog;
 
     unsafe fn from_raw(raw: *mut raw::git_reflog) -> Reflog {
-        Reflog { raw: raw }
+        Reflog { raw }
     }
     fn raw(&self) -> *mut raw::git_reflog {
         self.raw
@@ -151,7 +151,7 @@ impl<'reflog> Binding for ReflogEntry<'reflog> {
 
     unsafe fn from_raw(raw: *const raw::git_reflog_entry) -> ReflogEntry<'reflog> {
         ReflogEntry {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/refspec.rs
+++ b/src/refspec.rs
@@ -112,7 +112,7 @@ impl<'remote> Binding for Refspec<'remote> {
 
     unsafe fn from_raw(raw: *const raw::git_refspec) -> Refspec<'remote> {
         Refspec {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -1,4 +1,3 @@
-use libc;
 use std::ffi::CString;
 use std::marker;
 use std::mem;
@@ -401,7 +400,7 @@ impl<'repo> Binding for Remote<'repo> {
 
     unsafe fn from_raw(raw: *mut raw::git_remote) -> Remote<'repo> {
         Remote {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -348,6 +348,7 @@ impl<'repo> Remote<'repo> {
                 mem::size_of::<*const raw::git_remote_head>()
             );
             let slice = slice::from_raw_parts(base as *const _, size as usize);
+            #[allow(clippy::transmute_ptr_to_ptr)]
             Ok(mem::transmute::<
                 &[*const raw::git_remote_head],
                 &[RemoteHead<'_>],

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -61,7 +61,7 @@ pub struct RemoteConnection<'repo, 'connection, 'cb> {
 pub fn remote_into_raw(remote: Remote<'_>) -> *mut raw::git_remote {
     let ret = remote.raw;
     mem::forget(remote);
-    return ret;
+    ret
 }
 
 impl<'repo> Remote<'repo> {

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -878,6 +878,7 @@ impl Repository {
     /// One way to think of this is if you were to do "git add ." on the
     /// directory containing the file, would it be added or not?
     pub fn status_should_ignore(&self, path: &Path) -> Result<bool, Error> {
+        #[allow(clippy::unnecessary_cast)]
         let mut ret = 0 as c_int;
         let path = util::cstring_to_repo_path(path)?;
         unsafe {
@@ -903,6 +904,7 @@ impl Repository {
     /// detection, there is no choice but to do a full `statuses` and scan
     /// through looking for the path that you are interested in.
     pub fn status_file(&self, path: &Path) -> Result<Status, Error> {
+        #[allow(clippy::unnecessary_cast)]
         let mut ret = 0 as c_uint;
         let path = path_to_repo_path(path)?;
         unsafe {
@@ -2413,6 +2415,7 @@ impl Repository {
     /// like binary data, the `DiffFile` binary attribute will be set to 1 and no call to
     /// the `hunk_cb` nor `line_cb` will be made (unless you set the `force_text`
     /// option).
+    #[allow(clippy::too_many_arguments)]
     pub fn diff_blobs(
         &self,
         old_blob: Option<&Blob<'_>>,
@@ -2995,6 +2998,7 @@ impl RepositoryInitOptions {
     ///
     /// By default this will set flags for creating all necessary directories
     /// and initializing a directory from the user-configured templates path.
+    #[allow(clippy::new_without_default)]
     pub fn new() -> RepositoryInitOptions {
         RepositoryInitOptions {
             flags: raw::GIT_REPOSITORY_INIT_MKDIR as u32

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -2785,7 +2785,7 @@ impl Repository {
         let raw_opts = options.map(|o| o.raw());
         let ptr_raw_opts = match raw_opts.as_ref() {
             Some(v) => v,
-            None => 0 as *const _,
+            None => std::ptr::null(),
         };
         unsafe {
             try_call!(raw::git_cherrypick(self.raw(), commit.raw(), ptr_raw_opts));
@@ -2880,7 +2880,7 @@ impl Repository {
         let raw_opts = options.map(|o| o.raw());
         let ptr_raw_opts = match raw_opts.as_ref() {
             Some(v) => v,
-            None => 0 as *const _,
+            None => std::ptr::null(),
         };
         unsafe {
             try_call!(raw::git_revert(self.raw(), commit.raw(), ptr_raw_opts));
@@ -2959,7 +2959,7 @@ impl Repository {
     }
 
     /// Create a new transaction
-    pub fn transaction<'a>(&'a self) -> Result<Transaction<'a>, Error> {
+    pub fn transaction(&self) -> Result<Transaction<'_>, Error> {
         let mut raw = ptr::null_mut();
         unsafe {
             try_call!(raw::git_transaction_new(&mut raw, self.raw));
@@ -3132,6 +3132,7 @@ impl RepositoryInitOptions {
     /// Creates a set of raw init options to be used with
     /// `git_repository_init_ext`.
     ///
+    /// # Safety
     /// This method is unsafe as the returned value may have pointers to the
     /// interior of this structure.
     pub unsafe fn raw(&self) -> raw::git_repository_init_options {

--- a/src/revert.rs
+++ b/src/revert.rs
@@ -14,6 +14,7 @@ pub struct RevertOptions<'cb> {
 
 impl<'cb> RevertOptions<'cb> {
     /// Creates a default set of revert options
+    #[allow(clippy::new_without_default)]
     pub fn new() -> RevertOptions<'cb> {
         RevertOptions {
             mainline: 0,

--- a/src/revspec.rs
+++ b/src/revspec.rs
@@ -14,11 +14,7 @@ impl<'repo> Revspec<'repo> {
         to: Option<Object<'repo>>,
         mode: RevparseMode,
     ) -> Revspec<'repo> {
-        Revspec {
-            from: from,
-            to: to,
-            mode: mode,
-        }
+        Revspec { from, to, mode }
     }
 
     /// Access the `from` range of this revspec.

--- a/src/revwalk.rs
+++ b/src/revwalk.rs
@@ -28,9 +28,10 @@ where
     panic::wrap(|| unsafe {
         let hide_cb = payload as *mut C;
         if (*hide_cb)(Oid::from_raw(commit_id)) {
-            return 1;
+            1
+        } else {
+            0
         }
-        return 0;
     })
     .unwrap_or(-1)
 }

--- a/src/revwalk.rs
+++ b/src/revwalk.rs
@@ -219,7 +219,7 @@ impl<'repo> Binding for Revwalk<'repo> {
     type Raw = *mut raw::git_revwalk;
     unsafe fn from_raw(raw: *mut raw::git_revwalk) -> Revwalk<'repo> {
         Revwalk {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -1,4 +1,3 @@
-use libc;
 use std::ffi::CString;
 use std::fmt;
 use std::marker;
@@ -120,7 +119,7 @@ impl<'a> Binding for Signature<'a> {
 ///
 /// This function is unsafe as there is no guarantee that `raw` is valid for
 /// `'a` nor if it's a valid pointer.
-pub unsafe fn from_raw_const<'b, T>(_lt: &'b T, raw: *const raw::git_signature) -> Signature<'b> {
+pub unsafe fn from_raw_const<T>(_lt: &T, raw: *const raw::git_signature) -> Signature<'_> {
     Signature {
         raw: raw as *mut raw::git_signature,
         _marker: marker::PhantomData,

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -105,7 +105,7 @@ impl<'a> Binding for Signature<'a> {
     type Raw = *mut raw::git_signature;
     unsafe fn from_raw(raw: *mut raw::git_signature) -> Signature<'a> {
         Signature {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
             owned: true,
         }

--- a/src/status.rs
+++ b/src/status.rs
@@ -218,6 +218,7 @@ impl StatusOptions {
 
     /// Get a pointer to the inner list of status options.
     ///
+    /// # Safety
     /// This function is unsafe as the returned structure has interior pointers
     /// and may no longer be valid if these options continue to be mutated.
     pub unsafe fn raw(&mut self) -> *const raw::git_status_options {

--- a/src/status.rs
+++ b/src/status.rs
@@ -72,7 +72,7 @@ impl StatusOptions {
             let r = raw::git_status_init_options(&mut raw, raw::GIT_STATUS_OPTIONS_VERSION);
             assert_eq!(r, 0);
             StatusOptions {
-                raw: raw,
+                raw,
                 pathspec: Vec::new(),
                 ptrs: Vec::new(),
             }
@@ -264,7 +264,7 @@ impl<'repo> Binding for Statuses<'repo> {
     type Raw = *mut raw::git_status_list;
     unsafe fn from_raw(raw: *mut raw::git_status_list) -> Statuses<'repo> {
         Statuses {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }
@@ -340,7 +340,7 @@ impl<'statuses> Binding for StatusEntry<'statuses> {
 
     unsafe fn from_raw(raw: *const raw::git_status_entry) -> StatusEntry<'statuses> {
         StatusEntry {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/string_array.rs
+++ b/src/string_array.rs
@@ -79,7 +79,7 @@ impl StringArray {
 impl Binding for StringArray {
     type Raw = raw::git_strarray;
     unsafe fn from_raw(raw: raw::git_strarray) -> StringArray {
-        StringArray { raw: raw }
+        StringArray { raw }
     }
     fn raw(&self) -> raw::git_strarray {
         self.raw

--- a/src/submodule.rs
+++ b/src/submodule.rs
@@ -233,7 +233,7 @@ impl<'repo> Binding for Submodule<'repo> {
     type Raw = *mut raw::git_submodule;
     unsafe fn from_raw(raw: *mut raw::git_submodule) -> Submodule<'repo> {
         Submodule {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/submodule.rs
+++ b/src/submodule.rs
@@ -271,13 +271,12 @@ impl<'cb> SubmoduleUpdateOptions<'cb> {
             raw::git_checkout_init_options(&mut checkout_opts, raw::GIT_CHECKOUT_OPTIONS_VERSION);
         assert_eq!(0, init_res);
         self.checkout_builder.configure(&mut checkout_opts);
-        let opts = raw::git_submodule_update_options {
+        raw::git_submodule_update_options {
             version: raw::GIT_SUBMODULE_UPDATE_OPTIONS_VERSION,
             checkout_opts,
             fetch_opts: self.fetch_opts.raw(),
             allow_fetch: self.allow_fetch as c_int,
-        };
-        opts
+        }
     }
 
     /// Set checkout options.

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -118,7 +118,7 @@ impl<'repo> Binding for Tag<'repo> {
     type Raw = *mut raw::git_tag;
     unsafe fn from_raw(raw: *mut raw::git_tag) -> Tag<'repo> {
         Tag {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/time.rs
+++ b/src/time.rs
@@ -61,7 +61,7 @@ impl Ord for Time {
 impl Binding for Time {
     type Raw = raw::git_time;
     unsafe fn from_raw(raw: raw::git_time) -> Time {
-        Time { raw: raw }
+        Time { raw }
     }
     fn raw(&self) -> raw::git_time {
         self.raw
@@ -73,8 +73,8 @@ impl IndexTime {
     pub fn new(seconds: i32, nanoseconds: u32) -> IndexTime {
         unsafe {
             Binding::from_raw(raw::git_index_time {
-                seconds: seconds,
-                nanoseconds: nanoseconds,
+                seconds,
+                nanoseconds,
             })
         }
     }
@@ -92,7 +92,7 @@ impl IndexTime {
 impl Binding for IndexTime {
     type Raw = raw::git_index_time;
     unsafe fn from_raw(raw: raw::git_index_time) -> IndexTime {
-        IndexTime { raw: raw }
+        IndexTime { raw }
     }
     fn raw(&self) -> raw::git_index_time {
         self.raw

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -271,7 +271,7 @@ extern "C" fn subtransport_action(
                     write: Some(stream_write),
                     free: Some(stream_free),
                 },
-                obj: obj,
+                obj,
             }));
             transport.stream = Some(*stream);
         } else {

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -103,6 +103,7 @@ struct RawSmartSubtransportStream {
 /// Add a custom transport definition, to be used in addition to the built-in
 /// set of transports that come with libgit2.
 ///
+/// # Safety
 /// This function is unsafe as it needs to be externally synchronized with calls
 /// to creation of other transports.
 pub unsafe fn register<F>(prefix: &str, factory: F) -> Result<(), Error>

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -225,7 +225,7 @@ impl<'repo> Binding for Tree<'repo> {
 
     unsafe fn from_raw(raw: *mut raw::git_tree) -> Tree<'repo> {
         Tree {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }
@@ -334,7 +334,7 @@ impl<'a> Binding for TreeEntry<'a> {
     type Raw = *mut raw::git_tree_entry;
     unsafe fn from_raw(raw: *mut raw::git_tree_entry) -> TreeEntry<'a> {
         TreeEntry {
-            raw: raw,
+            raw,
             owned: true,
             _marker: marker::PhantomData,
         }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -206,7 +206,7 @@ extern "C" fn treewalk_cb<T: Into<i32>>(
     entry: *const raw::git_tree_entry,
     payload: *mut c_void,
 ) -> c_int {
-    match panic::wrap(|| unsafe {
+    panic::wrap(|| unsafe {
         let root = match CStr::from_ptr(root).to_str() {
             Ok(value) => value,
             _ => return -1,
@@ -214,10 +214,8 @@ extern "C" fn treewalk_cb<T: Into<i32>>(
         let entry = entry_from_raw_const(entry);
         let payload = payload as *mut &mut TreeWalkCb<'_, T>;
         (*payload)(root, &entry).into()
-    }) {
-        Some(value) => value,
-        None => -1,
-    }
+    })
+    .unwrap_or(-1)
 }
 
 impl<'repo> Binding for Tree<'repo> {

--- a/src/treebuilder.rs
+++ b/src/treebuilder.rs
@@ -141,7 +141,7 @@ impl<'repo> Binding for TreeBuilder<'repo> {
 
     unsafe fn from_raw(raw: *mut raw::git_treebuilder) -> TreeBuilder<'repo> {
         TreeBuilder {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -204,7 +204,7 @@ pub fn c_cmp_to_ordering(cmp: c_int) -> Ordering {
 pub fn path_to_repo_path(path: &Path) -> Result<CString, Error> {
     macro_rules! err {
         ($msg:literal, $path:expr) => {
-            return Err(Error::from_str(&format!($msg, $path.display())))
+            return Err(Error::from_str(&format!($msg, $path.display())));
         };
     }
     match path.components().next() {
@@ -221,12 +221,10 @@ pub fn path_to_repo_path(path: &Path) -> Result<CString, Error> {
     #[cfg(windows)]
     {
         match path.to_str() {
-            None => {
-                return Err(Error::from_str(
-                    "only valid unicode paths are accepted on windows",
-                ))
-            }
-            Some(s) => return fixup_windows_path(s),
+            None => Err(Error::from_str(
+                "only valid unicode paths are accepted on windows",
+            )),
+            Some(s) => fixup_windows_path(s),
         }
     }
     #[cfg(not(windows))]
@@ -242,9 +240,9 @@ pub fn cstring_to_repo_path<T: IntoCString>(path: T) -> Result<CString, Error> {
 #[cfg(windows)]
 fn fixup_windows_path<P: Into<Vec<u8>>>(path: P) -> Result<CString, Error> {
     let mut bytes: Vec<u8> = path.into();
-    for i in 0..bytes.len() {
-        if bytes[i] == b'\\' {
-            bytes[i] = b'/';
+    for b in &mut bytes {
+        if *b == b'\\' {
+            *b = b'/';
         }
     }
     Ok(CString::new(bytes)?)

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -145,6 +145,7 @@ impl<'a> WorktreeAddOptions<'a> {
     /// Creates a default set of add options.
     ///
     /// By default this will not lock the worktree
+    #[allow(clippy::new_without_default)]
     pub fn new() -> WorktreeAddOptions<'a> {
         unsafe {
             let mut raw = mem::zeroed();
@@ -189,6 +190,7 @@ impl WorktreePruneOptions {
     ///
     /// By defaults this will prune only worktrees that are no longer valid
     /// unlocked and not checked out
+    #[allow(clippy::new_without_default)]
     pub fn new() -> WorktreePruneOptions {
         unsafe {
             let mut raw = mem::zeroed();


### PR DESCRIPTION
This PR includes a additional CI workflow for testing git2-rs for various targets.
```
          # - { os: ubuntu-latest  , target: arm-unknown-linux-gnueabihf , use-cross: use-cross }
          - { os: ubuntu-latest  , target: aarch64-unknown-linux-gnu   , use-cross: use-cross }
          - { os: ubuntu-latest  , target: aarch64-unknown-linux-musl  , use-cross: use-cross }
          - { os: ubuntu-latest  , target: i686-unknown-linux-gnu      , use-cross: use-cross }
          - { os: ubuntu-latest  , target: i686-unknown-linux-musl     , use-cross: use-cross }
          - { os: ubuntu-latest  , target: x86_64-unknown-linux-gnu    , use-cross: use-cross }
          - { os: ubuntu-latest  , target: x86_64-unknown-linux-musl   , use-cross: use-cross }
          - { os: macos-latest   , target: x86_64-apple-darwin }
          # - { os: windows-latest , target: i686-pc-windows-gnu }
          - { os: windows-latest , target: i686-pc-windows-msvc }
          - { os: windows-latest , target: x86_64-pc-windows-gnu }
          - { os: windows-latest , target: x86_64-pc-windows-msvc }
```
I found test or compilation errors in the targets as comments.

This CI workflow also include a clippy check for linux/mac/windows (due to specific sections for windows -- mac target could not be useful since there is no specific mac section)

Activating clippy has produced many warnings (promoted as errors in this CI workflow). I've fixed all of them (and sometimes I add an `allow(clippy:xxx)` pragmas:
* `clippy::new_without_default`
* `clippy::unnecessary_cast`
* `clippy::too_many_arguments`
* `clippy::manual_non_exhaustive`
* `clippy::should_implement_trait`
* `clippy::transmute_ptr_to_ptr`

I note 2 special cases of maybe useless "unsafe" function. I put them in a separate commit.

A coverage section is ready to use in the same workflow.