### PR TITLE
Skip the systest tests on nightly rust

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,9 @@ jobs:
       shell: bash
     - run: cargo test --no-default-features
     - run: cargo test
-    - run: cargo run --manifest-path systest/Cargo.toml
+    # skip systest on nightly because it requires the extprim crate which fails to compile on nightly rust
+    - run: if [[ "${{ matrix.rust }}" != "nightly" ]]; then cargo run --manifest-path systest/Cargo.toml; fi
+      shell: bash
     - run: cargo test --manifest-path git2-curl/Cargo.toml
 
   rustfmt:


### PR DESCRIPTION
These tests are failing now because the extprim crate required by
the systest build-dependencies no longer compiles with nightly rust.