### PR TITLE
Harmonize commitish and committish in docstrings

### DIFF
--- a/src/repo.rs
+++ b/src/repo.rs
@@ -811,7 +811,7 @@ impl Repository {
 
     /// Make the repository HEAD directly point to the commit.
     ///
-    /// If the provided committish cannot be found in the repository, the HEAD
+    /// If the provided commitish cannot be found in the repository, the HEAD
     /// is unaltered and an error is returned.
     ///
     /// If the provided commitish cannot be peeled into a commit, the HEAD is
@@ -831,7 +831,7 @@ impl Repository {
 
     /// Make the repository HEAD directly point to the commit.
     ///
-    /// If the provided committish cannot be found in the repository, the HEAD
+    /// If the provided commitish cannot be found in the repository, the HEAD
     /// is unaltered and an error is returned.
     /// If the provided commitish cannot be peeled into a commit, the HEAD is
     /// unaltered and an error is returned.

--- a/src/revwalk.rs
+++ b/src/revwalk.rs
@@ -81,7 +81,7 @@ impl<'repo> Revwalk<'repo> {
 
     /// Mark a commit to start traversal from.
     ///
-    /// The given OID must belong to a committish on the walked repository.
+    /// The given OID must belong to a commitish on the walked repository.
     ///
     /// The given commit will be used as one of the roots when starting the
     /// revision walk. At least one commit must be pushed onto the walker before
@@ -111,7 +111,7 @@ impl<'repo> Revwalk<'repo> {
     /// A leading 'refs/' is implied if not present as well as a trailing `/ \
     /// *` if the glob lacks '?', ' \ *' or '['.
     ///
-    /// Any references matching this glob which do not point to a committish
+    /// Any references matching this glob which do not point to a commitish
     /// will be ignored.
     pub fn push_glob(&mut self, glob: &str) -> Result<(), Error> {
         let glob = CString::new(glob)?;
@@ -136,7 +136,7 @@ impl<'repo> Revwalk<'repo> {
 
     /// Push the OID pointed to by a reference
     ///
-    /// The reference must point to a committish.
+    /// The reference must point to a commitish.
     pub fn push_ref(&mut self, reference: &str) -> Result<(), Error> {
         let reference = CString::new(reference)?;
         unsafe {
@@ -194,7 +194,7 @@ impl<'repo> Revwalk<'repo> {
     /// A leading 'refs/' is implied if not present as well as a trailing `/ \
     /// *` if the glob lacks '?', ' \ *' or '['.
     ///
-    /// Any references matching this glob which do not point to a committish
+    /// Any references matching this glob which do not point to a commitish
     /// will be ignored.
     pub fn hide_glob(&mut self, glob: &str) -> Result<(), Error> {
         let glob = CString::new(glob)?;
@@ -206,7 +206,7 @@ impl<'repo> Revwalk<'repo> {
 
     /// Hide the OID pointed to by a reference.
     ///
-    /// The reference must point to a committish.
+    /// The reference must point to a commitish.
     pub fn hide_ref(&mut self, reference: &str) -> Result<(), Error> {
         let reference = CString::new(reference)?;
         unsafe {


### PR DESCRIPTION
The git glossary mentions both verions. However in-code, only the first
variant is used. This commit harmonizes the usages:
https://git-scm.com/docs/gitglossary#Documentation/
gitglossary.txt-aiddefcommit-ishacommit-ishalsocommittish