### PR TITLE
Add Repository::commit_new method with permissive parent param

### DIFF
--- a/examples/init.rs
+++ b/examples/init.rs
@@ -14,7 +14,7 @@
 
 #![deny(warnings)]
 
-use git2::{Error, Repository, RepositoryInitMode, RepositoryInitOptions};
+use git2::{Commit, Error, Repository, RepositoryInitMode, RepositoryInitOptions};
 use std::path::{Path, PathBuf};
 use structopt::StructOpt;
 
@@ -113,7 +113,14 @@ fn create_initial_commit(repo: &Repository) -> Result<(), Error> {
     // Normally creating a commit would involve looking up the current HEAD
     // commit and making that be the parent of the initial commit, but here this
     // is the first commit so there will be no parent.
-    repo.commit(Some("HEAD"), &sig, &sig, "Initial commit", &tree, &[])?;
+    repo.new_commit(
+        Some("HEAD"),
+        &sig,
+        &sig,
+        "Initial commit",
+        &tree,
+        &[] as &[Commit<'_>],
+    )?;
 
     Ok(())
 }

--- a/examples/init.rs
+++ b/examples/init.rs
@@ -113,7 +113,7 @@ fn create_initial_commit(repo: &Repository) -> Result<(), Error> {
     // Normally creating a commit would involve looking up the current HEAD
     // commit and making that be the parent of the initial commit, but here this
     // is the first commit so there will be no parent.
-    repo.new_commit(
+    repo.commit_new(
         Some("HEAD"),
         &sig,
         &sig,

--- a/examples/pull.rs
+++ b/examples/pull.rs
@@ -131,7 +131,7 @@ fn normal_merge(
     let local_commit = repo.find_commit(local.id())?;
     let remote_commit = repo.find_commit(remote.id())?;
     // Do our merge commit and set current branch head to that commit.
-    let _merge_commit = repo.commit(
+    let _merge_commit = repo.new_commit(
         Some("HEAD"),
         &sig,
         &sig,

--- a/examples/pull.rs
+++ b/examples/pull.rs
@@ -131,7 +131,7 @@ fn normal_merge(
     let local_commit = repo.find_commit(local.id())?;
     let remote_commit = repo.find_commit(remote.id())?;
     // Do our merge commit and set current branch head to that commit.
-    let _merge_commit = repo.new_commit(
+    let _merge_commit = repo.commit_new(
         Some("HEAD"),
         &sig,
         &sig,

--- a/src/blame.rs
+++ b/src/blame.rs
@@ -330,7 +330,7 @@ mod tests {
         let id = repo.refname_to_id("HEAD").unwrap();
         let parent = repo.find_commit(id).unwrap();
         let commit = repo
-            .new_commit(Some("HEAD"), &sig, &sig, "commit", &tree, &[&parent])
+            .commit_new(Some("HEAD"), &sig, &sig, "commit", &tree, &[&parent])
             .unwrap();
 
         let blame = repo.blame_file(Path::new("foo/bar"), None).unwrap();

--- a/src/blame.rs
+++ b/src/blame.rs
@@ -330,7 +330,7 @@ mod tests {
         let id = repo.refname_to_id("HEAD").unwrap();
         let parent = repo.find_commit(id).unwrap();
         let commit = repo
-            .commit(Some("HEAD"), &sig, &sig, "commit", &tree, &[&parent])
+            .new_commit(Some("HEAD"), &sig, &sig, "commit", &tree, &[&parent])
             .unwrap();
 
         let blame = repo.blame_file(Path::new("foo/bar"), None).unwrap();

--- a/src/build.rs
+++ b/src/build.rs
@@ -825,7 +825,7 @@ mod tests {
 
             let tree = repo.find_tree(id).unwrap();
             let sig = repo.signature().unwrap();
-            repo.new_commit(
+            repo.commit_new(
                 Some("HEAD"),
                 &sig,
                 &sig,

--- a/src/build.rs
+++ b/src/build.rs
@@ -754,7 +754,7 @@ impl TreeUpdateBuilder {
 #[cfg(test)]
 mod tests {
     use super::{CheckoutBuilder, RepoBuilder, TreeUpdateBuilder};
-    use crate::{CheckoutNotificationType, FileMode, Repository};
+    use crate::{CheckoutNotificationType, Commit, FileMode, Repository};
     use std::fs;
     use std::path::Path;
     use tempfile::TempDir;
@@ -825,8 +825,15 @@ mod tests {
 
             let tree = repo.find_tree(id).unwrap();
             let sig = repo.signature().unwrap();
-            repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
-                .unwrap();
+            repo.new_commit(
+                Some("HEAD"),
+                &sig,
+                &sig,
+                "initial",
+                &tree,
+                &[] as &[Commit<'_>],
+            )
+            .unwrap();
         }
 
         let repo = Repository::open_bare(&td.path().join(".git")).unwrap();

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -379,6 +379,12 @@ impl<'commit> DoubleEndedIterator for ParentIds<'commit> {
 
 impl<'commit> ExactSizeIterator for ParentIds<'commit> {}
 
+impl<'repo> AsRef<Commit<'repo>> for Commit<'repo> {
+    fn as_ref(&self) -> &Self {
+        &self
+    }
+}
+
 impl<'repo> Clone for Commit<'repo> {
     fn clone(&self) -> Self {
         self.as_object().clone().into_commit().ok().unwrap()
@@ -422,7 +428,7 @@ mod tests {
         let sig = repo.signature().unwrap();
         let tree = repo.find_tree(commit.tree_id()).unwrap();
         let id = repo
-            .commit(Some("HEAD"), &sig, &sig, "bar", &tree, &[&commit])
+            .new_commit(Some("HEAD"), &sig, &sig, "bar", &tree, &[&commit])
             .unwrap();
         let head = repo.find_commit(id).unwrap();
 

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -428,7 +428,7 @@ mod tests {
         let sig = repo.signature().unwrap();
         let tree = repo.find_tree(commit.tree_id()).unwrap();
         let id = repo
-            .new_commit(Some("HEAD"), &sig, &sig, "bar", &tree, &[&commit])
+            .commit_new(Some("HEAD"), &sig, &sig, "bar", &tree, &[&commit])
             .unwrap();
         let head = repo.find_commit(id).unwrap();
 

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1758,7 +1758,7 @@ mod tests {
         let time = Time::new(64_000_000, 0);
         let author = Signature::new("Techcable", "dummy@dummy.org", &time).unwrap();
         let updated_commit = repo
-            .new_commit(
+            .commit_new(
                 None,
                 &author,
                 &author,

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1542,7 +1542,7 @@ impl DiffPatchidOptions {
 
 #[cfg(test)]
 mod tests {
-    use crate::{DiffLineType, DiffOptions, Oid, Signature, Time};
+    use crate::{Commit, DiffLineType, DiffOptions, Oid, Signature, Time};
     use std::borrow::Borrow;
     use std::fs::File;
     use std::io::Write;
@@ -1758,13 +1758,13 @@ mod tests {
         let time = Time::new(64_000_000, 0);
         let author = Signature::new("Techcable", "dummy@dummy.org", &time).unwrap();
         let updated_commit = repo
-            .commit(
+            .new_commit(
                 None,
                 &author,
                 &author,
                 COMMIT_MESSAGE,
                 &repo.find_tree(updated_tree).unwrap(),
-                &[], // NOTE: Have no parents to ensure stable hash
+                &[] as &[Commit<'_>], // NOTE: Have no parents to ensure stable hash
             )
             .unwrap();
         let updated_commit = repo.find_commit(updated_commit).unwrap();

--- a/src/index.rs
+++ b/src/index.rs
@@ -835,7 +835,7 @@ mod tests {
         let id = repo.refname_to_id("HEAD").unwrap();
         let parent = repo.find_commit(id).unwrap();
         let commit = repo
-            .commit(Some("HEAD"), &sig, &sig, "commit", &tree, &[&parent])
+            .new_commit(Some("HEAD"), &sig, &sig, "commit", &tree, &[&parent])
             .unwrap();
         let obj = repo.find_object(commit, None).unwrap();
         repo.reset(&obj, ResetType::Hard, None).unwrap();

--- a/src/index.rs
+++ b/src/index.rs
@@ -835,7 +835,7 @@ mod tests {
         let id = repo.refname_to_id("HEAD").unwrap();
         let parent = repo.find_commit(id).unwrap();
         let commit = repo
-            .new_commit(Some("HEAD"), &sig, &sig, "commit", &tree, &[&parent])
+            .commit_new(Some("HEAD"), &sig, &sig, "commit", &tree, &[&parent])
             .unwrap();
         let obj = repo.find_object(commit, None).unwrap();
         repo.reset(&obj, ResetType::Hard, None).unwrap();

--- a/src/rebase.rs
+++ b/src/rebase.rs
@@ -349,11 +349,11 @@ mod tests {
         // We just want to see the iteration work so we can create commits with
         // no changes
         let c1 = repo
-            .new_commit(Some("refs/heads/main"), &sig, &sig, "foo", &tree, &[&tip])
+            .commit_new(Some("refs/heads/main"), &sig, &sig, "foo", &tree, &[&tip])
             .unwrap();
         let c1 = repo.find_commit(c1).unwrap();
         let c2 = repo
-            .new_commit(Some("refs/heads/main"), &sig, &sig, "foo", &tree, &[&c1])
+            .commit_new(Some("refs/heads/main"), &sig, &sig, "foo", &tree, &[&c1])
             .unwrap();
 
         let head = repo.find_reference("refs/heads/main").unwrap();
@@ -397,7 +397,7 @@ mod tests {
         let tree_id_a = index.write_tree().unwrap();
         let tree_a = repo.find_tree(tree_id_a).unwrap();
         let c1 = repo
-            .new_commit(Some("refs/heads/main"), &sig, &sig, "A", &tree_a, &[&tip])
+            .commit_new(Some("refs/heads/main"), &sig, &sig, "A", &tree_a, &[&tip])
             .unwrap();
         let c1 = repo.find_commit(c1).unwrap();
 
@@ -407,7 +407,7 @@ mod tests {
         let tree_id_b = index.write_tree().unwrap();
         let tree_b = repo.find_tree(tree_id_b).unwrap();
         let c2 = repo
-            .new_commit(Some("refs/heads/main"), &sig, &sig, "B", &tree_b, &[c1])
+            .commit_new(Some("refs/heads/main"), &sig, &sig, "B", &tree_b, &[c1])
             .unwrap();
 
         let branch = repo.find_annotated_commit(c2).unwrap();

--- a/src/rebase.rs
+++ b/src/rebase.rs
@@ -349,11 +349,11 @@ mod tests {
         // We just want to see the iteration work so we can create commits with
         // no changes
         let c1 = repo
-            .commit(Some("refs/heads/main"), &sig, &sig, "foo", &tree, &[&tip])
+            .new_commit(Some("refs/heads/main"), &sig, &sig, "foo", &tree, &[&tip])
             .unwrap();
         let c1 = repo.find_commit(c1).unwrap();
         let c2 = repo
-            .commit(Some("refs/heads/main"), &sig, &sig, "foo", &tree, &[&c1])
+            .new_commit(Some("refs/heads/main"), &sig, &sig, "foo", &tree, &[&c1])
             .unwrap();
 
         let head = repo.find_reference("refs/heads/main").unwrap();
@@ -397,7 +397,7 @@ mod tests {
         let tree_id_a = index.write_tree().unwrap();
         let tree_a = repo.find_tree(tree_id_a).unwrap();
         let c1 = repo
-            .commit(Some("refs/heads/main"), &sig, &sig, "A", &tree_a, &[&tip])
+            .new_commit(Some("refs/heads/main"), &sig, &sig, "A", &tree_a, &[&tip])
             .unwrap();
         let c1 = repo.find_commit(c1).unwrap();
 
@@ -407,7 +407,7 @@ mod tests {
         let tree_id_b = index.write_tree().unwrap();
         let tree_b = repo.find_tree(tree_id_b).unwrap();
         let c2 = repo
-            .commit(Some("refs/heads/main"), &sig, &sig, "B", &tree_b, &[&c1])
+            .new_commit(Some("refs/heads/main"), &sig, &sig, "B", &tree_b, &[c1])
             .unwrap();
 
         let branch = repo.find_annotated_commit(c2).unwrap();

--- a/src/test.rs
+++ b/src/test.rs
@@ -6,7 +6,7 @@ use std::ptr;
 use tempfile::TempDir;
 use url::Url;
 
-use crate::{Branch, Oid, Repository, RepositoryInitOptions};
+use crate::{Branch, Commit, Oid, Repository, RepositoryInitOptions};
 
 macro_rules! t {
     ($e:expr) => {
@@ -31,8 +31,15 @@ pub fn repo_init() -> (TempDir, Repository) {
 
         let tree = repo.find_tree(id).unwrap();
         let sig = repo.signature().unwrap();
-        repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
-            .unwrap();
+        repo.new_commit(
+            Some("HEAD"),
+            &sig,
+            &sig,
+            "initial",
+            &tree,
+            &[] as &[Commit<'_>],
+        )
+        .unwrap();
     }
     (td, repo)
 }
@@ -48,7 +55,7 @@ pub fn commit(repo: &Repository) -> (Oid, Oid) {
     let sig = t!(repo.signature());
     let head_id = t!(repo.refname_to_id("HEAD"));
     let parent = t!(repo.find_commit(head_id));
-    let commit = t!(repo.commit(Some("HEAD"), &sig, &sig, "commit", &tree, &[&parent]));
+    let commit = t!(repo.new_commit(Some("HEAD"), &sig, &sig, "commit", &tree, &[&parent]));
     (commit, tree_id)
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -31,7 +31,7 @@ pub fn repo_init() -> (TempDir, Repository) {
 
         let tree = repo.find_tree(id).unwrap();
         let sig = repo.signature().unwrap();
-        repo.new_commit(
+        repo.commit_new(
             Some("HEAD"),
             &sig,
             &sig,
@@ -55,7 +55,7 @@ pub fn commit(repo: &Repository) -> (Oid, Oid) {
     let sig = t!(repo.signature());
     let head_id = t!(repo.refname_to_id("HEAD"));
     let parent = t!(repo.find_commit(head_id));
-    let commit = t!(repo.new_commit(Some("HEAD"), &sig, &sig, "commit", &tree, &[&parent]));
+    let commit = t!(repo.commit_new(Some("HEAD"), &sig, &sig, "commit", &tree, &[&parent]));
     (commit, tree_id)
 }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -482,7 +482,7 @@ mod tests {
         let parent = repo
             .find_commit(repo.head().unwrap().target().unwrap())
             .unwrap();
-        repo.commit(
+        repo.new_commit(
             Some("HEAD"),
             &sig,
             &sig,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -482,7 +482,7 @@ mod tests {
         let parent = repo
             .find_commit(repo.head().unwrap().target().unwrap())
             .unwrap();
-        repo.new_commit(
+        repo.commit_new(
             Some("HEAD"),
             &sig,
             &sig,


### PR DESCRIPTION
The existing method doesn't accept owned commits as parameters in
Repository::commit. This new method allows for both owned and unowned
versions of the slice, which will simplify passing in Vectors
containing owned values as well as retain backwards compatibility in
_most_ cases (unfortunately, an empty slice still needs a type specified if passed).


Fixes https://github.com/rust-lang/git2-rs/issues/140, which specifies the issue in more detail.