### PR TITLE
Bump version of git2-curl

### DIFF
--- a/git2-curl/Cargo.toml
+++ b/git2-curl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git2-curl"
-version = "0.14.1"
+version = "0.15.0"
 authors = ["Josh Triplett <josh@joshtriplett.org>", "Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rust-lang/git2-rs"

--- a/git2-curl/src/lib.rs
+++ b/git2-curl/src/lib.rs
@@ -15,7 +15,7 @@
 //! > **NOTE**: At this time this crate likely does not support a `git push`
 //! >           operation, only clones.
 
-#![doc(html_root_url = "https://docs.rs/git2-curl/0.14")]
+#![doc(html_root_url = "https://docs.rs/git2-curl/0.15")]
 #![deny(missing_docs)]
 #![warn(rust_2018_idioms)]
 #![cfg_attr(test, deny(warnings))]


### PR DESCRIPTION
It needs a SemVer breaking bump because the version of underlying git2/libgit2-sys changes.

