### PR TITLE
bump libgit2 to 1.5.0

### DIFF
--- a/libgit2-sys/Cargo.toml
+++ b/libgit2-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libgit2-sys"
-version = "0.14.0+1.4.4"
+version = "0.14.0+1.5.0"
 authors = ["Josh Triplett <josh@joshtriplett.org>", "Alex Crichton <alex@alexcrichton.com>"]
 links = "git2"
 build = "build.rs"

--- a/libgit2-sys/build.rs
+++ b/libgit2-sys/build.rs
@@ -14,7 +14,7 @@ fn main() {
     let try_to_use_system_libgit2 = !vendored && !zlib_ng_compat;
     if try_to_use_system_libgit2 {
         let mut cfg = pkg_config::Config::new();
-        if let Ok(lib) = cfg.range_version("1.4.4".."1.5.0").probe("libgit2") {
+        if let Ok(lib) = cfg.range_version("1.4.4".."1.6.0").probe("libgit2") {
             for include in &lib.include_paths {
                 println!("cargo:root={}", include.display());
             }


### PR DESCRIPTION
Fixup for #839
libgit2 1.5.0 was released shortly after it was merged, so switch from `main` to the stable `v1.5.0` tag and amend `cfg.range_version` to include v1.5.0.