### PR TITLE
Implemented FusedIterator for various iterators

### DIFF
--- a/src/blame.rs
+++ b/src/blame.rs
@@ -1,5 +1,6 @@
 use crate::util::{self, Binding};
 use crate::{raw, signature, Oid, Repository, Signature};
+use std::iter::FusedIterator;
 use std::marker;
 use std::mem;
 use std::ops::Range;
@@ -306,6 +307,8 @@ impl<'blame> DoubleEndedIterator for BlameIter<'blame> {
         self.range.next_back().and_then(|i| self.blame.get_index(i))
     }
 }
+
+impl<'blame> FusedIterator for BlameIter<'blame> {}
 
 impl<'blame> ExactSizeIterator for BlameIter<'blame> {}
 

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -1,4 +1,5 @@
 use libc;
+use std::iter::FusedIterator;
 use std::marker;
 use std::mem;
 use std::ops::Range;
@@ -376,6 +377,8 @@ impl<'repo, 'commit> DoubleEndedIterator for Parents<'commit, 'repo> {
     }
 }
 
+impl<'repo, 'commit> FusedIterator for Parents<'commit, 'repo> {}
+
 impl<'repo, 'commit> ExactSizeIterator for Parents<'commit, 'repo> {}
 
 /// Aborts iteration when a commit cannot be found
@@ -399,6 +402,8 @@ impl<'commit> DoubleEndedIterator for ParentIds<'commit> {
             .and_then(|i| self.commit.parent_id(i).ok())
     }
 }
+
+impl<'commit> FusedIterator for ParentIds<'commit> {}
 
 impl<'commit> ExactSizeIterator for ParentIds<'commit> {}
 

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,5 +1,6 @@
 use libc::{c_char, c_int, c_void, size_t};
 use std::ffi::CString;
+use std::iter::FusedIterator;
 use std::marker;
 use std::mem;
 use std::ops::Range;
@@ -959,6 +960,8 @@ impl<'diff> DoubleEndedIterator for Deltas<'diff> {
         self.range.next_back().and_then(|i| self.diff.get_delta(i))
     }
 }
+impl<'diff> FusedIterator for Deltas<'diff> {}
+
 impl<'diff> ExactSizeIterator for Deltas<'diff> {}
 
 /// Line origin constants.

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,6 +1,7 @@
 use core::ops::Range;
 use std::ffi::CStr;
 use std::ffi::CString;
+use std::iter::FusedIterator;
 use std::ptr;
 
 use libc::{c_char, c_int};
@@ -171,6 +172,8 @@ impl<'pair> Iterator for MessageTrailersStrsIterator<'pair> {
     }
 }
 
+impl FusedIterator for MessageTrailersStrsIterator<'_> {}
+
 impl ExactSizeIterator for MessageTrailersStrsIterator<'_> {
     fn len(&self) -> usize {
         self.0.range.len()
@@ -212,6 +215,8 @@ impl<'pair> Iterator for MessageTrailersBytesIterator<'pair> {
         self.0.range.size_hint()
     }
 }
+
+impl FusedIterator for MessageTrailersBytesIterator<'_> {}
 
 impl ExactSizeIterator for MessageTrailersBytesIterator<'_> {
     fn len(&self) -> usize {

--- a/src/pathspec.rs
+++ b/src/pathspec.rs
@@ -1,5 +1,5 @@
 use libc::size_t;
-use std::iter::IntoIterator;
+use std::iter::{FusedIterator, IntoIterator};
 use std::marker;
 use std::ops::Range;
 use std::path::Path;
@@ -297,6 +297,7 @@ impl<'list> DoubleEndedIterator for PathspecEntries<'list> {
         self.range.next_back().and_then(|i| self.list.entry(i))
     }
 }
+impl<'list> FusedIterator for PathspecEntries<'list> {}
 impl<'list> ExactSizeIterator for PathspecEntries<'list> {}
 
 impl<'list> Iterator for PathspecDiffEntries<'list> {
@@ -313,6 +314,7 @@ impl<'list> DoubleEndedIterator for PathspecDiffEntries<'list> {
         self.range.next_back().and_then(|i| self.list.diff_entry(i))
     }
 }
