### PR TITLE
struct: remove redundant fields

### DIFF
--- a/src/blame.rs
+++ b/src/blame.rs
@@ -247,7 +247,7 @@ impl<'repo> Binding for Blame<'repo> {
 
     unsafe fn from_raw(raw: *mut raw::git_blame) -> Blame<'repo> {
         Blame {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }
@@ -268,7 +268,7 @@ impl<'blame> Binding for BlameHunk<'blame> {
 
     unsafe fn from_raw(raw: *mut raw::git_blame_hunk) -> BlameHunk<'blame> {
         BlameHunk {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -56,7 +56,7 @@ impl<'repo> Binding for Blob<'repo> {
 
     unsafe fn from_raw(raw: *mut raw::git_blob) -> Blob<'repo> {
         Blob {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }
@@ -110,7 +110,7 @@ impl<'repo> Binding for BlobWriter<'repo> {
 
     unsafe fn from_raw(raw: *mut raw::git_writestream) -> BlobWriter<'repo> {
         BlobWriter {
-            raw: raw,
+            raw,
             need_cleanup: true,
             _marker: marker::PhantomData,
         }

--- a/src/branch.rs
+++ b/src/branch.rs
@@ -130,7 +130,7 @@ impl<'repo> Branches<'repo> {
     /// pointer.
     pub unsafe fn from_raw(raw: *mut raw::git_branch_iterator) -> Branches<'repo> {
         Branches {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/cert.rs
+++ b/src/cert.rs
@@ -100,7 +100,7 @@ impl<'a> Binding for Cert<'a> {
     type Raw = *mut raw::git_cert;
     unsafe fn from_raw(raw: *mut raw::git_cert) -> Cert<'a> {
         Cert {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -313,7 +313,7 @@ impl<'repo> Binding for Commit<'repo> {
     type Raw = *mut raw::git_commit;
     unsafe fn from_raw(raw: *mut raw::git_commit) -> Commit<'repo> {
         Commit {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -465,7 +465,7 @@ impl Config {
 impl Binding for Config {
     type Raw = *mut raw::git_config;
     unsafe fn from_raw(raw: *mut raw::git_config) -> Config {
-        Config { raw: raw }
+        Config { raw }
     }
     fn raw(&self) -> *mut raw::git_config {
         self.raw
@@ -534,7 +534,7 @@ impl<'cfg> Binding for ConfigEntry<'cfg> {
 
     unsafe fn from_raw(raw: *mut raw::git_config_entry) -> ConfigEntry<'cfg> {
         ConfigEntry {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
             owned: true,
         }
@@ -549,7 +549,7 @@ impl<'cfg> Binding for ConfigEntries<'cfg> {
 
     unsafe fn from_raw(raw: *mut raw::git_config_iterator) -> ConfigEntries<'cfg> {
         ConfigEntries {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }
@@ -571,7 +571,7 @@ impl<'cfg, 'b> Iterator for &'b ConfigEntries<'cfg> {
             try_call_iter!(raw::git_config_next(&mut raw, self.raw));
             Some(Ok(ConfigEntry {
                 owned: false,
-                raw: raw,
+                raw,
                 _marker: marker::PhantomData,
             }))
         }

--- a/src/cred.rs
+++ b/src/cred.rs
@@ -171,7 +171,7 @@ impl Binding for Cred {
     type Raw = *mut raw::git_cred;
 
     unsafe fn from_raw(raw: *mut raw::git_cred) -> Cred {
-        Cred { raw: raw }
+        Cred { raw }
     }
     fn raw(&self) -> *mut raw::git_cred {
         self.raw

--- a/src/describe.rs
+++ b/src/describe.rs
@@ -44,7 +44,7 @@ impl<'repo> Binding for Describe<'repo> {
 
     unsafe fn from_raw(raw: *mut raw::git_describe_result) -> Describe<'repo> {
         Describe {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -447,7 +447,7 @@ impl<'repo> Binding for Diff<'repo> {
     type Raw = *mut raw::git_diff;
     unsafe fn from_raw(raw: *mut raw::git_diff) -> Diff<'repo> {
         Diff {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }
@@ -545,7 +545,7 @@ impl<'a> Binding for DiffDelta<'a> {
     type Raw = *mut raw::git_diff_delta;
     unsafe fn from_raw(raw: *mut raw::git_diff_delta) -> DiffDelta<'a> {
         DiffDelta {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }
@@ -630,7 +630,7 @@ impl<'a> Binding for DiffFile<'a> {
     type Raw = *const raw::git_diff_file;
     unsafe fn from_raw(raw: *const raw::git_diff_file) -> DiffFile<'a> {
         DiffFile {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }
@@ -1081,7 +1081,7 @@ impl<'a> Binding for DiffLine<'a> {
     type Raw = *const raw::git_diff_line;
     unsafe fn from_raw(raw: *const raw::git_diff_line) -> DiffLine<'a> {
         DiffLine {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }
@@ -1143,7 +1143,7 @@ impl<'a> Binding for DiffHunk<'a> {
     type Raw = *const raw::git_diff_hunk;
     unsafe fn from_raw(raw: *const raw::git_diff_hunk) -> DiffHunk<'a> {
         DiffHunk {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }
@@ -1199,7 +1199,7 @@ impl Binding for DiffStats {
     type Raw = *mut raw::git_diff_stats;
 
     unsafe fn from_raw(raw: *mut raw::git_diff_stats) -> DiffStats {
-        DiffStats { raw: raw }
+        DiffStats { raw }
     }
     fn raw(&self) -> *mut raw::git_diff_stats {
         self.raw
@@ -1248,7 +1248,7 @@ impl<'a> Binding for DiffBinary<'a> {
     type Raw = *const raw::git_diff_binary;
     unsafe fn from_raw(raw: *const raw::git_diff_binary) -> DiffBinary<'a> {
         DiffBinary {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }
@@ -1280,7 +1280,7 @@ impl<'a> Binding for DiffBinaryFile<'a> {
     type Raw = *const raw::git_diff_binary_file;
     unsafe fn from_raw(raw: *const raw::git_diff_binary_file) -> DiffBinaryFile<'a> {
         DiffBinaryFile {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -69,12 +69,12 @@ impl Error {
     }
 
     unsafe fn from_raw(code: c_int, ptr: *const raw::git_error) -> Error {
-        let msg = CStr::from_ptr((*ptr).message as *const _).to_bytes();
-        let msg = String::from_utf8_lossy(msg).into_owned();
+        let message = CStr::from_ptr((*ptr).message as *const _).to_bytes();
+        let message = String::from_utf8_lossy(message).into_owned();
         Error {
-            code: code,
+            code,
             klass: (*ptr).klass,
-            message: msg,
+            message,
         }
     }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -166,7 +166,7 @@ impl Index {
                 gid: entry.gid,
                 file_size: entry.file_size,
                 id: *entry.id.raw(),
-                flags: flags,
+                flags,
                 flags_extended: entry.flags_extended,
                 path: path.as_ptr(),
                 mtime: raw::git_index_time {
@@ -223,7 +223,7 @@ impl Index {
                 gid: entry.gid,
                 file_size: entry.file_size,
                 id: *entry.id.raw(),
-                flags: flags,
+                flags,
                 flags_extended: entry.flags_extended,
                 path: path.as_ptr(),
                 mtime: raw::git_index_time {
@@ -600,7 +600,7 @@ impl Index {
 impl Binding for Index {
     type Raw = *mut raw::git_index;
     unsafe fn from_raw(raw: *mut raw::git_index) -> Index {
-        Index { raw: raw }
+        Index { raw }
     }
     fn raw(&self) -> *mut raw::git_index {
         self.raw
@@ -718,15 +718,15 @@ impl Binding for IndexEntry {
         let path = slice::from_raw_parts(path as *const u8, pathlen);
 
         IndexEntry {
-            dev: dev,
-            ino: ino,
-            mode: mode,
-            uid: uid,
-            gid: gid,
-            file_size: file_size,
+            dev,
+            ino,
+            mode,
+            uid,
+            gid,
+            file_size,
             id: Binding::from_raw(&id as *const _),
-            flags: flags,
-            flags_extended: flags_extended,
+            flags,
+            flags_extended,
             path: path.to_vec(),
             mtime: Binding::from_raw(mtime),
             ctime: Binding::from_raw(ctime),

--- a/src/mempack.rs
+++ b/src/mempack.rs
@@ -16,7 +16,7 @@ impl<'odb> Binding for Mempack<'odb> {
 
     unsafe fn from_raw(raw: *mut raw::git_odb_backend) -> Mempack<'odb> {
         Mempack {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -178,7 +178,7 @@ impl<'repo> Binding for AnnotatedCommit<'repo> {
     type Raw = *mut raw::git_annotated_commit;
     unsafe fn from_raw(raw: *mut raw::git_annotated_commit) -> AnnotatedCommit<'repo> {
         AnnotatedCommit {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/note.rs
+++ b/src/note.rs
@@ -53,7 +53,7 @@ impl<'repo> Binding for Note<'repo> {
     type Raw = *mut raw::git_note;
     unsafe fn from_raw(raw: *mut raw::git_note) -> Note<'repo> {
         Note {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }
@@ -80,7 +80,7 @@ impl<'repo> Binding for Notes<'repo> {
     type Raw = *mut raw::git_note_iterator;
     unsafe fn from_raw(raw: *mut raw::git_note_iterator) -> Notes<'repo> {
         Notes {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/object.rs
+++ b/src/object.rs
@@ -232,7 +232,7 @@ impl<'repo> Binding for Object<'repo> {
 
     unsafe fn from_raw(raw: *mut raw::git_object) -> Object<'repo> {
         Object {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/odb.rs
+++ b/src/odb.rs
@@ -23,7 +23,7 @@ impl<'repo> Binding for Odb<'repo> {
 
     unsafe fn from_raw(raw: *mut raw::git_odb) -> Odb<'repo> {
         Odb {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }
@@ -273,7 +273,7 @@ impl<'a> Binding for OdbObject<'a> {
 
     unsafe fn from_raw(raw: *mut raw::git_odb_object) -> OdbObject<'a> {
         OdbObject {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }
@@ -327,7 +327,7 @@ impl<'repo> Binding for OdbReader<'repo> {
 
     unsafe fn from_raw(raw: *mut raw::git_odb_stream) -> OdbReader<'repo> {
         OdbReader {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }
@@ -386,7 +386,7 @@ impl<'repo> Binding for OdbWriter<'repo> {
 
     unsafe fn from_raw(raw: *mut raw::git_odb_stream) -> OdbWriter<'repo> {
         OdbWriter {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -35,7 +35,7 @@ impl Oid {
                 s.len() as libc::size_t
             ));
         }
-        Ok(Oid { raw: raw })
+        Ok(Oid { raw })
     }
 
     /// Parse a raw object id into an Oid structure.
@@ -52,7 +52,7 @@ impl Oid {
             unsafe {
                 try_call!(raw::git_oid_fromraw(&mut raw, bytes.as_ptr()));
             }
-            Ok(Oid { raw: raw })
+            Ok(Oid { raw })
         }
     }
 

--- a/src/oid_array.rs
+++ b/src/oid_array.rs
@@ -32,7 +32,7 @@ impl Deref for OidArray {
 impl Binding for OidArray {
     type Raw = raw::git_oidarray;
     unsafe fn from_raw(raw: raw::git_oidarray) -> OidArray {
-        OidArray { raw: raw }
+        OidArray { raw }
     }
     fn raw(&self) -> raw::git_oidarray {
         self.raw

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -21,7 +21,7 @@ impl<'buffers> Binding for Patch<'buffers> {
     type Raw = *mut raw::git_patch;
     unsafe fn from_raw(raw: Self::Raw) -> Self {
         Patch {
-            raw: raw,
+            raw,
             buffers: PhantomData,
         }
     }

--- a/src/pathspec.rs
+++ b/src/pathspec.rs
@@ -168,7 +168,7 @@ impl Binding for Pathspec {
     type Raw = *mut raw::git_pathspec;
 
     unsafe fn from_raw(raw: *mut raw::git_pathspec) -> Pathspec {
-        Pathspec { raw: raw }
+        Pathspec { raw }
     }
     fn raw(&self) -> *mut raw::git_pathspec {
         self.raw
@@ -268,7 +268,7 @@ impl<'ps> Binding for PathspecMatchList<'ps> {
 
     unsafe fn from_raw(raw: *mut raw::git_pathspec_match_list) -> PathspecMatchList<'ps> {
         PathspecMatchList {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/rebase.rs
+++ b/src/rebase.rs
@@ -230,7 +230,7 @@ impl<'repo> Binding for Rebase<'repo> {
     type Raw = *mut raw::git_rebase;
     unsafe fn from_raw(raw: *mut raw::git_rebase) -> Rebase<'repo> {
         Rebase {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }
@@ -324,7 +324,7 @@ impl<'rebase> Binding for RebaseOperation<'rebase> {
     type Raw = *const raw::git_rebase_operation;
     unsafe fn from_raw(raw: *const raw::git_rebase_operation) -> RebaseOperation<'rebase> {
         RebaseOperation {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -387,7 +387,7 @@ impl<'repo> Binding for Reference<'repo> {
     type Raw = *mut raw::git_reference;
     unsafe fn from_raw(raw: *mut raw::git_reference) -> Reference<'repo> {
         Reference {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }
@@ -419,7 +419,7 @@ impl<'repo> Binding for References<'repo> {
     type Raw = *mut raw::git_reference_iterator;
     unsafe fn from_raw(raw: *mut raw::git_reference_iterator) -> References<'repo> {
         References {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/reflog.rs
+++ b/src/reflog.rs
@@ -103,7 +103,7 @@ impl Binding for Reflog {
     type Raw = *mut raw::git_reflog;
 
     unsafe fn from_raw(raw: *mut raw::git_reflog) -> Reflog {
-        Reflog { raw: raw }
+        Reflog { raw }
     }
     fn raw(&self) -> *mut raw::git_reflog {
         self.raw
@@ -151,7 +151,7 @@ impl<'reflog> Binding for ReflogEntry<'reflog> {
 
     unsafe fn from_raw(raw: *const raw::git_reflog_entry) -> ReflogEntry<'reflog> {
         ReflogEntry {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/refspec.rs
+++ b/src/refspec.rs
@@ -112,7 +112,7 @@ impl<'remote> Binding for Refspec<'remote> {
 
     unsafe fn from_raw(raw: *const raw::git_refspec) -> Refspec<'remote> {
         Refspec {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -67,7 +67,7 @@ pub struct RemoteConnection<'repo, 'connection, 'cb> {
 pub fn remote_into_raw(remote: Remote<'_>) -> *mut raw::git_remote {
     let ret = remote.raw;
     mem::forget(remote);
-    return ret;
+    ret
 }
 
 impl<'repo> Remote<'repo> {
@@ -406,7 +406,7 @@ impl<'repo> Binding for Remote<'repo> {
 
     unsafe fn from_raw(raw: *mut raw::git_remote) -> Remote<'repo> {
         Remote {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -2805,7 +2805,7 @@ impl Repository {
         let raw_opts = options.map(|o| o.raw());
         let ptr_raw_opts = match raw_opts.as_ref() {
             Some(v) => v,
-            None => 0 as *const _,
+            None => std::ptr::null(),
         };
         unsafe {
             try_call!(raw::git_cherrypick(self.raw(), commit.raw(), ptr_raw_opts));

--- a/src/revspec.rs
+++ b/src/revspec.rs
@@ -15,9 +15,9 @@ impl<'repo> Revspec<'repo> {
         mode: RevparseMode,
     ) -> Revspec<'repo> {
         Revspec {
-            from: from,
-            to: to,
-            mode: mode,
+            from,
+            to,
+            mode,
         }
     }
 

--- a/src/revspec.rs
+++ b/src/revspec.rs
@@ -14,11 +14,7 @@ impl<'repo> Revspec<'repo> {
         to: Option<Object<'repo>>,
         mode: RevparseMode,
     ) -> Revspec<'repo> {
-        Revspec {
-            from,
-            to,
-            mode,
-        }
+        Revspec { from, to, mode }
     }
 
     /// Access the `from` range of this revspec.

--- a/src/revwalk.rs
+++ b/src/revwalk.rs
@@ -28,9 +28,10 @@ where
     panic::wrap(|| unsafe {
         let hide_cb = payload as *mut C;
         if (*hide_cb)(Oid::from_raw(commit_id)) {
-            return 1;
+            1
+        } else {
+            0
         }
-        return 0;
     })
     .unwrap_or(-1)
 }
@@ -219,7 +220,7 @@ impl<'repo> Binding for Revwalk<'repo> {
     type Raw = *mut raw::git_revwalk;
     unsafe fn from_raw(raw: *mut raw::git_revwalk) -> Revwalk<'repo> {
         Revwalk {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -105,7 +105,7 @@ impl<'a> Binding for Signature<'a> {
     type Raw = *mut raw::git_signature;
     unsafe fn from_raw(raw: *mut raw::git_signature) -> Signature<'a> {
         Signature {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
             owned: true,
         }

--- a/src/status.rs
+++ b/src/status.rs
@@ -72,7 +72,7 @@ impl StatusOptions {
             let r = raw::git_status_init_options(&mut raw, raw::GIT_STATUS_OPTIONS_VERSION);
             assert_eq!(r, 0);
             StatusOptions {
-                raw: raw,
+                raw,
                 pathspec: Vec::new(),
                 ptrs: Vec::new(),
             }
@@ -264,7 +264,7 @@ impl<'repo> Binding for Statuses<'repo> {
     type Raw = *mut raw::git_status_list;
     unsafe fn from_raw(raw: *mut raw::git_status_list) -> Statuses<'repo> {
         Statuses {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }
@@ -340,7 +340,7 @@ impl<'statuses> Binding for StatusEntry<'statuses> {
 
     unsafe fn from_raw(raw: *const raw::git_status_entry) -> StatusEntry<'statuses> {
         StatusEntry {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/string_array.rs
+++ b/src/string_array.rs
@@ -79,7 +79,7 @@ impl StringArray {
 impl Binding for StringArray {
     type Raw = raw::git_strarray;
     unsafe fn from_raw(raw: raw::git_strarray) -> StringArray {
-        StringArray { raw: raw }
+        StringArray { raw }
     }
     fn raw(&self) -> raw::git_strarray {
         self.raw

--- a/src/submodule.rs
+++ b/src/submodule.rs
@@ -233,7 +233,7 @@ impl<'repo> Binding for Submodule<'repo> {
     type Raw = *mut raw::git_submodule;
     unsafe fn from_raw(raw: *mut raw::git_submodule) -> Submodule<'repo> {
         Submodule {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -118,7 +118,7 @@ impl<'repo> Binding for Tag<'repo> {
     type Raw = *mut raw::git_tag;
     unsafe fn from_raw(raw: *mut raw::git_tag) -> Tag<'repo> {
         Tag {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }

--- a/src/time.rs
+++ b/src/time.rs
@@ -61,7 +61,7 @@ impl Ord for Time {
 impl Binding for Time {
     type Raw = raw::git_time;
     unsafe fn from_raw(raw: raw::git_time) -> Time {
-        Time { raw: raw }
+        Time { raw }
     }
     fn raw(&self) -> raw::git_time {
         self.raw
@@ -73,8 +73,8 @@ impl IndexTime {
     pub fn new(seconds: i32, nanoseconds: u32) -> IndexTime {
         unsafe {
             Binding::from_raw(raw::git_index_time {
-                seconds: seconds,
-                nanoseconds: nanoseconds,
+                seconds,
+                nanoseconds,
             })
         }
     }
@@ -92,7 +92,7 @@ impl IndexTime {
 impl Binding for IndexTime {
     type Raw = raw::git_index_time;
     unsafe fn from_raw(raw: raw::git_index_time) -> IndexTime {
-        IndexTime { raw: raw }
+        IndexTime { raw }
     }
     fn raw(&self) -> raw::git_index_time {
         self.raw

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -271,7 +271,7 @@ extern "C" fn subtransport_action(
                     write: Some(stream_write),
                     free: Some(stream_free),
                 },
-                obj: obj,
+                obj,
             }));
             transport.stream = Some(*stream);
         } else {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -225,7 +225,7 @@ impl<'repo> Binding for Tree<'repo> {
 
     unsafe fn from_raw(raw: *mut raw::git_tree) -> Tree<'repo> {
         Tree {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }
@@ -334,7 +334,7 @@ impl<'a> Binding for TreeEntry<'a> {
     type Raw = *mut raw::git_tree_entry;
     unsafe fn from_raw(raw: *mut raw::git_tree_entry) -> TreeEntry<'a> {
         TreeEntry {
-            raw: raw,
+            raw,
             owned: true,
             _marker: marker::PhantomData,
         }

--- a/src/treebuilder.rs
+++ b/src/treebuilder.rs
@@ -141,7 +141,7 @@ impl<'repo> Binding for TreeBuilder<'repo> {
 
     unsafe fn from_raw(raw: *mut raw::git_treebuilder) -> TreeBuilder<'repo> {
         TreeBuilder {
-            raw: raw,
+            raw,
             _marker: marker::PhantomData,
         }
     }


### PR DESCRIPTION
- insignificant update, just to remove RLS warnings 