### PR TITLE
Fix libgit2-sys rerun-if-changed on Windows

### DIFF
--- a/libgit2-sys/build.rs
+++ b/libgit2-sys/build.rs
@@ -205,7 +205,6 @@ fn main() {
         println!("cargo:rustc-link-lib=rpcrt4");
         println!("cargo:rustc-link-lib=ole32");
         println!("cargo:rustc-link-lib=crypt32");
-        return;
     }
 
     if target.contains("apple") {
@@ -214,9 +213,9 @@ fn main() {
         println!("cargo:rustc-link-lib=framework=CoreFoundation");
     }
 
-    rerun_if(Path::new("libgit2/include"));
-    rerun_if(Path::new("libgit2/src"));
-    rerun_if(Path::new("libgit2/deps"));
+    println!("cargo:rerun-if-changed=libgit2/include");
+    println!("cargo:rerun-if-changed=libgit2/src");
+    println!("cargo:rerun-if-changed=libgit2/deps");
 }
 
 fn cp_r(from: impl AsRef<Path>, to: impl AsRef<Path>) {
@@ -251,15 +250,5 @@ fn add_c_files(build: &mut cc::Build, path: impl AsRef<Path>) {
         } else if path.extension().and_then(|s| s.to_str()) == Some("c") {
             build.file(&path);
         }
-    }
-}
-
-fn rerun_if(path: &Path) {
-    if path.is_dir() {
-        for entry in fs::read_dir(path).expect("read_dir") {
-            rerun_if(&entry.expect("entry").path());
-        }
-    } else {
-        println!("cargo:rerun-if-changed={}", path.display());
     }
 }


### PR DESCRIPTION
This fixes it so that the libgit2-sys build script will re-run if any of the libgit2 source files changes. There was an early exit return that was preventing the code from running on Windows.

This also removes the built-in recursion support. Cargo was updated in Rust 1.50 to have this support built-in.