### PR TITLE
Derive `Debug` for `IndexEntry`, `IndexTime`, and `Time`

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -143,7 +143,7 @@ pub struct git_signature {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct git_time {
     pub time: git_time_t,
     pub offset: c_int,
@@ -817,7 +817,7 @@ pub const GIT_INDEX_ENTRY_STAGEMASK: u16 = 0x3000;
 pub const GIT_INDEX_ENTRY_STAGESHIFT: u16 = 12;
 
 #[repr(C)]
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct git_index_time {
     pub seconds: i32,
     pub nanoseconds: u32,

--- a/src/index.rs
+++ b/src/index.rs
@@ -54,6 +54,7 @@ pub type IndexMatchedPath<'a> = dyn FnMut(&Path, &[u8]) -> i32 + 'a;
 /// All fields of an entry are public for modification and inspection. This is
 /// also how a new index entry is created.
 #[allow(missing_docs)]
+#[derive(Debug)]
 pub struct IndexEntry {
     pub ctime: IndexTime,
     pub mtime: IndexTime,

--- a/src/time.rs
+++ b/src/time.rs
@@ -6,13 +6,13 @@ use crate::raw;
 use crate::util::Binding;
 
 /// Time in a signature
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Time {
     raw: raw::git_time,
 }
 
 /// Time structure used in a git index entry.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct IndexTime {
     raw: raw::git_index_time,
 }


### PR DESCRIPTION
Sometimes it's useful to quickly dump an IndexEntry for debugging;
having a `Debug` impl helps. Derive `Debug` for several time-related
types (as well as the underlying structures in libgit2-sys).