### PR TITLE
Use correct class for credentials_cb error

### DIFF
--- a/src/remote_callbacks.rs
+++ b/src/remote_callbacks.rs
@@ -290,7 +290,7 @@ extern "C" fn credentials_cb(
 
             callback(url, username_from_url, cred_type).map_err(|e| {
                 let s = CString::new(e.to_string()).unwrap();
-                raw::git_error_set_str(e.raw_code() as c_int, s.as_ptr());
+                raw::git_error_set_str(e.class() as c_int, s.as_ptr());
                 e.raw_code() as c_int
             })
         });


### PR DESCRIPTION
The first parameter of `git_error_set_str` is supposed to be an error class, not the raw error code. The main consequence is that the error message should show the class code instead of the error code (which would usually just be GIT_ERROR).