### PR TITLE
Fix revparsing with windows paths in blame example

### DIFF
--- a/examples/blame.rs
+++ b/examples/blame.rs
@@ -73,7 +73,15 @@ fn run(args: &Args) -> Result<(), git2::Error> {
         }
     }
 
-    let spec = format!("{}:{}", commit_id, path.display());
+    let spec = if cfg!(unix) {
+        format!("{}:{}", commit_id, path.display())
+    } else {
+        format!(
+            "{}:{}",
+            commit_id,
+            path.display().to_string().replace("\\", "/")
+        )
+    };
     let blame = repo.blame_file(path, Some(&mut opts))?;
     let object = repo.revparse_single(&spec[..])?;
     let blob = repo.find_blob(object.id())?;


### PR DESCRIPTION
`revparse_single` uses a git object name and not a file path - that means backslashes must be translated to slashes on windows.
Otherwise the example fails:
```
E:\dev\git2-rs>.\target\debug\blame.exe examples\blame.rs
error: the path 'examples\blame.rs' does not exist in the given tree; class=Tree (14); code=NotFound (-3)
```
I reused the `cfg!` conditional from `remote.rs`, but there might be a better way to do that.