### PR TITLE
Implement Send for all simple git types

### DIFF
--- a/src/blame.rs
+++ b/src/blame.rs
@@ -11,6 +11,8 @@ pub struct Blame<'repo> {
     _marker: marker::PhantomData<&'repo Repository>,
 }
 
+unsafe impl<'repo> Send for Blame<'repo> {}
+
 /// Structure that represents a blame hunk.
 pub struct BlameHunk<'blame> {
     raw: *mut raw::git_blame_hunk,

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -14,6 +14,8 @@ pub struct Blob<'repo> {
     _marker: marker::PhantomData<Object<'repo>>,
 }
 
+unsafe impl<'repo> Send for Blob<'repo> {}
+
 impl<'repo> Blob<'repo> {
     /// Get the id (SHA1) of a repository blob
     pub fn id(&self) -> Oid {

--- a/src/branch.rs
+++ b/src/branch.rs
@@ -22,6 +22,8 @@ pub struct Branches<'repo> {
     _marker: marker::PhantomData<References<'repo>>,
 }
 
+unsafe impl<'repo> Send for Branches<'repo> {}
+
 impl<'repo> Branch<'repo> {
     /// Creates Branch type from a Reference
     pub fn wrap(reference: Reference<'_>) -> Branch<'_> {

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -14,6 +14,8 @@ pub struct Buf {
     raw: raw::git_buf,
 }
 
+unsafe impl<'repo> Send for Buf {}
+
 impl Default for Buf {
     fn default() -> Self {
         Self::new()

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -16,6 +16,8 @@ pub struct Commit<'repo> {
     _marker: marker::PhantomData<Object<'repo>>,
 }
 
+unsafe impl<'repo> Send for Commit<'repo> {}
+
 /// An iterator over the parent commits of a commit.
 ///
 /// Aborts iteration when a commit cannot be found

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,8 @@ pub struct Config {
     raw: *mut raw::git_config,
 }
 
+unsafe impl Send for Config {}
+
 /// A struct representing a certain entry owned by a `Config` instance.
 ///
 /// An entry has a name, a value, and a level it applies to.
@@ -58,6 +60,8 @@ pub struct ConfigEntries<'cfg> {
     current: Option<ConfigEntry<'cfg>>,
     _marker: marker::PhantomData<&'cfg Config>,
 }
+
+unsafe impl<'cfg> Send for ConfigEntries<'cfg> {}
 
 impl Config {
     /// Allocate a new configuration object

--- a/src/describe.rs
+++ b/src/describe.rs
@@ -15,6 +15,8 @@ pub struct Describe<'repo> {
     _marker: marker::PhantomData<&'repo Repository>,
 }
 
+unsafe impl<'repo> Send for Describe<'repo> {}
+
 /// Options which indicate how a `Describe` is created.
 pub struct DescribeOptions {
     raw: raw::git_describe_options,

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -86,6 +86,8 @@ pub struct DiffStats {
     raw: *mut raw::git_diff_stats,
 }
 
+unsafe impl Send for DiffStats {}
+
 /// Structure describing the binary contents of a diff.
 pub struct DiffBinary<'a> {
     raw: *const raw::git_diff_binary,

--- a/src/index.rs
+++ b/src/index.rs
@@ -18,6 +18,8 @@ pub struct Index {
     raw: *mut raw::git_index,
 }
 
+unsafe impl Send for Index {}
+
 /// An iterator over the entries in an index
 pub struct IndexEntries<'index> {
     range: Range<usize>,
@@ -29,6 +31,8 @@ pub struct IndexConflicts<'index> {
     conflict_iter: *mut raw::git_index_conflict_iterator,
     _marker: marker::PhantomData<&'index Index>,
 }
+
+unsafe impl<'index> Send for IndexConflicts<'index> {}
 
 /// A structure to represent the information returned when a conflict is detected in an index entry
 pub struct IndexConflict {

--- a/src/mailmap.rs
+++ b/src/mailmap.rs
@@ -11,6 +11,8 @@ pub struct Mailmap {
     raw: *mut raw::git_mailmap,
 }
 
+unsafe impl Send for Mailmap {}
+
 impl Binding for Mailmap {
     type Raw = *mut raw::git_mailmap;
 

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -17,6 +17,8 @@ pub struct AnnotatedCommit<'repo> {
     _marker: marker::PhantomData<Commit<'repo>>,
 }
 
+unsafe impl<'repo> Send for AnnotatedCommit<'repo> {}
+
 /// Options to specify when merging.
 pub struct MergeOptions {
     raw: raw::git_merge_options,

--- a/src/note.rs
+++ b/src/note.rs
@@ -16,11 +16,15 @@ pub struct Note<'repo> {
     _marker: marker::PhantomData<&'repo Repository>,
 }
 
+unsafe impl<'repo> Send for Note<'repo> {}
+
 /// An iterator over all of the notes within a repository.
 pub struct Notes<'repo> {
     raw: *mut raw::git_note_iterator,
     _marker: marker::PhantomData<&'repo Repository>,
 }
+
+unsafe impl<'repo> Send for Notes<'repo> {}
 
 impl<'repo> Note<'repo> {
     /// Get the note author

--- a/src/object.rs
+++ b/src/object.rs
@@ -14,6 +14,8 @@ pub struct Object<'repo> {
     _marker: marker::PhantomData<&'repo Repository>,
 }
 
+unsafe impl<'repo> Send for Object<'repo> {}
+
 impl<'repo> Object<'repo> {
     /// Get the id (SHA1) of a repository object
     pub fn id(&self) -> Oid {

--- a/src/packbuilder.rs
+++ b/src/packbuilder.rs
@@ -26,6 +26,8 @@ pub struct PackBuilder<'repo> {
     _marker: marker::PhantomData<&'repo Repository>,
 }
 
+unsafe impl<'repo> Send for PackBuilder<'repo> {}
+
 impl<'repo> PackBuilder<'repo> {
     /// Insert a single object. For an optimal pack it's mandatory to insert
     /// objects in recency order, commits followed by trees and blobs.

--- a/src/pathspec.rs
+++ b/src/pathspec.rs
@@ -14,11 +14,15 @@ pub struct Pathspec {
     raw: *mut raw::git_pathspec,
 }
 
+unsafe impl Send for Pathspec {}
+
 /// List of filenames matching a pathspec.
 pub struct PathspecMatchList<'ps> {
     raw: *mut raw::git_pathspec_match_list,
     _marker: marker::PhantomData<&'ps Pathspec>,
 }
+
+unsafe impl<'ps> Send for PathspecMatchList<'ps> {}
 
 /// Iterator over the matched paths in a pathspec.
 pub struct PathspecEntries<'list> {

--- a/src/rebase.rs
+++ b/src/rebase.rs
@@ -106,6 +106,8 @@ pub struct Rebase<'repo> {
     _marker: marker::PhantomData<&'repo raw::git_rebase>,
 }
 
+unsafe impl<'repo> Send for Rebase<'repo> {}
+
 impl<'repo> Rebase<'repo> {
     /// Gets the count of rebase operations that are to be applied.
     pub fn len(&self) -> usize {

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -26,11 +26,15 @@ pub struct Reference<'repo> {
     _marker: marker::PhantomData<Refdb<'repo>>,
 }
 
+unsafe impl<'repo> Send for Reference<'repo> {}
+
 /// An iterator over the references in a repository.
 pub struct References<'repo> {
     raw: *mut raw::git_reference_iterator,
     _marker: marker::PhantomData<Refdb<'repo>>,
 }
+
+unsafe impl<'repo> Send for References<'repo> {}
 
 /// An iterator over the names of references in a repository.
 pub struct ReferenceNames<'repo, 'references> {

--- a/src/reflog.rs
+++ b/src/reflog.rs
@@ -11,11 +11,15 @@ pub struct Reflog {
     raw: *mut raw::git_reflog,
 }
 
+unsafe impl Send for Reflog {}
+
 /// An entry inside the reflog of a repository
 pub struct ReflogEntry<'reflog> {
     raw: *const raw::git_reflog_entry,
     _marker: marker::PhantomData<&'reflog Reflog>,
 }
+
+unsafe impl<'reflog> Send for ReflogEntry<'reflog> {}
 
 /// An iterator over the entries inside of a reflog.
 pub struct ReflogIter<'reflog> {

--- a/src/refspec.rs
+++ b/src/refspec.rs
@@ -15,6 +15,8 @@ pub struct Refspec<'remote> {
     _marker: marker::PhantomData<&'remote raw::git_remote>,
 }
 
+unsafe impl<'remote> Send for Refspec<'remote> {}
+
 impl<'remote> Refspec<'remote> {
     /// Get the refspec's direction.
     pub fn direction(&self) -> Direction {

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -24,6 +24,8 @@ pub struct Remote<'repo> {
     _marker: marker::PhantomData<&'repo Repository>,
 }
 
+unsafe impl<'repo> Send for Remote<'repo> {}
+
 /// An iterator over the refspecs that a remote contains.
 pub struct Refspecs<'remote> {
     range: Range<usize>,

--- a/src/revwalk.rs
+++ b/src/revwalk.rs
@@ -12,6 +12,8 @@ pub struct Revwalk<'repo> {
     _marker: marker::PhantomData<&'repo Repository>,
 }
 
+unsafe impl<'repo> Send for Revwalk<'repo> {}
+
 /// A `Revwalk` with an associated "hide callback", see `with_hide_callback`
 pub struct RevwalkWithHideCb<'repo, 'cb, C>
 where

--- a/src/status.rs
+++ b/src/status.rs
@@ -44,6 +44,8 @@ pub struct Statuses<'repo> {
     _marker: marker::PhantomData<&'repo Repository>,
 }
 
+unsafe impl<'repo> Send for Statuses<'repo> {}
+
 /// An iterator over the statuses in a `Statuses` instance.
 pub struct StatusIter<'statuses> {
     statuses: &'statuses Statuses<'statuses>,

--- a/src/submodule.rs
+++ b/src/submodule.rs
@@ -17,6 +17,8 @@ pub struct Submodule<'repo> {
     _marker: marker::PhantomData<&'repo Repository>,
 }
 
+unsafe impl<'repo> Send for Submodule<'repo> {}
+
 impl<'repo> Submodule<'repo> {
     /// Get the submodule's branch.
     ///

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -14,6 +14,8 @@ pub struct Tag<'repo> {
     _marker: marker::PhantomData<Object<'repo>>,
 }
 
+unsafe impl<'repo> Send for Tag<'repo> {}
+
 impl<'repo> Tag<'repo> {
     /// Get the id (SHA1) of a repository tag
     pub fn id(&self) -> Oid {

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -14,6 +14,8 @@ pub struct Transaction<'repo> {
     _marker: marker::PhantomData<&'repo Repository>,
 }
 
+unsafe impl<'repo> Send for Transaction<'repo> {}
+
 impl Drop for Transaction<'_> {
     fn drop(&mut self) {
         unsafe { raw::git_transaction_free(self.raw) }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -27,6 +27,8 @@ pub struct TreeEntry<'tree> {
     _marker: marker::PhantomData<&'tree raw::git_tree_entry>,
 }
 
+unsafe impl<'tree> Send for TreeEntry<'tree> {}
+
 /// An iterator over the entries in a tree.
 pub struct TreeIter<'tree> {
     range: Range<usize>,

--- a/src/treebuilder.rs
+++ b/src/treebuilder.rs
@@ -12,6 +12,8 @@ pub struct TreeBuilder<'repo> {
     _marker: marker::PhantomData<&'repo Repository>,
 }
 
+unsafe impl<'repo> Send for TreeBuilder<'repo> {}
+
 impl<'repo> TreeBuilder<'repo> {
     /// Clear all the entries in the builder
     pub fn clear(&mut self) -> Result<(), Error> {

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -17,6 +17,8 @@ pub struct Worktree {
     raw: *mut raw::git_worktree,
 }
 
+unsafe impl Send for Worktree {}
+
 /// Options which can be used to configure how a worktree is initialized
 pub struct WorktreeAddOptions<'a> {
     raw: raw::git_worktree_add_options,


### PR DESCRIPTION
This implements Send for all simple libgit2-sys types. According to https://github.com/libgit2/libgit2/blob/main/docs/threading.md this is fine - objects can be sent between threads.

Refs https://github.com/rust-lang/git2-rs/issues/194