### PR TITLE
Add binding for git_odb_exists_ext

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -1511,6 +1511,12 @@ pub struct git_odb_backend {
     pub free: Option<extern "C" fn(*mut git_odb_backend)>,
 }
 
+git_enum! {
+    pub enum git_odb_lookup_flags_t {
+        GIT_ODB_LOOKUP_NO_REFRESH = 1 << 0,
+    }
+}
+
 #[repr(C)]
 pub struct git_odb_writepack {
     pub backend: *mut git_odb_backend,
@@ -3836,6 +3842,7 @@ extern "C" {
     ) -> c_int;
 
     pub fn git_odb_exists(odb: *mut git_odb, oid: *const git_oid) -> c_int;
+    pub fn git_odb_exists_ext(odb: *mut git_odb, oid: *const git_oid, flags: c_uint) -> c_int;
 
     pub fn git_odb_refresh(odb: *mut git_odb) -> c_int;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -637,6 +637,17 @@ impl MergePreference {
     is_bit_set!(is_fastforward_only, MergePreference::FASTFORWARD_ONLY);
 }
 
+bitflags! {
+    /// Flags controlling the behavior of ODB lookup operations
+    pub struct OdbLookupFlags: u32 {
+        /// Don't call `git_odb_refresh` if the lookup fails. Useful when doing
+        /// a batch of lookup operations for objects that may legitimately not
+        /// exist. When using this flag, you may wish to manually call
+        /// `git_odb_refresh` before processing a batch of objects.
+        const NO_REFRESH = raw::GIT_ODB_LOOKUP_NO_REFRESH as u32;
+    }
+}
+
 #[cfg(test)]
 #[macro_use]
 mod test;

--- a/src/odb.rs
+++ b/src/odb.rs
@@ -6,11 +6,13 @@ use std::slice;
 
 use std::ffi::CString;
 
-use libc::{c_char, c_int, c_void, size_t};
+use libc::{c_char, c_int, c_uint, c_void, size_t};
 
 use crate::panic;
 use crate::util::Binding;
-use crate::{raw, Error, IndexerProgress, Mempack, Object, ObjectType, Oid, Progress};
+use crate::{
+    raw, Error, IndexerProgress, Mempack, Object, ObjectType, OdbLookupFlags, Oid, Progress,
+};
 
 /// A structure to represent a git object database
 pub struct Odb<'repo> {
@@ -184,6 +186,11 @@ impl<'repo> Odb<'repo> {
     /// Checks if the object database has an object.
     pub fn exists(&self, oid: Oid) -> bool {
         unsafe { raw::git_odb_exists(self.raw, oid.raw()) != 0 }
+    }
+
+    /// Checks if the object database has an object, with extended flags.
+    pub fn exists_ext(&self, oid: Oid, flags: OdbLookupFlags) -> bool {
+        unsafe { raw::git_odb_exists_ext(self.raw, oid.raw(), flags.bits() as c_uint) != 0 }
     }
 
     /// Potentially finds an object that starts with the given prefix.


### PR DESCRIPTION
This allows checking for the existence of an object without refreshing
the ODB if the lookup fails. Useful when doing a batch of lookup
operations for objects that may legitimately not exist.
