### PR TITLE
impl Send for TreeUpdateBuilder

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -680,6 +680,8 @@ extern "C" fn notify_cb(
     .unwrap_or(2)
 }
 
+unsafe impl Send for TreeUpdateBuilder {}
+
 impl Default for TreeUpdateBuilder {
     fn default() -> Self {
         Self::new()


### PR DESCRIPTION
TreeUpdateBuilder does not have any interior mutability, and the
underlying libgit2 data structures are safe to send to a different
thread as long as the old doesn't have a copy anymore.
