### PR TITLE
Update to bitflags 2.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2018"
 
 [dependencies]
 url = "2.0"
-bitflags = "1.1.0"
+bitflags = "2.1.0"
 libc = "0.2"
 log = "0.4.8"
 libgit2-sys = { path = "libgit2-sys", version = "0.15.1" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -415,6 +415,7 @@ pub enum FileFavor {
 
 bitflags! {
     /// Orderings that may be specified for Revwalk iteration.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct Sort: u32 {
         /// Sort the repository contents in no particular ordering.
         ///
@@ -449,6 +450,7 @@ impl Sort {
 
 bitflags! {
     /// Types of credentials that can be requested by a credential callback.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct CredentialType: u32 {
         #[allow(missing_docs)]
         const USER_PASS_PLAINTEXT = raw::GIT_CREDTYPE_USERPASS_PLAINTEXT as u32;
@@ -485,6 +487,7 @@ impl Default for CredentialType {
 
 bitflags! {
     /// Flags for the `flags` field of an IndexEntry.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct IndexEntryFlag: u16 {
         /// Set when the `extended_flags` field is valid.
         const EXTENDED = raw::GIT_INDEX_ENTRY_EXTENDED as u16;
@@ -500,6 +503,7 @@ impl IndexEntryFlag {
 
 bitflags! {
     /// Flags for the `extended_flags` field of an IndexEntry.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct IndexEntryExtendedFlag: u16 {
         /// An "intent to add" entry from "git add -N"
         const INTENT_TO_ADD = raw::GIT_INDEX_ENTRY_INTENT_TO_ADD as u16;
@@ -519,6 +523,7 @@ impl IndexEntryExtendedFlag {
 
 bitflags! {
     /// Flags for APIs that add files matching pathspec
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct IndexAddOption: u32 {
         #[allow(missing_docs)]
         const DEFAULT = raw::GIT_INDEX_ADD_DEFAULT as u32;
@@ -550,6 +555,7 @@ impl Default for IndexAddOption {
 
 bitflags! {
     /// Flags for `Repository::open_ext`
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct RepositoryOpenFlags: u32 {
         /// Only open the specified path; don't walk upward searching.
         const NO_SEARCH = raw::GIT_REPOSITORY_OPEN_NO_SEARCH as u32;
@@ -574,6 +580,7 @@ impl RepositoryOpenFlags {
 
 bitflags! {
     /// Flags for the return value of `Repository::revparse`
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct RevparseMode: u32 {
         /// The spec targeted a single object
         const SINGLE = raw::GIT_REVPARSE_SINGLE as u32;
@@ -592,6 +599,7 @@ impl RevparseMode {
 
 bitflags! {
     /// The results of `merge_analysis` indicating the merge opportunities.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct MergeAnalysis: u32 {
         /// No merge is possible.
         const ANALYSIS_NONE = raw::GIT_MERGE_ANALYSIS_NONE as u32;
@@ -622,6 +630,7 @@ impl MergeAnalysis {
 
 bitflags! {
     /// The user's stated preference for merges.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct MergePreference: u32 {
         /// No configuration was found that suggests a preferred behavior for
         /// merge.
@@ -643,6 +652,7 @@ impl MergePreference {
 
 bitflags! {
     /// Flags controlling the behavior of ODB lookup operations
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct OdbLookupFlags: u32 {
         /// Don't call `git_odb_refresh` if the lookup fails. Useful when doing
         /// a batch of lookup operations for objects that may legitimately not
@@ -997,6 +1007,7 @@ bitflags! {
     /// represents the status of file in the index relative to the HEAD, and the
     /// `STATUS_WT_*` set of flags represent the status of the file in the
     /// working directory relative to the index.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct Status: u32 {
         #[allow(missing_docs)]
         const CURRENT = raw::GIT_STATUS_CURRENT as u32;
@@ -1047,6 +1058,7 @@ impl Status {
 
 bitflags! {
     /// Mode options for RepositoryInitOptions
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct RepositoryInitMode: u32 {
         /// Use permissions configured by umask - the default
         const SHARED_UMASK = raw::GIT_REPOSITORY_INIT_SHARED_UMASK as u32;
@@ -1179,6 +1191,7 @@ bitflags! {
     /// Lastly, the following will only be returned for ignore "NONE".
     ///
     /// * WD_UNTRACKED      - workdir contains untracked files
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct SubmoduleStatus: u32 {
         #[allow(missing_docs)]
         const IN_HEAD = raw::GIT_SUBMODULE_STATUS_IN_HEAD as u32;
@@ -1275,6 +1288,7 @@ pub enum SubmoduleUpdate {
 
 bitflags! {
     /// ...
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct PathspecFlags: u32 {
         /// Use the default pathspec matching configuration.
         const DEFAULT = raw::GIT_PATHSPEC_DEFAULT as u32;
@@ -1320,6 +1334,7 @@ impl Default for PathspecFlags {
 
 bitflags! {
     /// Types of notifications emitted from checkouts.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct CheckoutNotificationType: u32 {
         /// Notification about a conflict.
         const CONFLICT = raw::GIT_CHECKOUT_NOTIFY_CONFLICT as u32;
@@ -1361,6 +1376,7 @@ pub enum DiffFormat {
 
 bitflags! {
     /// Formatting options for diff stats
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct DiffStatsFormat: raw::git_diff_stats_format_t {
         /// Don't generate any stats
         const NONE = raw::GIT_DIFF_STATS_NONE;
@@ -1431,6 +1447,7 @@ pub enum StashApplyProgress {
 
 bitflags! {
     #[allow(missing_docs)]
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct StashApplyFlags: u32 {
         #[allow(missing_docs)]
         const DEFAULT = raw::GIT_STASH_APPLY_DEFAULT as u32;
@@ -1453,6 +1470,7 @@ impl Default for StashApplyFlags {
 
 bitflags! {
     #[allow(missing_docs)]
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct StashFlags: u32 {
         #[allow(missing_docs)]
         const DEFAULT = raw::GIT_STASH_DEFAULT as u32;
@@ -1483,6 +1501,7 @@ impl Default for StashFlags {
 
 bitflags! {
     #[allow(missing_docs)]
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct AttrCheckFlags: u32 {
         /// Check the working directory, then the index.
         const FILE_THEN_INDEX = raw::GIT_ATTR_CHECK_FILE_THEN_INDEX as u32;
@@ -1503,6 +1522,7 @@ impl Default for AttrCheckFlags {
 
 bitflags! {
     #[allow(missing_docs)]
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct DiffFlags: u32 {
         /// File(s) treated as binary data.
         const BINARY = raw::GIT_DIFF_FLAG_BINARY as u32;
@@ -1524,6 +1544,7 @@ impl DiffFlags {
 
 bitflags! {
     /// Options for [`Reference::normalize_name`].
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct ReferenceFormat: u32 {
         /// No particular normalization.
         const NORMAL = raw::GIT_REFERENCE_FORMAT_NORMAL as u32;
@@ -1575,5 +1596,71 @@ mod tests {
         assert_eq!(u32::from(FileMode::Blob), 0o100644);
         assert_eq!(u32::from(FileMode::BlobGroupWritable), 0o100664);
         assert_eq!(u32::from(FileMode::BlobExecutable), 0o100755);
+    }
+
+    #[test]
+    fn bitflags_partial_eq() {
+        use super::{
+            AttrCheckFlags, CheckoutNotificationType, CredentialType, DiffFlags, DiffStatsFormat,
+            IndexAddOption, IndexEntryExtendedFlag, IndexEntryFlag, MergeAnalysis, MergePreference,
+            OdbLookupFlags, PathspecFlags, ReferenceFormat, RepositoryInitMode,
+            RepositoryOpenFlags, RevparseMode, Sort, StashApplyFlags, StashFlags, Status,
+            SubmoduleStatus,
+        };
+
+        assert_eq!(
+            AttrCheckFlags::FILE_THEN_INDEX,
+            AttrCheckFlags::FILE_THEN_INDEX
+        );
+        assert_eq!(
+            CheckoutNotificationType::CONFLICT,
+            CheckoutNotificationType::CONFLICT
+        );
+        assert_eq!(
+            CredentialType::USER_PASS_PLAINTEXT,
+            CredentialType::USER_PASS_PLAINTEXT
+        );
+        assert_eq!(DiffFlags::BINARY, DiffFlags::BINARY);
+        assert_eq!(
+            DiffStatsFormat::INCLUDE_SUMMARY,
+            DiffStatsFormat::INCLUDE_SUMMARY
+        );
+        assert_eq!(
+            IndexAddOption::CHECK_PATHSPEC,
+            IndexAddOption::CHECK_PATHSPEC
+        );
+        assert_eq!(
+            IndexEntryExtendedFlag::INTENT_TO_ADD,
+            IndexEntryExtendedFlag::INTENT_TO_ADD
+        );
+        assert_eq!(IndexEntryFlag::EXTENDED, IndexEntryFlag::EXTENDED);
+        assert_eq!(
+            MergeAnalysis::ANALYSIS_FASTFORWARD,
+            MergeAnalysis::ANALYSIS_FASTFORWARD
+        );
+        assert_eq!(
+            MergePreference::FASTFORWARD_ONLY,
+            MergePreference::FASTFORWARD_ONLY
+        );
+        assert_eq!(OdbLookupFlags::NO_REFRESH, OdbLookupFlags::NO_REFRESH);
+        assert_eq!(PathspecFlags::FAILURES_ONLY, PathspecFlags::FAILURES_ONLY);
+        assert_eq!(
+            ReferenceFormat::ALLOW_ONELEVEL,
+            ReferenceFormat::ALLOW_ONELEVEL
+        );
+        assert_eq!(
+            RepositoryInitMode::SHARED_ALL,
+            RepositoryInitMode::SHARED_ALL
+        );
+        assert_eq!(RepositoryOpenFlags::CROSS_FS, RepositoryOpenFlags::CROSS_FS);
+        assert_eq!(RevparseMode::RANGE, RevparseMode::RANGE);
+        assert_eq!(Sort::REVERSE, Sort::REVERSE);
+        assert_eq!(
+            StashApplyFlags::REINSTATE_INDEX,
+            StashApplyFlags::REINSTATE_INDEX
+        );
+        assert_eq!(StashFlags::INCLUDE_IGNORED, StashFlags::INCLUDE_IGNORED);
+        assert_eq!(Status::WT_MODIFIED, Status::WT_MODIFIED);
+        assert_eq!(SubmoduleStatus::WD_ADDED, SubmoduleStatus::WD_ADDED);
     }
 }


### PR DESCRIPTION
This upgrades this project to use bitflags 2.1.0 which includes some ergonomic improvements for working with bit flags including iterators over name and values of the bit flag members. Change derives Debug and PartialEq for types so that we can display values for debugging and compare them.
