### PR TITLE
Upgrade libssh version

### DIFF
--- a/libgit2-sys/Cargo.toml
+++ b/libgit2-sys/Cargo.toml
@@ -22,7 +22,7 @@ path = "lib.rs"
 
 [dependencies]
 libc = "0.2"
-libssh2-sys = { version = "0.2.19", optional = true }
+libssh2-sys = { version = "1.9.0", optional = true }
 libz-sys = { version = "1.1.0", default-features = false, features = ["libc"] }
 
 [build-dependencies]


### PR DESCRIPTION
Could not pull from github anymore because of police changes

https://github.blog/2021-09-01-improving-git-protocol-security-github/#libgit2-and-other-git-clients

closes #872 