### PR TITLE
Add `Reference::symbolic_set_target`

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -2437,6 +2437,12 @@ extern "C" {
         id: *const git_oid,
         log_message: *const c_char,
     ) -> c_int;
+    pub fn git_reference_symbolic_set_target(
+        out: *mut *mut git_reference,
+        r: *mut git_reference,
+        target: *const c_char,
+        log_message: *const c_char,
+    ) -> c_int;
     pub fn git_reference_type(r: *const git_reference) -> git_reference_t;
     pub fn git_reference_iterator_new(
         out: *mut *mut git_reference_iterator,

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1480,6 +1480,19 @@ impl Repository {
 
     /// Create a new symbolic reference.
     ///
+    /// A symbolic reference is a reference name that refers to another
+    /// reference name.  If the other name moves, the symbolic name will move,
+    /// too.  As a simple example, the "HEAD" reference might refer to
+    /// "refs/heads/master" while on the "master" branch of a repository.
+    ///
+    /// Valid reference names must follow one of two patterns:
+    ///
+    /// 1. Top-level names must contain only capital letters and underscores,
+    ///    and must begin and end with a letter. (e.g. "HEAD", "ORIG_HEAD").
+    /// 2. Names prefixed with "refs/" can be almost anything.  You must avoid
+    ///    the characters '~', '^', ':', '\\', '?', '[', and '*', and the
+    ///    sequences ".." and "@{" which have special meaning to revparse.
+    ///
     /// This function will return an error if a reference already exists with
     /// the given name unless force is true, in which case it will be
     /// overwritten.


### PR DESCRIPTION
Fixes #852 

I've also modified the documentation of `Repository::reference_symbolic` because the original docs for `git_reference_symbolic_set_target` made a reference to `git_reference_symbolic_create`.