### PR TITLE
Publish via GitHub Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: Publish
+on:
+  workflow_dispatch:
+    inputs:
+      git2:
+        description: "Publish git2"
+        type: boolean
+        default: true
+      git2_curl:
+        description: "Publish git2-curl"
+        type: boolean
+        default: true
+      libgit2_sys:
+        description: "Publish libgit2-sys"
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          PUBLISH_GIT2: ${{ inputs.git2 }}
+          PUBLISH_GIT2_CURL: ${{ inputs.git2_curl }}
+          PUBLISH_LIBGIT2_SYS: ${{ inputs.libgit2_sys }}
+        run: ./ci/publish.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,15 +52,12 @@ Checklist for preparing for a release:
     - [`libgit2-sys/CHANGELOG.md`](https://github.com/rust-lang/git2-rs/blob/master/libgit2-sys/CHANGELOG.md)
     - [`git2-curl/CHANGELOG.md`](https://github.com/rust-lang/git2-rs/blob/master/git2-curl/CHANGELOG.md)
 
-To publish the new release:
+There is a GitHub workflow to handle publishing to crates.io and tagging the release. There are two different ways to run it:
 
-- In a fresh clone, make sure you run `git submodule update`.
-- For each updated package, run `cargo publish` (`libgit2-sys` then `git2` then `git2-curl`).
-- Set tags for each package that was update:
-    - `git tag 0.16.1`
-    - `git tag libgit2-sys-0.14.2+1.5.1`
-    - `git tag git2-curl-0.17.0`
-- Push the tags (substitute the "origin" remote name if you are using a different name):
-    - `git push origin 0.16.1`
-    - `git push origin libgit2-sys-0.14.2+1.5.1`
-    - `git push origin git2-curl-0.17.0`
+- In the GitHub web UI:
+    1. Go to <https://github.com/rust-lang/git2-rs/actions/workflows/publish.yml> (you can navigate here via the "Actions" tab at the top).
+    2. Click the "Run workflow" drop-down on the right.
+    3. Choose which crates to publish. It's OK to leave everything checked, it will skip if it is already published. Uncheck a crate if the version has been bumped in git, but you don't want to publish that particular one, yet.
+    4. Click "Run workflow"
+- In the CLI:
+    1. Run `gh workflow run publish.yml -R rust-lang/git2-rs`

--- a/ci/publish.sh
+++ b/ci/publish.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -e
+
+function publish {
+    publish_this="$1"
+    crate_name="$2"
+    manifest="$3"
+
+    if [ "$publish_this" != "true" ]
+    then
+        echo "Skipping $crate_name, publish not requested."
+        return
+    fi
+
+    # Get the version from Cargo.toml
+    version=`sed -n -E 's/^version = "(.*)"/\1/p' $manifest`
+
+    # Check crates.io if it is already published
+    set +e
+    output=`curl --fail --silent --head  https://crates.io/api/v1/crates/$crate_name/$version/download`
+    res="$?"
+    set -e
+    case $res in
+        0)
+            echo "${crate_name}@${version} appears to already be published"
+            return
+            ;;
+        22) ;;
+        *)
+            echo "Failed to check ${crate_name}@${version} res: $res"
+            echo "$output"
+            exit 1
+            ;;
+    esac
+
+    cargo publish --manifest-path $manifest --no-verify
+
+    tag="${crate_name}-${version}"
+    git tag $tag
+    git push origin "$tag"
+}
+
+publish $PUBLISH_LIBGIT2_SYS libgit2-sys libgit2-sys/Cargo.toml
+publish $PUBLISH_GIT2 git2 Cargo.toml
+publish $PUBLISH_GIT2_CURL git2-curl git2-curl/Cargo.toml


### PR DESCRIPTION
This sets up a manual workflow to publish to crates.io.