### PR TITLE
remote: remove unnecessary mutable borrow of FetchOptions

### DIFF
--- a/src/remote.rs
+++ b/src/remote.rs
@@ -233,7 +233,7 @@ impl<'repo> Remote<'repo> {
     pub fn download<Str: AsRef<str> + crate::IntoCString + Clone>(
         &mut self,
         specs: &[Str],
-        opts: Option<&mut FetchOptions<'_>>,
+        opts: Option<FetchOptions<'_>>,
     ) -> Result<(), Error> {
         let (_a, _b, arr) = crate::util::iter2cstrs(specs.iter())?;
         let raw = opts.map(|o| o.raw());
@@ -293,7 +293,7 @@ impl<'repo> Remote<'repo> {
     pub fn fetch<Str: AsRef<str> + crate::IntoCString + Clone>(
         &mut self,
         refspecs: &[Str],
-        opts: Option<&mut FetchOptions<'_>>,
+        opts: Option<FetchOptions<'_>>,
         reflog_msg: Option<&str>,
     ) -> Result<(), Error> {
         let (_a, _b, arr) = crate::util::iter2cstrs(refspecs.iter())?;


### PR DESCRIPTION
Fetch and download seem to be requesting a mutable borrow of FetchOptions but it is not necessary.

These appear confusing and not consistent with how FetchOptions should be dealt with, looking for example at RepoBuilder, where it accepts an owned value.

With this change, people will deal with a more consistent interface.