### PR TITLE
WIP: Add wrappers for git_index_conflict_{add,remove,get,cleanup}

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,4 +43,4 @@ ssh_key_from_memory = ["libgit2-sys/ssh_key_from_memory"]
 zlib-ng-compat = ["libgit2-sys/zlib-ng-compat"]
 
 [workspace]
-members = ["systest", "git2-curl"]
+members = ["systest", "git2-curl", "libgit2-sys"]

--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -2923,6 +2923,7 @@ extern "C" {
         our_entry: *const git_index_entry,
         their_entry: *const git_index_entry,
     ) -> c_int;
+    pub fn git_index_conflict_cleanup(index: *mut git_index) -> c_int;
     pub fn git_index_conflict_remove(index: *mut git_index, path: *const c_char) -> c_int;
     pub fn git_index_conflict_get(
         ancestor_out: *mut *const git_index_entry,

--- a/src/index.rs
+++ b/src/index.rs
@@ -93,9 +93,7 @@ fn try_raw_entries<const N: usize>(
     entries: &[Option<&IndexEntry>; N],
     cb: impl FnOnce(&[*const raw::git_index_entry; N]) -> Result<(), Error>,
 ) -> Result<(), Error> {
-    let mut paths: [Option<CString>; N] = unsafe {
-        std::mem::MaybeUninit::uninit().assume_init()
-    };
+    let mut paths: [Option<CString>; N] = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
     for (path, entry) in paths.iter_mut().zip(entries.iter()) {
         let c_path = if let Some(entry) = entry {
             Some(CString::new(&entry.path[..])?)
@@ -104,12 +102,13 @@ fn try_raw_entries<const N: usize>(
         };
 
         let path_ptr: *mut Option<CString> = path;
-        unsafe { path_ptr.write(c_path); }
+        unsafe {
+            path_ptr.write(c_path);
+        }
     }
 
-    let mut raw_entries: [Option<raw::git_index_entry>; N] = unsafe {
-        std::mem::MaybeUninit::uninit().assume_init()
-    };
+    let mut raw_entries: [Option<raw::git_index_entry>; N] =
+        unsafe { std::mem::MaybeUninit::uninit().assume_init() };
     for (raw_entry, (entry, path)) in raw_entries.iter_mut().zip(entries.iter().zip(&paths)) {
         let c_raw_entry = if let Some(entry) = entry {
             // libgit2 encodes the length of the path in the lower bits of the
@@ -148,17 +147,20 @@ fn try_raw_entries<const N: usize>(
         };
 
         let raw_entry_ptr: *mut Option<raw::git_index_entry> = raw_entry;
-        unsafe { raw_entry_ptr.write(c_raw_entry); }
+        unsafe {
+            raw_entry_ptr.write(c_raw_entry);
+        }
     }
 
-    let mut raw_entry_ptrs: [*const raw::git_index_entry; N] = unsafe {
-        std::mem::MaybeUninit::uninit().assume_init()
-    };
+    let mut raw_entry_ptrs: [*const raw::git_index_entry; N] =
+        unsafe { std::mem::MaybeUninit::uninit().assume_init() };
     for (raw_entry_ptr, raw_entry) in raw_entry_ptrs.iter_mut().zip(raw_entries.iter()) {
         let c_raw_entry_ptr = raw_entry.as_ref().map_or_else(std::ptr::null, |ptr| ptr);
 
         let raw_entry_ptr_ptr: *mut *const raw::git_index_entry = raw_entry_ptr;
-        unsafe { raw_entry_ptr_ptr.write(c_raw_entry_ptr); }
+        unsafe {
+            raw_entry_ptr_ptr.write(c_raw_entry_ptr);
+        }
     }
 
     cb(&raw_entry_ptrs)

--- a/src/index.rs
+++ b/src/index.rs
@@ -535,7 +535,12 @@ impl Index {
         let our_raw_ptr = our_raw.as_ref().map_or_else(std::ptr::null, |ptr| ptr);
         let their_raw_ptr = their_raw.as_ref().map_or_else(std::ptr::null, |ptr| ptr);
         unsafe {
-            try_call!(raw::git_index_conflict_add(self.raw, ancestor_raw_ptr, our_raw_ptr, their_raw_ptr));
+            try_call!(raw::git_index_conflict_add(
+                self.raw,
+                ancestor_raw_ptr,
+                our_raw_ptr,
+                their_raw_ptr
+            ));
             Ok(())
         }
     }
@@ -558,9 +563,13 @@ impl Index {
         let mut their = ptr::null();
 
         unsafe {
-            try_call!(
-                raw::git_index_conflict_get(&mut ancestor, &mut our, &mut their, self.raw, path)
-            );
+            try_call!(raw::git_index_conflict_get(
+                &mut ancestor,
+                &mut our,
+                &mut their,
+                self.raw,
+                path
+            ));
             Ok(IndexConflict {
                 ancestor: match ancestor.is_null() {
                     false => Some(IndexEntry::from_raw(*ancestor)),


### PR DESCRIPTION
In response to #778 I added wrapper functions for

 - `git_index_conflict_add`
 - `git_index_conflict_remove`
 - `git_index_conflict_cleanup`
 - `git_index_conflict_get` 

However, I do not know if this trivial addition is actually safe, as conflicts are already exposed via an iterator. I do not know whether it is safe to modify the index while iterating over the conflicts.

Suggestions welcome!