### PR TITLE
Fix Windows SSH authentication issues

### DIFF
--- a/libgit2-sys/Cargo.toml
+++ b/libgit2-sys/Cargo.toml
@@ -22,7 +22,7 @@ path = "lib.rs"
 
 [dependencies]
 libc = "0.2"
-libssh2-sys = { version = "0.2.19", optional = true }
+libssh2-sys = { version = "0.2.19", optional = true, features = ["openssl-on-win32"] }
 libz-sys = { version = "1.1.0", default-features = false, features = ["libc"] }
 
 [build-dependencies]


### PR DESCRIPTION
As was commented in issue #872 in [comment](https://github.com/rust-lang/git2-rs/issues/872#issuecomment-1234024308), libssh2 on Windows uses WinCNG backend by default.

Its implementation is old and does not support modern key formats, making libgit2 (and by extension git2-rs bindings) unusable on Windows when one wishes to use SSH authentication, as only formats that won't cause infinite loop when trying to authenticate or fail are the ones that GitHub and others don't support anymore.

Utilizing openssl-on-win32 ssh2-rs feature allows for proper use of SSH authentication method on Windows builds without infinite loops and fails inside git2-rs.
This PR does just that - enables this feature.

I don't know if this is the best approach for this (I'm still a bit new to Rust), but doing this solved all SSH auth issues I had (and which probably cannot be solved otherwise on Windows OS without libssh2 updating WinCNG backend...)