### PR TITLE
Avoid unconditional dependency on libssh2-sys when using zlib-ng-compat

### DIFF
--- a/libgit2-sys/Cargo.toml
+++ b/libgit2-sys/Cargo.toml
@@ -38,9 +38,4 @@ https = ["openssl-sys"]
 ssh_key_from_memory = []
 vendored = []
 vendored-openssl = ["openssl-sys/vendored"]
-# Cargo does not support requiring features on an optional dependency without
-# requiring the dependency. Rather than introduce additional complexity, we
-# just require libssh2 when using zlib-ng-compat. This will require building
-# libssh2, but it will not add code to the final binary without the "ssh"
-# feature enabled.
-zlib-ng-compat = ["libz-sys/zlib-ng", "libssh2-sys/zlib-ng-compat"]
+zlib-ng-compat = ["libz-sys/zlib-ng", "libssh2-sys?/zlib-ng-compat"]


### PR DESCRIPTION
Use a weak dependency feature to enable zlib-ng-compat on libssh2-sys
without forcibly enabling libssh2-sys.
