### PR TITLE
bump libgit2 to v1.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git2"
-version = "0.17.2"
+version = "0.18.0"
 authors = ["Josh Triplett <josh@joshtriplett.org>", "Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -20,7 +20,7 @@ url = "2.0"
 bitflags = "1.1.0"
 libc = "0.2"
 log = "0.4.8"
-libgit2-sys = { path = "libgit2-sys", version = "0.15.2" }
+libgit2-sys = { path = "libgit2-sys", version = "0.16.0" }
 
 [target."cfg(all(unix, not(target_os = \"macos\")))".dependencies]
 openssl-sys = { version = "0.9.45", optional = true }

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ libgit2 bindings for Rust.
 
 ```toml
 [dependencies]
-git2 = "0.17.2"
+git2 = "0.18.0"
 ```
 
 ## Rust version requirements
@@ -16,7 +16,7 @@ stable release as well.
 
 ## Version of libgit2
 
-Currently this library requires libgit2 1.6.4 (or newer patch versions). The
+Currently this library requires libgit2 1.7.0 (or newer patch versions). The
 source for libgit2 is included in the libgit2-sys crate so there's no need to
 pre-install the libgit2 library, the libgit2-sys crate will figure that and/or
 build that for you.

--- a/git2-curl/Cargo.toml
+++ b/git2-curl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git2-curl"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Josh Triplett <josh@joshtriplett.org>", "Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/git2-rs"
@@ -16,7 +16,7 @@ edition = "2018"
 curl = "0.4.33"
 url = "2.0"
 log = "0.4"
-git2 = { path = "..", version = "0.17", default-features = false }
+git2 = { path = "..", version = "0.18", default-features = false }
 
 [dev-dependencies]
 civet = "0.11"

--- a/libgit2-sys/Cargo.toml
+++ b/libgit2-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libgit2-sys"
-version = "0.15.2+1.6.4"
+version = "0.16.0+1.7.0"
 authors = ["Josh Triplett <josh@joshtriplett.org>", "Alex Crichton <alex@alexcrichton.com>"]
 links = "git2"
 build = "build.rs"

--- a/libgit2-sys/build.rs
+++ b/libgit2-sys/build.rs
@@ -210,6 +210,7 @@ fn main() {
         println!("cargo:rustc-link-lib=rpcrt4");
         println!("cargo:rustc-link-lib=ole32");
         println!("cargo:rustc-link-lib=crypt32");
+        println!("cargo:rustc-link-lib=secur32");
     }
 
     if target.contains("apple") {

--- a/libgit2-sys/build.rs
+++ b/libgit2-sys/build.rs
@@ -122,6 +122,14 @@ fn main() {
         features.push_str("#define GIT_USE_NSEC 1\n");
     }
 
+    if windows {
+        features.push_str("#define GIT_IO_WSAPOLL 1\n");
+    } else {
+        // Should we fallback to `select` as more systems have that?
+        features.push_str("#define GIT_IO_POLL 1\n");
+        features.push_str("#define GIT_IO_SELECT 1\n");
+    }
+
     if target.contains("apple") {
         features.push_str("#define GIT_USE_STAT_MTIMESPEC 1\n");
     } else {

--- a/libgit2-sys/build.rs
+++ b/libgit2-sys/build.rs
@@ -14,7 +14,7 @@ fn main() {
     let try_to_use_system_libgit2 = !vendored && !zlib_ng_compat;
     if try_to_use_system_libgit2 {
         let mut cfg = pkg_config::Config::new();
-        if let Ok(lib) = cfg.range_version("1.6.4".."1.7.0").probe("libgit2") {
+        if let Ok(lib) = cfg.range_version("1.7.0".."1.8.0").probe("libgit2") {
             for include in &lib.include_paths {
                 println!("cargo:root={}", include.display());
             }

--- a/libgit2-sys/build.rs
+++ b/libgit2-sys/build.rs
@@ -49,7 +49,6 @@ fn main() {
     // Include all cross-platform C files
     add_c_files(&mut cfg, "libgit2/src/libgit2");
     add_c_files(&mut cfg, "libgit2/src/util");
-    add_c_files(&mut cfg, "libgit2/src/libgit2/xdiff");
 
     // These are activated by features, but they're all unconditionally always
     // compiled apparently and have internal #define's to make sure they're
@@ -60,6 +59,10 @@ fn main() {
     // Always use bundled http-parser for now
     cfg.include("libgit2/deps/http-parser")
         .file("libgit2/deps/http-parser/http_parser.c");
+
+    // external/system xdiff is not yet supported
+    cfg.include("libgit2/deps/xdiff");
+    add_c_files(&mut cfg, "libgit2/deps/xdiff");
 
     // Use the included PCRE regex backend.
     //

--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -394,8 +394,18 @@ pub struct git_fetch_options {
     pub update_fetchhead: c_int,
     pub download_tags: git_remote_autotag_option_t,
     pub proxy_opts: git_proxy_options,
+    pub depth: c_int,
     pub follow_redirects: git_remote_redirect_t,
     pub custom_headers: git_strarray,
+}
+
+#[repr(C)]
+pub struct git_fetch_negotiation {
+    refs: *const *const git_remote_head,
+    refs_len: size_t,
+    shallow_roots: *mut git_oid,
+    shallow_roots_len: size_t,
+    depth: c_int,
 }
 
 git_enum! {
@@ -1406,10 +1416,11 @@ pub struct git_transport {
         extern "C" fn(
             transport: *mut git_transport,
             repo: *mut git_repository,
-            refs: *const *const git_remote_head,
-            count: size_t,
+            fetch_data: *const git_fetch_negotiation,
         ) -> c_int,
     >,
+    pub shallow_roots:
+        Option<extern "C" fn(out: *mut git_oidarray, transport: *mut git_transport) -> c_int>,
     pub download_pack: Option<
         extern "C" fn(
             transport: *mut git_transport,

--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -1147,10 +1147,19 @@ pub struct git_diff_options {
     pub payload: *mut c_void,
     pub context_lines: u32,
     pub interhunk_lines: u32,
+    pub oid_type: git_oid_t,
     pub id_abbrev: u16,
     pub max_size: git_off_t,
     pub old_prefix: *const c_char,
     pub new_prefix: *const c_char,
+}
+
+git_enum! {
+    pub enum git_oid_t {
+        GIT_OID_SHA1 = 1,
+        // SHA256 is still experimental so we are not going to enable it.
+        /* GIT_OID_SHA256 = 2, */
+    }
 }
 
 git_enum! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@
 //! source `Repository`, to ensure that they do not outlive the repository
 //! itself.
 
-#![doc(html_root_url = "https://docs.rs/git2/0.17")]
+#![doc(html_root_url = "https://docs.rs/git2/0.18")]
 #![allow(trivial_numeric_casts, trivial_casts)]
 #![deny(missing_docs)]
 #![warn(rust_2018_idioms)]

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -588,6 +588,7 @@ impl<'cb> Binding for FetchOptions<'cb> {
             prune: crate::call::convert(&self.prune),
             update_fetchhead: crate::call::convert(&self.update_fetchhead),
             download_tags: crate::call::convert(&self.download_tags),
+            depth: 0, // GIT_FETCH_DEPTH_FULL.
             follow_redirects: self.follow_redirects.raw(),
             custom_headers: git_strarray {
                 count: self.custom_headers_ptrs.len(),

--- a/tests/add_extensions.rs
+++ b/tests/add_extensions.rs
@@ -12,10 +12,10 @@ fn test_add_extensions() -> Result<(), Error> {
     let extensions = unsafe { get_extensions() }?;
 
     assert_eq!(extensions.len(), 3);
-    assert_eq!(extensions.get(0), Some("noop"));
+    assert_eq!(extensions.get(0), Some("custom"));
     // The objectformat extension was added in 1.6
-    assert_eq!(extensions.get(1), Some("objectformat"));
-    assert_eq!(extensions.get(2), Some("custom"));
+    assert_eq!(extensions.get(1), Some("noop"));
+    assert_eq!(extensions.get(2), Some("objectformat"));
 
     Ok(())
 }


### PR DESCRIPTION
[Changelog](https://github.com/libgit2/libgit2/releases/tag/v1.7.0)

See each commit for details.

I'll hold off shallow clone binding support in `git2` crate. We could add that in a follow-up.

