### PR TITLE
Add binding for git_commit_body

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -2747,6 +2747,7 @@ extern "C" {
     pub fn git_commit_parentcount(commit: *const git_commit) -> c_uint;
     pub fn git_commit_raw_header(commit: *const git_commit) -> *const c_char;
     pub fn git_commit_summary(commit: *mut git_commit) -> *const c_char;
+    pub fn git_commit_body(commit: *mut git_commit) -> *const c_char;
     pub fn git_commit_time(commit: *const git_commit) -> git_time_t;
     pub fn git_commit_time_offset(commit: *const git_commit) -> c_int;
     pub fn git_commit_tree(tree_out: *mut *mut git_tree, commit: *const git_commit) -> c_int;

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -956,7 +956,7 @@ mod tests {
         let repo = Repository::clone(&url, td3.path()).unwrap();
         let commit = repo.head().unwrap().target().unwrap();
         let commit = repo.find_commit(commit).unwrap();
-        assert_eq!(commit.message(), Some("initial"));
+        assert_eq!(commit.message(), Some("initial\n\nbody"));
     }
 
     #[test]

--- a/src/test.rs
+++ b/src/test.rs
@@ -31,7 +31,7 @@ pub fn repo_init() -> (TempDir, Repository) {
 
         let tree = repo.find_tree(id).unwrap();
         let sig = repo.signature().unwrap();
-        repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+        repo.commit(Some("HEAD"), &sig, &sig, "initial\n\nbody", &tree, &[])
             .unwrap();
     }
     (td, repo)


### PR DESCRIPTION
This pull request adds a binding for `git_commit_body`.
While users could previously retrieve the commit body as part of the commit message, they would have to reimplement libgit2's functionality to extract the body paragraphs.
In addition to the new binding, I also updated the test suite to test a commit with a body paragraph instead.

The data users can get with the new binding is useful when displaying the title and body parts of a commit message differently. My use case for this feature is validating the commit body with a separate set of rules in a commit message linter I'm writing.

Thank you for the review in advance!