+impl<'list> FusedIterator for PathspecDiffEntries<'list> {}
 impl<'list> ExactSizeIterator for PathspecDiffEntries<'list> {}
 
 impl<'list> Iterator for PathspecFailedEntries<'list> {
@@ -331,6 +333,7 @@ impl<'list> DoubleEndedIterator for PathspecFailedEntries<'list> {
             .and_then(|i| self.list.failed_entry(i))
     }
 }
+impl<'list> FusedIterator for PathspecFailedEntries<'list> {}
 impl<'list> ExactSizeIterator for PathspecFailedEntries<'list> {}
 
 #[cfg(test)]

--- a/src/reflog.rs
+++ b/src/reflog.rs
@@ -1,4 +1,5 @@
 use libc::size_t;
+use std::iter::FusedIterator;
 use std::marker;
 use std::ops::Range;
 use std::str;
@@ -174,6 +175,7 @@ impl<'reflog> DoubleEndedIterator for ReflogIter<'reflog> {
         self.range.next_back().and_then(|i| self.reflog.get(i))
     }
 }
+impl<'reflog> FusedIterator for ReflogIter<'reflog> {}
 impl<'reflog> ExactSizeIterator for ReflogIter<'reflog> {}
 
 #[cfg(test)]

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -1,5 +1,6 @@
 use libc;
 use raw::git_strarray;
+use std::iter::FusedIterator;
 use std::marker;
 use std::mem;
 use std::ops::Range;
@@ -462,6 +463,7 @@ impl<'repo> DoubleEndedIterator for Refspecs<'repo> {
             .and_then(|i| self.remote.get_refspec(i))
     }
 }
+impl<'repo> FusedIterator for Refspecs<'repo> {}
 impl<'repo> ExactSizeIterator for Refspecs<'repo> {}
 
 #[allow(missing_docs)] // not documented in libgit2 :(

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,5 +1,6 @@
 use libc::{c_char, c_uint, size_t};
 use std::ffi::CString;
+use std::iter::FusedIterator;
 use std::marker;
 use std::mem;
 use std::ops::Range;
@@ -303,6 +304,7 @@ impl<'a> DoubleEndedIterator for StatusIter<'a> {
         self.range.next_back().and_then(|i| self.statuses.get(i))
     }
 }
+impl<'a> FusedIterator for StatusIter<'a> {}
 impl<'a> ExactSizeIterator for StatusIter<'a> {}
 
 impl<'a> IntoIterator for &'a Statuses<'a> {

--- a/src/string_array.rs
+++ b/src/string_array.rs
@@ -1,5 +1,6 @@
 //! Bindings to libgit2's raw `git_strarray` type
 
+use std::iter::FusedIterator;
 use std::ops::Range;
 use std::str;
 
@@ -108,6 +109,7 @@ impl<'a> DoubleEndedIterator for Iter<'a> {
         self.range.next_back().map(|i| self.arr.get(i))
     }
 }
+impl<'a> FusedIterator for Iter<'a> {}
 impl<'a> ExactSizeIterator for Iter<'a> {}
 
 impl<'a> Iterator for IterBytes<'a> {
@@ -124,6 +126,7 @@ impl<'a> DoubleEndedIterator for IterBytes<'a> {
         self.range.next_back().and_then(|i| self.arr.get_bytes(i))
     }
 }
+impl<'a> FusedIterator for IterBytes<'a> {}
 impl<'a> ExactSizeIterator for IterBytes<'a> {}
 
 impl Drop for StringArray {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,6 +1,7 @@
 use libc::{self, c_char, c_int, c_void};
 use std::cmp::Ordering;
 use std::ffi::{CStr, CString};
+use std::iter::FusedIterator;
 use std::marker;
 use std::mem;
 use std::ops::Range;
@@ -401,6 +402,7 @@ impl<'tree> DoubleEndedIterator for TreeIter<'tree> {
         self.range.next_back().and_then(|i| self.tree.get(i))
     }
 }
+impl<'tree> FusedIterator for TreeIter<'tree> {}
 impl<'tree> ExactSizeIterator for TreeIter<'tree> {}
 
 #[cfg(test)]


### PR DESCRIPTION
Implemented `FusedIterator` for various iterators. All the iterators have one thing in common, they wrap a `Range`, which implements `FusedIterator`, thus guaranteeing the outer iterator is also fused.