### PR TITLE
we have to expect non-utf8 strings in tracing messages

### DIFF
--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -57,6 +57,12 @@ impl Binding for TraceLevel {
     }
 }
 
+/// Callback type used to pass tracing events to the subscriber.
+/// see `trace_set` to register a scubscriber.
+///
+/// Note:
+///     libgit2 might pass non-utf8 strings therefore we
+///     pass the message as a byte slice
 pub type TracingCb = fn(TraceLevel, &[u8]);
 
 static CALLBACK: AtomicUsize = AtomicUsize::new(0);

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -76,7 +76,7 @@ extern "C" fn tracing_cb_c(level: raw::git_trace_level_t, msg: *const c_char) {
     let cb = CALLBACK.load(Ordering::SeqCst);
     panic::wrap(|| unsafe {
         let cb: TracingCb = std::mem::transmute(cb);
-        let msg = std::ffi::CStr::from_ptr(msg).to_str().unwrap();
-        cb(Binding::from_raw(level), msg);
+        let msg = std::ffi::CStr::from_ptr(msg).to_string_lossy();
+        cb(Binding::from_raw(level), msg.as_ref());
     });
 }

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -57,12 +57,9 @@ impl Binding for TraceLevel {
     }
 }
 
+//TODO: pass raw &[u8] and leave conversion to consumer (breaking API)
 /// Callback type used to pass tracing events to the subscriber.
 /// see `trace_set` to register a scubscriber.
-///
-/// Note:
-///     libgit2 might pass non-utf8 strings therefore we
-///     pass the message as a byte slice
 pub type TracingCb = fn(TraceLevel, &str);
 
 static CALLBACK: AtomicUsize = AtomicUsize::new(0);


### PR DESCRIPTION
fixes #769 