### PR TITLE
Update to 1.4.1 and bump versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing
+
+## Updating libgit2
+
+The following steps can be used to update libgit2:
+
+1. Update the submodule.
+   There are several ways to go about this.
+   One way is to go to the `libgit2-sys/libgit2` directory and run `git fetch origin` to download the latest updates, and then check out a specific tag (such as `git checkout v1.4.1`).
+2. Update all the references to the version:
+    * Update [`libgit2-sys/build.rs`](https://github.com/rust-lang/git2-rs/blob/master/libgit2-sys/build.rs).
+      There is a version probe (search for `cfg.atleast_version`) which should be updated.
+    * Update the version in
+      [`libgit2-sys/Cargo.toml`](https://github.com/rust-lang/git2-rs/blob/master/libgit2-sys/Cargo.toml).
+      Update the metadata portion (the part after the `+`) to match libgit2.
+      Also bump the Cargo version (the part before the `+`), keeping in mind
+      if this will be a SemVer breaking change or not.
+    * Update the dependency version in [`Cargo.toml`](https://github.com/rust-lang/git2-rs/blob/master/Cargo.toml) to match the version in the last step (do not include the `+` metadata).
+      Also update the version of the `git2` crate itself so it will pick up the change to `libgit2-sys` (also keeping in mind if it is a SemVer breaking release).
+    * Update the version in [`README.md`](https://github.com/rust-lang/git2-rs/blob/master/README.md) if needed.
+    * If there was a SemVer-breaking version bump for either library, also update the `html_root_url` attribute in the `lib.rs` of each library.
+3. Run tests.
+   `cargo test -p git2 -p git2-curl` is a good starting point.
+4. Run `systest`.
+   This will validate for any C-level API problems.
+   Unfortunately `systest` does not work on nightly, so you'll need to use stable.
+
+   `cargo +stable run -p systest`
+
+   The changelog at <https://github.com/libgit2/libgit2/blob/main/docs/changelog.md>
+   can be helpful for seeing what has changed.
+   The project has recently started labeling API and ABI breaking changes with labels:
+   <https://github.com/libgit2/libgit2/pulls?q=is%3Apr+label%3A%22api+breaking%22%2C%22abi+breaking%22+is%3Aclosed>
+4. Once you have everything functional, publish a PR with the updates.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git2"
-version = "0.13.25"
+version = "0.14.0"
 authors = ["Josh Triplett <josh@joshtriplett.org>", "Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -20,7 +20,7 @@ url = "2.0"
 bitflags = "1.1.0"
 libc = "0.2"
 log = "0.4.8"
-libgit2-sys = { path = "libgit2-sys", version = "0.12.26" }
+libgit2-sys = { path = "libgit2-sys", version = "0.13.0" }
 
 [target."cfg(all(unix, not(target_os = \"macos\")))".dependencies]
 openssl-sys = { version = "0.9.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ stable release as well.
 
 ## Version of libgit2
 
-Currently this library requires libgit2 1.4.0. The source for libgit2 is
+Currently this library requires libgit2 1.4. The source for libgit2 is
 included in the libgit2-sys crate so there's no need to pre-install the libgit2
 library, the libgit2-sys crate will figure that and/or build that for you.
 

--- a/git2-curl/Cargo.toml
+++ b/git2-curl/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 curl = "0.4.33"
 url = "2.0"
 log = "0.4"
-git2 = { path = "..", version = "0.13", default-features = false }
+git2 = { path = "..", version = "0.14", default-features = false }
 
 [dev-dependencies]
 civet = "0.11"

--- a/libgit2-sys/Cargo.toml
+++ b/libgit2-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libgit2-sys"
-version = "0.12.26+1.4.0"
+version = "0.13.0+1.4.1"
 authors = ["Josh Triplett <josh@joshtriplett.org>", "Alex Crichton <alex@alexcrichton.com>"]
 links = "git2"
 build = "build.rs"

--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/libgit2-sys/0.12")]
+#![doc(html_root_url = "https://docs.rs/libgit2-sys/0.13")]
 #![allow(non_camel_case_types, unused_extern_crates)]
 
 // This is required to link libz when libssh2-sys is not included.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@
 //! source `Repository`, to ensure that they do not outlive the repository
 //! itself.
 
-#![doc(html_root_url = "https://docs.rs/git2/0.13")]
+#![doc(html_root_url = "https://docs.rs/git2/0.14")]
 #![allow(trivial_numeric_casts, trivial_casts)]
 #![deny(missing_docs)]
 #![warn(rust_2018_idioms)]


### PR DESCRIPTION
This updates libgit2 to 1.4.1, and bumps the Cargo versions as a SemVer breaking change.

This also includes a file with instructions on how to do a libgit2 update.