### PR TITLE
PartialEq, Eq for Signature

### DIFF
--- a/src/signature.rs
+++ b/src/signature.rs
@@ -158,6 +158,16 @@ impl<'a> fmt::Display for Signature<'a> {
     }
 }
 
+impl PartialEq for Signature<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.when() == other.when()
+            && self.email_bytes() == other.email_bytes()
+            && self.name_bytes() == other.name_bytes()
+    }
+}
+
+impl Eq for Signature<'_> {}
+
 #[cfg(test)]
 mod tests {
     use crate::{Signature, Time};


### PR DESCRIPTION
Necessarily hand-derived structural equality, as the raw binding stores
pointers for the string fields.
