### PR TITLE
build: `LIBGIT2_NO_VENDOR` to force to use system libgit2

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ source for libgit2 is included in the libgit2-sys crate so there's no need to
 pre-install the libgit2 library, the libgit2-sys crate will figure that and/or
 build that for you.
 
+You can enable the Cargo feature `vendored-libgit2` to always compile and
+statically link to a copy of libgit2. Sometimes the libgit2 on the system is
+required to be found and used even when `vendored-libgit2` is activated. In
+this case, you shall set the environment variable `LIBGIT2_NO_VENDOR=1`.
+
 ## Building git2-rs
 
 ```sh


### PR DESCRIPTION
Specify `LIBGIT2_NO_VENDOR` to force to use system libgit2.

Due to the additive nature of Cargo features, if some crate in the
dependency graph activates `vendored` feature, there is no way to
revert it back. This env var serves as a workaround for this purpose.

An alternative is having `no_vendored` feature. We still need to
modify `build.rs` to make both `vendored` and `no_vendored` play
nice with each other (or bail out as they are mutual-exclusive).
However, there is no way to activate a Cargo feature via environment
variable (see rust-lang/cargo#4829). Altering environment variables
may be the only way to interact with some external build systems.

It is also pretty common that people don't want to vendor anything and
rather to see the build fail than vendoring.

Some prior arts:

* `OPENSSL_NO_VENDOR` in `openssl` crate, which serves the exact
  purpose of `LIBGIT2_NO_VENDOR` [^1].
* Crate `ssh2` has a similar `LIBSSH2_SYS_USE_PKG_CONFIG`, but it
  doesn't force to do so. It still falls back to vendored lib [^2].
* Crate `curl` has a feature `force-system-lib-on-osx` to trump all
  others features. It was created primarily for Rust releases [^3].

[^1]: https://github.com/sfackler/rust-openssl/blob/50787ed35bf9efa9dd3cbb1993a2564014b67489/openssl/src/lib.rs#L65
[^2]: https://github.com/alexcrichton/ssh2-rs/blob/d9a1dfac4b8c09c5437eb477606b82aa4f67b092/libssh2-sys/build.rs#L22-L33
[^3]: https://github.com/alexcrichton/curl-rust/blob/431babf1dffe205641793353d3d57fdd36fe8534/curl-sys/build.rs#L15-L20
