### PR TITLE
Update build.rs

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -28,7 +28,7 @@ use crate::{CheckoutNotificationType, DiffFile, FileMode, Remote};
 ///     Cred::ssh_key(
 ///       username_from_url.unwrap(),
 ///       None,
-///       std::path::Path::new(&format!("{}/.ssh/id_rsa", env::var("HOME").unwrap())),
+///       Path::new(&format!("{}/.ssh/id_rsa", env::var("HOME").unwrap())),
 ///       None,
 ///     )
 ///   });


### PR DESCRIPTION
std::path::Path is already imported for use towards the bottom of the example. No point in using a fully qualified path