### PR TITLE
Respect libgit2's ABI instability

### DIFF
--- a/libgit2-sys/build.rs
+++ b/libgit2-sys/build.rs
@@ -14,7 +14,7 @@ fn main() {
     let try_to_use_system_libgit2 = !vendored && !zlib_ng_compat;
     if try_to_use_system_libgit2 {
         let mut cfg = pkg_config::Config::new();
-        if let Ok(lib) = cfg.atleast_version("1.4.0").probe("libgit2") {
+        if let Ok(lib) = cfg.range_version("1.4.0".."1.5.0").probe("libgit2") {
             for include in &lib.include_paths {
                 println!("cargo:root={}", include.display());
             }


### PR DESCRIPTION
Notably this PR does _not_ close the mentioned issues. The problem there is that old versions of this library become broken when the system version of the library moves on. All I can suggest is that maybe old versions of this library might be better yanked or with this fix backported.

libgit2 does not have a stable ABI across minor versions, as has been
demonstrated in the last few minor releases, see #813 and #746. This
pain is primarily suffered by users of rolling release distros, because
they tend to get a new libgit2 version before the authors of libraries
release versions that pull in the new libgit2-sys version which works
with the new binary. (see also https://github.com/rust-lang/crater/pull/598)

This patch means that going forward, users don't need to rush to
upgrade their version of libgit2-sys or suffer errors/UB in the
meantime. If the system version changes, they will just start using
the vendored version which has been tested against the bindings.