### PR TITLE
Remove reference to old MSRV CI job in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ git2 = "0.13"
 ## Rust version requirements
 
 git2-rs works with stable Rust, and typically works with the most recent prior
-stable release as well. Check the MSRV job of [the CI script](.github/workflows/main.yml) to see the oldest
-version of Rust known to pass tests.
+stable release as well.
 
 ## Version of libgit2
 


### PR DESCRIPTION
The job was removed in abd3785084e3cc7accdd12afbc4eaae53d0135e7.