### PR TITLE
Correct/relax lifetime requirements on getter methods of Commit and Signature

### DIFF
--- a/src/commit.rs
+++ b/src/commit.rs
@@ -65,7 +65,7 @@ impl<'repo> Commit<'repo> {
     /// potential leading newlines.
     ///
     /// `None` will be returned if the message is not valid utf-8
-    pub fn message(&self) -> Option<&str> {
+    pub fn message(&self) -> Option<&'repo str> {
         str::from_utf8(self.message_bytes()).ok()
     }
 
@@ -73,35 +73,36 @@ impl<'repo> Commit<'repo> {
     ///
     /// The returned message will be slightly prettified by removing any
     /// potential leading newlines.
-    pub fn message_bytes(&self) -> &[u8] {
-        unsafe { crate::opt_bytes(self, raw::git_commit_message(&*self.raw)).unwrap() }
+    pub fn message_bytes(&self) -> &'repo [u8] {
+        unsafe { crate::opt_bytes_very_unsafe(raw::git_commit_message(&*self.raw)).unwrap() }
     }
 
     /// Get the encoding for the message of a commit, as a string representing a
     /// standard encoding name.
     ///
     /// `None` will be returned if the encoding is not known
-    pub fn message_encoding(&self) -> Option<&str> {
-        let bytes = unsafe { crate::opt_bytes(self, raw::git_commit_message_encoding(&*self.raw)) };
+    pub fn message_encoding(&self) -> Option<&'repo str> {
+        let bytes =
+            unsafe { crate::opt_bytes_very_unsafe(raw::git_commit_message_encoding(&*self.raw)) };
         bytes.and_then(|b| str::from_utf8(b).ok())
     }
 
     /// Get the full raw message of a commit.
     ///
     /// `None` will be returned if the message is not valid utf-8
-    pub fn message_raw(&self) -> Option<&str> {
+    pub fn message_raw(&self) -> Option<&'repo str> {
         str::from_utf8(self.message_raw_bytes()).ok()
     }
 
     /// Get the full raw message of a commit.
-    pub fn message_raw_bytes(&self) -> &[u8] {
-        unsafe { crate::opt_bytes(self, raw::git_commit_message_raw(&*self.raw)).unwrap() }
+    pub fn message_raw_bytes(&self) -> &'repo [u8] {
+        unsafe { crate::opt_bytes_very_unsafe(raw::git_commit_message_raw(&*self.raw)).unwrap() }
     }
 
     /// Get the full raw text of the commit header.
     ///
     /// `None` will be returned if the message is not valid utf-8
-    pub fn raw_header(&self) -> Option<&str> {
+    pub fn raw_header(&self) -> Option<&'repo str> {
         str::from_utf8(self.raw_header_bytes()).ok()
     }
 
@@ -120,8 +121,8 @@ impl<'repo> Commit<'repo> {
     }
 
     /// Get the full raw text of the commit header.
-    pub fn raw_header_bytes(&self) -> &[u8] {
-        unsafe { crate::opt_bytes(self, raw::git_commit_raw_header(&*self.raw)).unwrap() }
+    pub fn raw_header_bytes(&self) -> &'repo [u8] {
+        unsafe { crate::opt_bytes_very_unsafe(raw::git_commit_raw_header(&*self.raw)).unwrap() }
     }
 
     /// Get the short "summary" of the git commit message.
@@ -131,7 +132,7 @@ impl<'repo> Commit<'repo> {
     ///
     /// `None` may be returned if an error occurs or if the summary is not valid
     /// utf-8.
-    pub fn summary(&self) -> Option<&str> {
+    pub fn summary(&self) -> Option<&'repo str> {
         self.summary_bytes().and_then(|s| str::from_utf8(s).ok())
     }
 
@@ -141,8 +142,8 @@ impl<'repo> Commit<'repo> {
     /// paragraph of the message with whitespace trimmed and squashed.
     ///
     /// `None` may be returned if an error occurs
-    pub fn summary_bytes(&self) -> Option<&[u8]> {
-        unsafe { crate::opt_bytes(self, raw::git_commit_summary(self.raw)) }
+    pub fn summary_bytes(&self) -> Option<&'repo [u8]> {
+        unsafe { crate::opt_bytes_very_unsafe(raw::git_commit_summary(self.raw)) }
     }
 
     /// Get the long "body" of the git commit message.
@@ -153,7 +154,7 @@ impl<'repo> Commit<'repo> {
     ///
     /// `None` may be returned if an error occurs or if the summary is not valid
     /// utf-8.
-    pub fn body(&self) -> Option<&str> {
+    pub fn body(&self) -> Option<&'repo str> {
         self.body_bytes().and_then(|s| str::from_utf8(s).ok())
     }
 
@@ -164,8 +165,8 @@ impl<'repo> Commit<'repo> {
     /// are trimmed.
     ///
     /// `None` may be returned if an error occurs.
-    pub fn body_bytes(&self) -> Option<&[u8]> {
-        unsafe { crate::opt_bytes(self, raw::git_commit_body(self.raw)) }
+    pub fn body_bytes(&self) -> Option<&'repo [u8]> {
+        unsafe { crate::opt_bytes_very_unsafe(raw::git_commit_body(self.raw)) }
     }
 
     /// Get the commit time (i.e. committer time) of a commit.
@@ -199,10 +200,10 @@ impl<'repo> Commit<'repo> {
     }
 
     /// Get the author of this commit.
-    pub fn author(&self) -> Signature<'_> {
+    pub fn author(&self) -> Signature<'repo> {
         unsafe {
             let ptr = raw::git_commit_author(&*self.raw);
-            signature::from_raw_const(self, ptr)
+            signature::from_raw_const_very_unsafe(ptr)
         }
     }
 
@@ -221,10 +222,10 @@ impl<'repo> Commit<'repo> {
     }
 
     /// Get the committer of this commit.
-    pub fn committer(&self) -> Signature<'_> {
+    pub fn committer(&self) -> Signature<'repo> {
         unsafe {
             let ptr = raw::git_commit_committer(&*self.raw);
-            signature::from_raw_const(self, ptr)
+            signature::from_raw_const_very_unsafe(ptr)
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -857,11 +857,29 @@ fn openssl_env_init() {
 ))]
 fn openssl_env_init() {}
 
-unsafe fn opt_bytes<'a, T>(_anchor: &'a T, c: *const libc::c_char) -> Option<&'a [u8]> {
-    if c.is_null() {
+/// Creates a new byte slice from the give raw pointer, tied to the lifetime
+/// of the given object. If the pointer is null, `None` is returned
+///
+/// This function is unsafe as there is no guarantee that `raw` is valid for
+/// `'a` nor if it's a valid pointer.
+unsafe fn opt_bytes<'a, T>(_anchor: &'a T, raw: *const libc::c_char) -> Option<&'a [u8]> {
+    if raw.is_null() {
         None
     } else {
-        Some(CStr::from_ptr(c).to_bytes())
+        Some(CStr::from_ptr(raw).to_bytes())
+    }
+}
+
+/// Creates a new byte slice from the give raw pointer, tied to whatever lifetime
+/// the caller chooses. If the pointer is null, `None` is returned
+///
+/// This function is very unsafe as there is no guarantee that `raw` is valid
+/// for `'a` nor if it's a valid pointer.
+unsafe fn opt_bytes_very_unsafe<'a>(raw: *const libc::c_char) -> Option<&'a [u8]> {
+    if raw.is_null() {
+        None
+    } else {
+        Some(CStr::from_ptr(raw).to_bytes())
     }
 }
 

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -65,25 +65,25 @@ impl<'a> Signature<'a> {
     /// Gets the name on the signature.
     ///
     /// Returns `None` if the name is not valid utf-8
-    pub fn name(&self) -> Option<&str> {
+    pub fn name(&self) -> Option<&'a str> {
         str::from_utf8(self.name_bytes()).ok()
     }
 
     /// Gets the name on the signature as a byte slice.
-    pub fn name_bytes(&self) -> &[u8] {
-        unsafe { crate::opt_bytes(self, (*self.raw).name).unwrap() }
+    pub fn name_bytes(&self) -> &'a [u8] {
+        unsafe { crate::opt_bytes_very_unsafe((*self.raw).name).unwrap() }
     }
 
     /// Gets the email on the signature.
     ///
     /// Returns `None` if the email is not valid utf-8
-    pub fn email(&self) -> Option<&str> {
+    pub fn email(&self) -> Option<&'a str> {
         str::from_utf8(self.email_bytes()).ok()
     }
 
     /// Gets the email on the signature as a byte slice.
-    pub fn email_bytes(&self) -> &[u8] {
-        unsafe { crate::opt_bytes(self, (*self.raw).email).unwrap() }
+    pub fn email_bytes(&self) -> &'a [u8] {
+        unsafe { crate::opt_bytes_very_unsafe((*self.raw).email).unwrap() }
     }
 
     /// Get the `when` of this signature.
@@ -121,6 +121,19 @@ impl<'a> Binding for Signature<'a> {
 /// This function is unsafe as there is no guarantee that `raw` is valid for
 /// `'a` nor if it's a valid pointer.
 pub unsafe fn from_raw_const<'b, T>(_lt: &'b T, raw: *const raw::git_signature) -> Signature<'b> {
+    Signature {
+        raw: raw as *mut raw::git_signature,
+        _marker: marker::PhantomData,
+        owned: false,
+    }
+}
+
+/// Creates a new signature from the give raw pointer, tied to whatever lifetime
+/// the caller chooses
+///
+/// This function is very unsafe as there is no guarantee that `raw` is valid
+/// for `'a` nor if it's a valid pointer.
+pub unsafe fn from_raw_const_very_unsafe<'a>(raw: *const raw::git_signature) -> Signature<'a> {
     Signature {
         raw: raw as *mut raw::git_signature,
         _marker: marker::PhantomData,


### PR DESCRIPTION
This PR fixes #895

It is very similar to https://github.com/rust-lang/git2-rs/pull/302, which addressed a similar issue: https://github.com/rust-lang/git2-rs/issues/299

# Overview

On the `Commit` struct, there are several "getter" methods where the lifetime of the return object is tied to a borrow of `Self`:
* `pub fn author(&self) -> Signature<'_> {`
* `pub fn body(&self) -> Option<&str> {`
* Etc.

In other words, written without elision, these signatures all look like
* `pub fn author<'a>(&'a self) -> Signature<'a> {` 
* `pub fn body<'a>(&'a self) -> Option<&'a str> {`
* Etc.

But the pointers that are returned by these methods all live as long as the `'repo` lifetime if you look at the C code. In other words, they should all have these (more flexible) signatures:

```rust
struct Commit<'repo> { ... }

impl<'repo> Commit<'repo> {
    pub fn author(&self) -> Signature<'repo> { .. } 
    pub fn body(&self) -> Option<&'repo str> { .. }
    // Etc.
}
```

There is a very similar problem happening for the "getter" methods of the `Signature` struct.

This PR fixes these methods so that they return references with the correct (more flexible) lifetimes.

# Motivating example

This code should compile

```
struct Wrapper<'repo> {
    inner: git2::Commit<'repo>,
}

impl<'repo> Wrapper<'repo> {
    fn email(&self) -> Option<&'repo str> {
        let signature = self.inner.author();
        let email = signature.email();
        email
    }
}
```

but fails with

```
error: lifetime may not live long enough
 --> src/lib.rs:9:9
  |
5 | impl<'repo> Wrapper<'repo> {
  |      ----- lifetime `'repo` defined here
6 |     fn email(&self) -> Option<&'repo str> {
  |              - let's call the lifetime of this reference `'1`
...
9 |         email
  |         ^^^^^ associated function was supposed to return data with lifetime `'repo` but it is returning data with lifetime `'1`

error[E0515]: cannot return value referencing local variable `signature`
 --> src/lib.rs:9:9
  |
8 |         let email = signature.email();
  |                     ----------------- `signature` is borrowed here
9 |         email
  |         ^^^^^ returns a value referencing data owned by the current function

For more information about this error, try `rustc --explain E0515`.
```

# The C code

The equivalent "getter" methods are defined in the underlying C code is here: 
* https://github.com/libgit2/libgit2/blob/a3841af5eecc6301e87f8302c7fdce6555e39247/src/libgit2/commit.c#L521

The pointers they return live here:
* https://github.com/libgit2/libgit2/blob/main/src/libgit2/commit.h#L19

I believe all these pointers live as long as this raw `*mut raw::git_commit` pointer here:
* https://github.com/rust-lang/git2-rs/blob/master/src/commit.rs#L15

which has the `'repo` lifetime.