### PR TITLE
Added some more documentation to the certificate_check function

### DIFF
--- a/src/remote_callbacks.rs
+++ b/src/remote_callbacks.rs
@@ -171,6 +171,10 @@ impl<'a> RemoteCallbacks<'a> {
     /// If certificate verification fails, then this callback will be invoked to
     /// let the caller make the final decision of whether to allow the
     /// connection to proceed.
+    ///
+    /// A failure to handle this callback will most likely result in a security
+    /// problem, as that will open the connection up to MITM attacks. As can
+    /// be seen in this CVE: <https://blog.rust-lang.org/2023/01/10/cve-2022-46176.html>
     pub fn certificate_check<F>(&mut self, cb: F) -> &mut RemoteCallbacks<'a>
     where
         F: FnMut(&Cert<'_>, &str) -> Result<CertificateCheckStatus, Error> + 'a,


### PR DESCRIPTION
In order to underline how important it is to handle.

I missed the implications of implementing this callback in my project, and I fear that many others have done the same. Improving the documentation might help to reduce the risk that people in the future also misses this. 