### PR TITLE
Fix test `branch::tests::name_is_valid`

### DIFF
--- a/src/branch.rs
+++ b/src/branch.rs
@@ -30,6 +30,7 @@ impl<'repo> Branch<'repo> {
 
     /// Ensure the branch name is well-formed.
     pub fn name_is_valid(name: &str) -> Result<bool, Error> {
+        crate::init();
         let name = CString::new(name)?;
         let mut valid: libc::c_int = 0;
         unsafe {


### PR DESCRIPTION
This was an easy fix for a frustrating-to-debug issue. Closes #728. This is the same test failure mentioned in https://github.com/rust-lang/git2-rs/issues/721#issuecomment-860256600.
