### PR TITLE
chore: switch from ctest to ctest2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,8 +31,8 @@ jobs:
       shell: bash
     - run: cargo test --no-default-features
     - run: cargo test
-    - run: cargo run --manifest-path systest/Cargo.toml
-    - run: cargo test --manifest-path git2-curl/Cargo.toml
+    - run: cargo run -p systest
+    - run: cargo test -p git2-curl
 
   rustfmt:
     name: Rustfmt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,9 +31,7 @@ jobs:
       shell: bash
     - run: cargo test --no-default-features
     - run: cargo test
-    # skip systest on nightly because it requires the extprim crate which fails to compile on nightly rust
-    - run: if [[ "${{ matrix.rust }}" != "nightly" ]]; then cargo run --manifest-path systest/Cargo.toml; fi
-      shell: bash
+    - run: cargo run --manifest-path systest/Cargo.toml
     - run: cargo test --manifest-path git2-curl/Cargo.toml
 
   rustfmt:

--- a/systest/Cargo.toml
+++ b/systest/Cargo.toml
@@ -10,4 +10,4 @@ libgit2-sys = { path = "../libgit2-sys", features = ['https', 'ssh'] }
 libc = "0.2"
 
 [build-dependencies]
-ctest = "0.2.17"
+ctest2 = "0.4"

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
-    let mut cfg = ctest::TestGenerator::new();
+    let mut cfg = ctest2::TestGenerator::new();
     if let Some(root) = env::var_os("DEP_GIT2_ROOT") {
         cfg.include(PathBuf::from(root).join("include"));
     }


### PR DESCRIPTION
ctest is nearly unmaintained and emits lots of warnings. Switch to ctest2 to fix those. (rust-lang/libz-sys did this a couple years ago)

Also, with `ctest2` we won't be blocked on https://github.com/gnzlbg/ctest/issues/90, so enable systest on beta and nightly channels.