### PR TITLE
chore(deps): bump openssl-sys to 0.9.73

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ log = "0.4.8"
 libgit2-sys = { path = "libgit2-sys", version = "0.13.4" }
 
 [target."cfg(all(unix, not(target_os = \"macos\")))".dependencies]
-openssl-sys = { version = "0.9.0", optional = true }
+openssl-sys = { version = "0.9.73", optional = true }
 openssl-probe = { version = "0.1", optional = true }
 
 [dev-dependencies]

--- a/libgit2-sys/Cargo.toml
+++ b/libgit2-sys/Cargo.toml
@@ -30,7 +30,7 @@ pkg-config = "0.3.7"
 cc = { version = "1.0.43", features = ['parallel'] }
 
 [target.'cfg(unix)'.dependencies]
-openssl-sys = { version = "0.9", optional = true }
+openssl-sys = { version = "0.9.73", optional = true }
 
 [features]
 ssh = ["libssh2-sys"]


### PR DESCRIPTION
This bumps the openssl-sys crate version to the latest version (v0.9.73). Since 0.9.0, which was released a while ago, openssl 3.0 support has been added to that crate. Also Fedora 36 ships openssl 3.0.2 , so building the git crate breaks.

Edit: Same thing happens in Ubuntu 22.04 which also has openssl 3.0.2)