### PR TITLE
Don't let pkg-config add system lib dirs to the search path

### DIFF
--- a/libgit2-sys/build.rs
+++ b/libgit2-sys/build.rs
@@ -14,7 +14,7 @@ fn main() {
     let try_to_use_system_libgit2 = !vendored && !zlib_ng_compat;
     if try_to_use_system_libgit2 {
         let mut cfg = pkg_config::Config::new();
-        if let Ok(lib) = cfg.range_version("1.4.0".."1.5.0").probe("libgit2") {
+        if let Ok(lib) = cfg.range_version("1.4.0".."1.5.0").print_system_libs(false).probe("libgit2") {
             for include in &lib.include_paths {
                 println!("cargo:root={}", include.display());
             }

--- a/libgit2-sys/build.rs
+++ b/libgit2-sys/build.rs
@@ -14,7 +14,11 @@ fn main() {
     let try_to_use_system_libgit2 = !vendored && !zlib_ng_compat;
     if try_to_use_system_libgit2 {
         let mut cfg = pkg_config::Config::new();
-        if let Ok(lib) = cfg.range_version("1.4.0".."1.5.0").print_system_libs(false).probe("libgit2") {
+        if let Ok(lib) = cfg
+            .range_version("1.4.0".."1.5.0")
+            .print_system_libs(false)
+            .probe("libgit2")
+        {
             for include in &lib.include_paths {
                 println!("cargo:root={}", include.display());
             }


### PR DESCRIPTION
In its default configuration, pkg-config adds system-wide library
directories to the linker search path (rust-lang/pkg-config-rs#11).
This causes these directories to be searched before other paths added
by later crates or by -Clink-arg in rustflags. If a library is present in
the system-wide directory and a later build step wants to specifically
link against a different version of that library in another path, the linker
will choose the library from the first search directory it finds. If the linker
doesn't find a library in any of the specified search directories, it falls
back on system-wide paths, so we don't need to print the
path we found libssh2 in if it is in one of those system paths.

See rust-lang/libz-sys#50 for the same fix to libz that landed a while back.
See also alexcrichton/curl-rust#441 for the same fix to libcurl-sys.