### PR TITLE
update libgit2 to newer snapshot

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git2"
-version = "0.14.4"
+version = "0.15.0"
 authors = ["Josh Triplett <josh@joshtriplett.org>", "Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -20,7 +20,7 @@ url = "2.0"
 bitflags = "1.1.0"
 libc = "0.2"
 log = "0.4.8"
-libgit2-sys = { path = "libgit2-sys", version = "0.13.4" }
+libgit2-sys = { path = "libgit2-sys", version = "0.14.0" }
 
 [target."cfg(all(unix, not(target_os = \"macos\")))".dependencies]
 openssl-sys = { version = "0.9.0", optional = true }

--- a/git2-curl/Cargo.toml
+++ b/git2-curl/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 curl = "0.4.33"
 url = "2.0"
 log = "0.4"
-git2 = { path = "..", version = "0.14", default-features = false }
+git2 = { path = "..", version = "0.15", default-features = false }
 
 [dev-dependencies]
 civet = "0.11"

--- a/libgit2-sys/Cargo.toml
+++ b/libgit2-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libgit2-sys"
-version = "0.13.4+1.4.2"
+version = "0.14.0+1.4.4"
 authors = ["Josh Triplett <josh@joshtriplett.org>", "Alex Crichton <alex@alexcrichton.com>"]
 links = "git2"
 build = "build.rs"

--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/libgit2-sys/0.13")]
+#![doc(html_root_url = "https://docs.rs/libgit2-sys/0.14")]
 #![allow(non_camel_case_types, unused_extern_crates)]
 
 // This is required to link libz when libssh2-sys is not included.
@@ -195,6 +195,7 @@ git_enum! {
         GIT_EMISMATCH = -33,
         GIT_EINDEXDIRTY = -34,
         GIT_EAPPLYFAIL = -35,
+        GIT_EOWNER = -36,
     }
 }
 
@@ -1894,6 +1895,8 @@ git_enum! {
         GIT_OPT_SET_ODB_LOOSE_PRIORITY,
         GIT_OPT_GET_EXTENSIONS,
         GIT_OPT_SET_EXTENSIONS,
+        GIT_OPT_GET_OWNER_VALIDATION,
+        GIT_OPT_SET_OWNER_VALIDATION,
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -127,6 +127,7 @@ impl Error {
             raw::GIT_EMISMATCH => super::ErrorCode::HashsumMismatch,
             raw::GIT_EINDEXDIRTY => super::ErrorCode::IndexDirty,
             raw::GIT_EAPPLYFAIL => super::ErrorCode::ApplyFail,
+            raw::GIT_EOWNER => super::ErrorCode::Owner,
             _ => super::ErrorCode::GenericError,
         }
     }
@@ -163,6 +164,7 @@ impl Error {
             ErrorCode::HashsumMismatch => raw::GIT_EMISMATCH,
             ErrorCode::IndexDirty => raw::GIT_EINDEXDIRTY,
             ErrorCode::ApplyFail => raw::GIT_EAPPLYFAIL,
+            ErrorCode::Owner => raw::GIT_EOWNER,
         };
     }
 
@@ -293,6 +295,7 @@ impl Error {
             GIT_EMISMATCH,
             GIT_EINDEXDIRTY,
             GIT_EAPPLYFAIL,
+            GIT_EOWNER,
         )
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@
 //! source `Repository`, to ensure that they do not outlive the repository
 //! itself.
 
-#![doc(html_root_url = "https://docs.rs/git2/0.14")]
+#![doc(html_root_url = "https://docs.rs/git2/0.15")]
 #![allow(trivial_numeric_casts, trivial_casts)]
 #![deny(missing_docs)]
 #![warn(rust_2018_idioms)]
@@ -215,6 +215,8 @@ pub enum ErrorCode {
     IndexDirty,
     /// Patch application failed
     ApplyFail,
+    /// The object is not owned by the current user
+    Owner,
 }
 
 /// An enumeration of possible categories of things that can have

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -178,6 +178,19 @@ where
     Ok(())
 }
 
+/// Set wheter or not to verify ownership before performing a repository.
+/// Enabled by default, but disabling this can lead to code execution vulnerabilities.
+pub unsafe fn set_verify_owner_validation(enabled: bool) -> Result<(), Error> {
+    let error = raw::git_libgit2_opts(
+        raw::GIT_OPT_SET_OWNER_VALIDATION as libc::c_int,
+        enabled as libc::c_int,
+    );
+    // This function cannot actually fail, but the function has an error return
+    // for other options that can.
+    debug_assert!(error >= 0);
+    Ok(())
+}
+
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
[Fixes CVE 2022-24765](https://github.com/libgit2/libgit2/releases/tag/v1.4.3)

@justinsteven has a [writeup of this issue](https://github.com/justinsteven/advisories/blob/main/2022_git_buried_bare_repos_and_fsmonitor_various_abuses.md?rgh-link-date=2022-05-09T04%3A16%3A51Z) (see also starship/starship#3974)

I think this also fixes #795.

I needed to make some changes to the libgit2-sys `build.rs` to get this to build and the owner validation needed to be disabled for  the tests on Windows, I've not investigated the cause in detail.

Furthermore, I've increased the minor version and treated this as a breaking change, since this change could prevent opening a repository if it is not owned by the current user.

I am disclosing this security issue publicly because this class of vulnerability has already been reported publicly in several other similar projects.