### PR TITLE
Revert 86721d1

### DIFF
--- a/libgit2-sys/build.rs
+++ b/libgit2-sys/build.rs
@@ -14,7 +14,7 @@ fn main() {
     let try_to_use_system_libgit2 = !vendored && !zlib_ng_compat;
     if try_to_use_system_libgit2 {
         let mut cfg = pkg_config::Config::new();
-        if let Ok(lib) = cfg.range_version("1.4.4".."1.5.0").probe("libgit2") {
+        if let Ok(lib) = cfg.atleast_version("1.4.4").probe("libgit2") {
             for include in &lib.include_paths {
                 println!("cargo:root={}", include.display());
             }


### PR DESCRIPTION
PR #817 (and commit 86721d1) are based on the false premise that ABI changes == API changes. This commit did not solve any issues, because the only reason git2-rs would be incompatible to compile with a new version of the system libgit2 would be if there was an *API* change. While libgit2 does have an unstable ABI when it comes to major releases, they do not have an unstable API. This means that system versions above what the library is "currently compatible with" can take advantage of the newer library version with minimal changes, there will just need to be a recompile.

Again, all this commit did was artificially limit the newer versions of libgit2 you can use with this library and not didn't solve anything. Programs will still need a recompile, and git2-rs will need a version bump simply to increase this number.