### PR TITLE
Remove mut when not needed

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -266,7 +266,7 @@ impl<'repo> Diff<'repo> {
         assert!(patch_no > 0);
         assert!(patch_no <= total_patches);
         let mut default = DiffFormatEmailOptions::default();
-        let mut raw_opts = opts.map_or(&mut default.raw, |opts| &mut opts.raw);
+        let raw_opts = opts.map_or(&mut default.raw, |opts| &mut opts.raw);
         let summary = commit.summary_bytes().unwrap();
         let mut message = commit.message_bytes();
         assert!(message.starts_with(summary));

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -251,7 +251,7 @@ extern "C" fn subtransport_action(
             n => panic!("unknown action: {}", n),
         };
 
-        let mut transport = &mut *(raw_transport as *mut RawSmartSubtransport);
+        let transport = &mut *(raw_transport as *mut RawSmartSubtransport);
         // Note: we only need to generate if rpc is on. Else, for receive-pack and upload-pack
         // libgit2 reuses the stream generated for receive-pack-ls or upload-pack-ls.
         let generate_stream =


### PR DESCRIPTION
A false negative for unused_mut was fixed in https://github.com/rust-lang/rust/pull/110960.