### PR TITLE
Fix vendored-openssl feature on macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ unstable = []
 default = ["ssh", "https", "ssh_key_from_memory"]
 ssh = ["libgit2-sys/ssh"]
 https = ["libgit2-sys/https", "openssl-sys", "openssl-probe"]
-vendored-openssl = ["openssl-sys/vendored"]
+vendored-openssl = ["openssl-sys/vendored", "libgit2-sys/vendored-openssl"]
 ssh_key_from_memory = ["libgit2-sys/ssh_key_from_memory"]
 zlib-ng-compat = ["libgit2-sys/zlib-ng-compat"]
 

--- a/libgit2-sys/Cargo.toml
+++ b/libgit2-sys/Cargo.toml
@@ -36,6 +36,7 @@ openssl-sys = { version = "0.9", optional = true }
 ssh = ["libssh2-sys"]
 https = ["openssl-sys"]
 ssh_key_from_memory = []
+vendored-openssl = ["openssl-sys/vendored"]
 # Cargo does not support requiring features on an optional dependency without
 # requiring the dependency. Rather than introduce additional complexity, we
 # just require libssh2 when using zlib-ng-compat. This will require building


### PR DESCRIPTION
Turns out the git2 dependency on openssl-sys was conditional to happen
everywhere but macOS, which means that vendored-openssl didn't work. The
fix here is to forward the feature to the `libgit2-sys` crate which
depends on `openssl-sys` even on macOS.

Closes #718