### PR TITLE
Add docs about Repository::index ownership.

### DIFF
--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1012,6 +1012,11 @@ impl Repository {
     ///
     /// If a custom index has not been set, the default index for the repository
     /// will be returned (the one located in .git/index).
+    ///
+    /// **Caution**: If the [`Repository`] of this index is dropped, then this
+    /// [`Index`] will become detached, and most methods on it will fail. See
+    /// [`Index::open`]. Be sure the repository has a binding such as a local
+    /// variable to keep it alive at least as long as the index.
     pub fn index(&self) -> Result<Index, Error> {
         let mut raw = ptr::null_mut();
         unsafe {


### PR DESCRIPTION
When doing something like `let index = Repository::open("foo")?.index()?;`, the resulting `index` can't do very much since many of its methods will fail (with errors like `This operation is not allowed against bare repositories`). This adds some documentation about this behavior.

There are some alternate solutions here, but I didn't find them very palatable:

* Add a lifetime to `Index`. This might be a little awkward (use `'static` for non-repo Indexes?).
* Add a lifetime wrapper that only applies to `Repository::index()`. This I think would make the `Index` a little more awkward to use, and seems a little overkill.
* Add checks in `Index` methods for a NULL `git_index_owner()` that need an owner, and provide a better error message.

There are a few other "owned" types, including `git_odb`, `git_refdb`, and `git_config`. However, those don't seem to have the same issues as `git_index`, since they are mostly revolved around caching.

I think adding a lifetime is still an option, but I figure this would be a good solution for now.

closes #897
