### PR TITLE
Add config level for worktrees

### DIFF
--- a/libgit2-sys/build.rs
+++ b/libgit2-sys/build.rs
@@ -180,7 +180,7 @@ The build is now aborting. To disable, unset the variable or use `LIBGIT2_NO_VEN
             cfg.include(path);
         }
         features.push_str("#define GIT_SSH 1\n");
-        features.push_str("#define GIT_SSH_MEMORY_CREDENTIALS 1\n");
+        features.push_str("#define GIT_SSH_LIBSSH2_MEMORY_CREDENTIALS 1\n");
     }
     if https {
         features.push_str("#define GIT_HTTPS 1\n");

--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -981,6 +981,7 @@ pub struct git_push_options {
     pub proxy_opts: git_proxy_options,
     pub follow_redirects: git_remote_redirect_t,
     pub custom_headers: git_strarray,
+    pub remote_push_options: git_strarray,
 }
 
 pub type git_tag_foreach_cb =

--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -868,7 +868,8 @@ git_enum! {
         GIT_CONFIG_LEVEL_XDG = 3,
         GIT_CONFIG_LEVEL_GLOBAL = 4,
         GIT_CONFIG_LEVEL_LOCAL = 5,
-        GIT_CONFIG_LEVEL_APP = 6,
+        GIT_CONFIG_LEVEL_WORKTREE = 6,
+        GIT_CONFIG_LEVEL_APP = 7,
         GIT_CONFIG_HIGHEST_LEVEL = -1,
     }
 }

--- a/src/call.rs
+++ b/src/call.rs
@@ -166,6 +166,7 @@ mod impls {
                 ConfigLevel::XDG => raw::GIT_CONFIG_LEVEL_XDG,
                 ConfigLevel::Global => raw::GIT_CONFIG_LEVEL_GLOBAL,
                 ConfigLevel::Local => raw::GIT_CONFIG_LEVEL_LOCAL,
+                ConfigLevel::Worktree => raw::GIT_CONFIG_LEVEL_WORKTREE,
                 ConfigLevel::App => raw::GIT_CONFIG_LEVEL_APP,
                 ConfigLevel::Highest => raw::GIT_CONFIG_HIGHEST_LEVEL,
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -385,6 +385,8 @@ pub enum ConfigLevel {
     Global,
     /// Repository specific config, e.g. $PWD/.git/config
     Local,
+    /// Worktree-specific config, e.g. $GIT_DIR/config.worktree
+    Worktree,
     /// Application specific configuration file
     App,
     /// Highest level available
@@ -963,6 +965,7 @@ impl ConfigLevel {
             raw::GIT_CONFIG_LEVEL_XDG => ConfigLevel::XDG,
             raw::GIT_CONFIG_LEVEL_GLOBAL => ConfigLevel::Global,
             raw::GIT_CONFIG_LEVEL_LOCAL => ConfigLevel::Local,
+            raw::GIT_CONFIG_LEVEL_WORKTREE => ConfigLevel::Worktree,
             raw::GIT_CONFIG_LEVEL_APP => ConfigLevel::App,
             raw::GIT_CONFIG_HIGHEST_LEVEL => ConfigLevel::Highest,
             n => panic!("unknown config level: {}", n),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -959,7 +959,8 @@ impl fmt::Display for ReferenceType {
 impl ConfigLevel {
     /// Converts a raw configuration level to a ConfigLevel
     pub fn from_raw(raw: raw::git_config_level_t) -> ConfigLevel {
-        match raw {
+        match raw >> 12 {
+            // TODO: why!?
             raw::GIT_CONFIG_LEVEL_PROGRAMDATA => ConfigLevel::ProgramData,
             raw::GIT_CONFIG_LEVEL_SYSTEM => ConfigLevel::System,
             raw::GIT_CONFIG_LEVEL_XDG => ConfigLevel::XDG,

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -58,6 +58,8 @@ pub struct PushOptions<'cb> {
     follow_redirects: RemoteRedirect,
     custom_headers: Vec<CString>,
     custom_headers_ptrs: Vec<*const c_char>,
+    remote_push_options: Vec<CString>,
+    remote_push_options_ptrs: Vec<*const c_char>,
 }
 
 /// Holds callbacks for a connection to a `Remote`. Disconnects when dropped
@@ -628,6 +630,8 @@ impl<'cb> PushOptions<'cb> {
             follow_redirects: RemoteRedirect::Initial,
             custom_headers: Vec::new(),
             custom_headers_ptrs: Vec::new(),
+            remote_push_options: Vec::new(),
+            remote_push_options_ptrs: Vec::new(),
         }
     }
 
@@ -673,6 +677,16 @@ impl<'cb> PushOptions<'cb> {
         self.custom_headers_ptrs = self.custom_headers.iter().map(|s| s.as_ptr()).collect();
         self
     }
+
+    /// Set server-side options for this push operation.
+    pub fn remote_push_options(&mut self, remote_push_options: &[&str]) -> &mut Self {
+        self.remote_push_options = remote_push_options
+            .iter()
+            .map(|&s| CString::new(s).unwrap())
+            .collect();
+        self.remote_push_options_ptrs = self.remote_push_options.iter().map(|s| s.as_ptr()).collect();
+        self
+    }
 }
 
 impl<'cb> Binding for PushOptions<'cb> {
@@ -699,6 +713,10 @@ impl<'cb> Binding for PushOptions<'cb> {
             custom_headers: git_strarray {
                 count: self.custom_headers_ptrs.len(),
                 strings: self.custom_headers_ptrs.as_ptr() as *mut _,
+            },
+            remote_push_options: git_strarray {
+                count: self.remote_push_options_ptrs.len(),
+                strings: self.remote_push_options_ptrs.as_ptr() as *mut _,
             },
         }
     }

--- a/tests/add_extensions.rs
+++ b/tests/add_extensions.rs
@@ -11,11 +11,12 @@ fn test_add_extensions() -> Result<(), Error> {
 
     let extensions = unsafe { get_extensions() }?;
 
-    assert_eq!(extensions.len(), 3);
+    assert_eq!(extensions.len(), 4);
     assert_eq!(extensions.get(0), Some("custom"));
     // The objectformat extension was added in 1.6
     assert_eq!(extensions.get(1), Some("noop"));
     assert_eq!(extensions.get(2), Some("objectformat"));
+    assert_eq!(extensions.get(3), Some("worktreeconfig"));
 
     Ok(())
 }

--- a/tests/get_extensions.rs
+++ b/tests/get_extensions.rs
@@ -7,10 +7,11 @@ use git2::Error;
 fn test_get_extensions() -> Result<(), Error> {
     let extensions = unsafe { get_extensions() }?;
 
-    assert_eq!(extensions.len(), 2);
+    assert_eq!(extensions.len(), 3);
     assert_eq!(extensions.get(0), Some("noop"));
     // The objectformat extension was added in 1.6
     assert_eq!(extensions.get(1), Some("objectformat"));
+    assert_eq!(extensions.get(2), Some("worktreeconfig"));
 
     Ok(())
 }

--- a/tests/remove_extensions.rs
+++ b/tests/remove_extensions.rs
@@ -11,9 +11,10 @@ fn test_remove_extensions() -> Result<(), Error> {
 
     let extensions = unsafe { get_extensions() }?;
 
-    assert_eq!(extensions.len(), 2);
+    assert_eq!(extensions.len(), 3);
     assert_eq!(extensions.get(0), Some("custom"));
     assert_eq!(extensions.get(1), Some("other"));
+    assert_eq!(extensions.get(2), Some("worktreeconfig"));
 
     Ok(())
 }


### PR DESCRIPTION
This uses the new support in libgit2 for [the worktree-config extension][1].

[1]: https://git-scm.com/docs/git-worktree/2.35.1#_configuration_file

See also https://github.com/libgit2/libgit2/pull/6202.

---

I suspect there is more work to be done on this PR, but I wanted to create it for tracking purposes. Tasks I can tell are coming:

- [ ] once the upstream PR is merged, update the libgit2 submodule
- [x] add unit tests around worktree-level config
  - no unit tests current exist for checking different levels of config
- [x] determine if documentation needs updating
  - no special documentation exists mentioning the `ConfigLevel` enum
- [x] determine if any libgit2/git2-rs glue code needs updating