### PR TITLE
Add way to get build version information.

### DIFF
--- a/libgit2-sys/build.rs
+++ b/libgit2-sys/build.rs
@@ -22,6 +22,8 @@ fn main() {
         }
     }
 
+    println!("cargo:rustc-cfg=libgit2_vendored");
+
     if !Path::new("libgit2/.git").exists() {
         let _ = Command::new("git")
             .args(&["submodule", "update", "--init", "libgit2"])

--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -1943,6 +1943,15 @@ git_enum! {
 
 pub type git_trace_cb = Option<extern "C" fn(level: git_trace_level_t, msg: *const c_char)>;
 
+git_enum! {
+    pub enum git_feature_t {
+        GIT_FEATURE_THREADS = 1 << 0,
+        GIT_FEATURE_HTTPS   = 1 << 1,
+        GIT_FEATURE_SSH     = 1 << 2,
+        GIT_FEATURE_NSEC    = 1 << 3,
+    }
+}
+
 extern "C" {
     // threads
     pub fn git_libgit2_init() -> c_int;
@@ -3948,6 +3957,9 @@ extern "C" {
         given_opts: *const git_revert_options,
     ) -> c_int;
 
+    // Common
+    pub fn git_libgit2_version(major: *mut c_int, minor: *mut c_int, rev: *mut c_int) -> c_int;
+    pub fn git_libgit2_features() -> c_int;
     pub fn git_libgit2_opts(option: c_int, ...) -> c_int;
 
     // Worktrees
@@ -4092,3 +4104,8 @@ fn ssh_init() {
 
 #[cfg(not(feature = "ssh"))]
 fn ssh_init() {}
+
+#[doc(hidden)]
+pub fn vendored() -> bool {
+    cfg!(libgit2_vendored)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,7 @@ pub use crate::transaction::Transaction;
 pub use crate::tree::{Tree, TreeEntry, TreeIter, TreeWalkMode, TreeWalkResult};
 pub use crate::treebuilder::TreeBuilder;
 pub use crate::util::IntoCString;
+pub use crate::version::Version;
 pub use crate::worktree::{Worktree, WorktreeAddOptions, WorktreeLockStatus, WorktreePruneOptions};
 
 // Create a convinience method on bitflag struct which checks the given flag
@@ -695,6 +696,7 @@ mod tracing;
 mod transaction;
 mod tree;
 mod treebuilder;
+mod version;
 mod worktree;
 
 fn init() {

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,95 @@
+use crate::raw;
+use libc::c_int;
+use std::fmt;
+
+/// Version information about libgit2 and the capabilities it supports.
+pub struct Version {
+    major: c_int,
+    minor: c_int,
+    rev: c_int,
+    features: c_int,
+}
+
+macro_rules! flag_test {
+    ($features:expr, $flag:expr) => {
+        ($features as u32 & $flag as u32) != 0
+    };
+}
+
+impl Version {
+    /// Returns a [`Version`] which provides information about libgit2.
+    pub fn get() -> Version {
+        let mut v = Version {
+            major: 0,
+            minor: 0,
+            rev: 0,
+            features: 0,
+        };
+        unsafe {
+            raw::git_libgit2_version(&mut v.major, &mut v.minor, &mut v.rev);
+            v.features = raw::git_libgit2_features();
+        }
+        v
+    }
+
+    /// Returns the version of libgit2.
+    ///
+    /// The return value is a tuple of `(major, minor, rev)`
+    pub fn libgit2_version(&self) -> (u32, u32, u32) {
+        (self.major as u32, self.minor as u32, self.rev as u32)
+    }
+
+    /// Returns the version of the libgit2-sys crate.
+    pub fn crate_version(&self) -> &'static str {
+        env!("CARGO_PKG_VERSION")
+    }
+
+    /// Returns true if this was built with the vendored version of libgit2.
+    pub fn vendored(&self) -> bool {
+        raw::vendored()
+    }
+
+    /// Returns true if libgit2 was built thread-aware and can be safely used
+    /// from multiple threads.
+    pub fn threads(&self) -> bool {
+        flag_test!(self.features, raw::GIT_FEATURE_THREADS)
+    }
+
+    /// Returns true if libgit2 was built with and linked against a TLS implementation.
+    ///
+    /// Custom TLS streams may still be added by the user to support HTTPS
+    /// regardless of this.
+    pub fn https(&self) -> bool {
+        flag_test!(self.features, raw::GIT_FEATURE_HTTPS)
+    }
+
+    /// Returns true if libgit2 was built with and linked against libssh2.
+    ///
+    /// A custom transport may still be added by the user to support libssh2
+    /// regardless of this.
+    pub fn ssh(&self) -> bool {
+        flag_test!(self.features, raw::GIT_FEATURE_SSH)
+    }
+
+    /// Returns true if libgit2 was built with support for sub-second
+    /// resolution in file modification times.
+    pub fn nsec(&self) -> bool {
+        flag_test!(self.features, raw::GIT_FEATURE_NSEC)
+    }
+}
+
+impl fmt::Debug for Version {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        let mut f = f.debug_struct("Version");
+        f.field("major", &self.major)
+            .field("minor", &self.minor)
+            .field("rev", &self.rev)
+            .field("crate_version", &self.crate_version())
+            .field("vendored", &self.vendored())
+            .field("threads", &self.threads())
+            .field("https", &self.https())
+            .field("ssh", &self.ssh())
+            .field("nsec", &self.nsec());
+        f.finish()
+    }
+}


### PR DESCRIPTION
This adds a `Version` struct which can be used to query the version information of libgit2.

My use case is to expose this information in Cargo (per https://github.com/rust-lang/cargo/issues/6275).
