### PR TITLE
On GLIBC, compile libgit2 with `-D_FILE_OFFSET_BITS=64`.

### DIFF
--- a/libgit2-sys/build.rs
+++ b/libgit2-sys/build.rs
@@ -112,6 +112,12 @@ fn main() {
         cfg.define("__EXTENSIONS__", None);
     }
 
+    // Support large files and dates after the year 2038 on 32-bit GLIBC.
+    if target.contains("gnu") {
+        cfg.define("_FILE_OFFSET_BITS", Some("64"));
+        cfg.define("_TIME_BITS", Some("64"));
+    }
+
     let mut features = String::new();
 
     features.push_str("#ifndef INCLUDE_features_h\n");


### PR DESCRIPTION
On GLIBC, compile libgit2 with `-D_FILE_OFFSET_BITS=64`. On 32-bit
architectures, this is needed for libgit2 to access files larger than 2 GiB.

While here, also use `-D_TIME_BITS=64`, which is needed on GLIBC on 32-bit
architectures for libgit2 to work correctly in in the year 2038 and beyond.