### PR TITLE
Make `Odb` `Send` and `Sync`

### DIFF
--- a/libgit2-sys/build.rs
+++ b/libgit2-sys/build.rs
@@ -14,7 +14,7 @@ fn main() {
     let try_to_use_system_libgit2 = !vendored && !zlib_ng_compat;
     if try_to_use_system_libgit2 {
         let mut cfg = pkg_config::Config::new();
-        if let Ok(lib) = cfg.atleast_version("1.1.0").probe("libgit2") {
+        if let Ok(lib) = cfg.atleast_version("1.3.0").probe("libgit2") {
             for include in &lib.include_paths {
                 println!("cargo:root={}", include.display());
             }

--- a/src/odb.rs
+++ b/src/odb.rs
@@ -18,6 +18,10 @@ pub struct Odb<'repo> {
     _marker: marker::PhantomData<Object<'repo>>,
 }
 
+// `git_odb` uses locking and atomics internally.
+unsafe impl<'repo> Send for Odb<'repo> {}
+unsafe impl<'repo> Sync for Odb<'repo> {}
+
 impl<'repo> Binding for Odb<'repo> {
     type Raw = *mut raw::git_odb;
 


### PR DESCRIPTION
As of libgit2 1.2.0, `git_odb` uses locking internally, and should be thread-safe. Mark it `Send` and `Sync` to allow access from multiple threads.
