### PR TITLE
enable tracing and add tracing types and func

### DIFF
--- a/libgit2-sys/build.rs
+++ b/libgit2-sys/build.rs
@@ -107,6 +107,7 @@ fn main() {
     features.push_str("#ifndef INCLUDE_features_h\n");
     features.push_str("#define INCLUDE_features_h\n");
     features.push_str("#define GIT_THREADS 1\n");
+    features.push_str("#define GIT_TRACE 1\n");
 
     if !target.contains("android") {
         features.push_str("#define GIT_USE_NSEC 1\n");

--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -1892,6 +1892,33 @@ pub const GIT_WORKTREE_PRUNE_OPTIONS_VERSION: c_uint = 1;
 pub type git_repository_mergehead_foreach_cb =
     Option<extern "C" fn(oid: *const git_oid, payload: *mut c_void) -> c_int>;
 
+git_enum! {
+    pub enum git_trace_level_t {
+        /* No tracing will be performed. */
+        GIT_TRACE_NONE = 0,
+
+        /* Severe errors that may impact the program's execution */
+        GIT_TRACE_FATAL = 1,
+
+        /* Errors that do not impact the program's execution */
+        GIT_TRACE_ERROR = 2,
+
+        /* Warnings that suggest abnormal data */
+        GIT_TRACE_WARN = 3,
+
+        /* Informational messages about program execution */
+        GIT_TRACE_INFO = 4,
+
+        /* Detailed data that allows for debugging */
+        GIT_TRACE_DEBUG = 5,
+
+        /* Exceptionally detailed debugging data */
+        GIT_TRACE_TRACE = 6,
+    }
+}
+
+pub type git_trace_cb = Option<extern "C" fn(level: git_trace_level_t, msg: *const c_char)>;
+
 extern "C" {
     // threads
     pub fn git_libgit2_init() -> c_int;
@@ -3986,6 +4013,8 @@ extern "C" {
         replace_name: *const c_char,
         replace_email: *const c_char,
     ) -> c_int;
+
+    pub fn git_trace_set(level: git_trace_level_t, cb: git_trace_cb);
 }
 
 pub fn init() {

--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -4014,7 +4014,7 @@ extern "C" {
         replace_email: *const c_char,
     ) -> c_int;
 
-    pub fn git_trace_set(level: git_trace_level_t, cb: git_trace_cb);
+    pub fn git_trace_set(level: git_trace_level_t, cb: git_trace_cb) -> c_int;
 }
 
 pub fn init() {


### PR DESCRIPTION
* this enables tracing define (default in their CMake since 0.99)
* adds the callback type and sys function for this

in terms of adding a safe interface for this I will followup in a separate issue/PR since this probably requires adding `lazy static` as a dependency to safely store a safe callback globally.

closes #696