### PR TITLE
clarify license

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "git2"
 version = "0.13.25"
 authors = ["Josh Triplett <josh@joshtriplett.org>", "Alex Crichton <alex@alexcrichton.com>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 readme = "README.md"
 keywords = ["git"]
 repository = "https://github.com/rust-lang/git2-rs"

--- a/git2-curl/Cargo.toml
+++ b/git2-curl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "git2-curl"
 version = "0.14.1"
 authors = ["Josh Triplett <josh@joshtriplett.org>", "Alex Crichton <alex@alexcrichton.com>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/git2-rs"
 documentation = "https://docs.rs/git2-curl"
 description = """

--- a/libgit2-sys/Cargo.toml
+++ b/libgit2-sys/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Josh Triplett <josh@joshtriplett.org>", "Alex Crichton <alex@alexcri
 links = "git2"
 build = "build.rs"
 repository = "https://github.com/rust-lang/git2-rs"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 description = "Native bindings to the libgit2 library"
 exclude = [
     "libgit2/ci/*",


### PR DESCRIPTION
Per <https://doc.rust-lang.org/cargo/reference/manifest.html#slash>

> Previously multiple licenses could be separated with a /, but that usage is deprecated.

pretty sure from the README that your intention is OR rather than AND, I guess this form makes that clear