### PR TITLE
Add reminder to update README version number

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git2"
-version = "0.15.0"
+version = "0.15.0" # update version in README.md!
 authors = ["Josh Triplett <josh@joshtriplett.org>", "Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
In [v0.15](https://github.com/rust-lang/git2-rs/tree/0.15.0), the project readme says

```toml
[dependencies]
git2 = "0.14"
```

Until it was later corrected in 0b340ffcdb21a7959f81c8ce77015723f5fc6037. 

This PR proposes adding a reminder to the Cargo.toml. I understand, however, if you consider this change to be clutter! Just a suggestion.