### PR TITLE
`libgit2-sys`: use `src` instead `.git` as vendored indicator

### DIFF
--- a/libgit2-sys/build.rs
+++ b/libgit2-sys/build.rs
@@ -24,7 +24,7 @@ fn main() {
 
     println!("cargo:rustc-cfg=libgit2_vendored");
 
-    if !Path::new("libgit2/.git").exists() {
+    if !Path::new("libgit2/src").exists() {
         let _ = Command::new("git")
             .args(&["submodule", "update", "--init", "libgit2"])
             .status();


### PR DESCRIPTION
When someone vendored `libgit2-sys` he may exclude `.git` folder.

When such things happened an attempt to build it may lead to error like: `fatal: not a git repository (or any of the parent directories): .git`.

The only way to fix it is using system's `libgit2` which may lead to `invalid version 0 on git_proxy_options; class=Invalid (3)` at some cases.