### PR TITLE
Update to libssh2-sys 0.3.0

### DIFF
--- a/libgit2-sys/Cargo.toml
+++ b/libgit2-sys/Cargo.toml
@@ -22,7 +22,7 @@ path = "lib.rs"
 
 [dependencies]
 libc = "0.2"
-libssh2-sys = { version = "0.2.19", optional = true }
+libssh2-sys = { version = "0.3.0", optional = true }
 libz-sys = { version = "1.1.0", default-features = false, features = ["libc"] }
 
 [build-dependencies]


### PR DESCRIPTION
Pull in upstream libssh2 changes were pulled in that fix a number of issues (specifically getting the sha2 signature algorithm support).

Using the fetch example in the repo with a small patch:
```patch
diff --git a/examples/fetch.rs b/examples/fetch.rs
index 64374a6..050769d 100644
--- a/examples/fetch.rs
+++ b/examples/fetch.rs
@@ -76,6 +76,19 @@ fn run(args: &Args) -> Result<(), git2::Error> {
         true
     });
 
+    cb.credentials(|_url, username, _cred_type| {
+        use std::path::Path;
+
+        let cred = git2::Cred::ssh_key(
+            username.unwrap(),
+            Some(Path::new("/home/luqman/.ssh/id_rsa.pub")),
+            Path::new("/home/luqman/.ssh/id_rsa"),
+            None,
+        )
+        .unwrap();
+        Ok(cred)
+    });
+
     // Download the packfile and index it. This function updates the amount of
     // received data and the indexer stats which lets you inform the user about
     // progress.
```

Before:
```console
$ ~/git2-rs/target/debug/examples/fetch
Fetching origin for repo
error: ERROR: You're using an RSA key with SHA-1, which is no longer allowed. Please use a newer client or a different key type.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.

; class=Ssh (23); code=Eof (-20)
```

After:
```console
$ ~/git2-rs/target/debug/examples/fetch
Fetching origin for repo
remote: Enumerating objects: 230, done.
remote: Counting objects: 100% (230/230), done.
remote: Compressing objects: 100% (100/100), done.
remote: Total 230 (delta 133), reused 212 (delta 121), pack-reused 0
Received 230/230 objects in 81776 bytes (used 10 local objects)
```