### PR TITLE
Fix warning about unused_must_use for Box::from_raw

### DIFF
--- a/src/odb.rs
+++ b/src/odb.rs
@@ -514,7 +514,7 @@ impl<'repo> Drop for OdbPackwriter<'repo> {
                 None => (),
             };
 
-            Box::from_raw(self.progress_payload_ptr);
+            drop(Box::from_raw(self.progress_payload_ptr));
         }
     }
 }


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/99270 recently added a `must_use` for `Box::from_raw`. This causes this particular line to raise a warning. This solves it by explicitly dropping the value. This code was storing a pointer to a Rust structure using `Box::into_raw`. This drop impl was reconstituting it as a Box in order to free the memory. However, this doesn't care about the return value as it is only doing this to then immediately drop and free the value.
