### PR TITLE
Add binding for GIT_OPT_SET_SSL_CERT_LOCATIONS

### DIFF
--- a/src/opts.rs
+++ b/src/opts.rs
@@ -195,22 +195,38 @@ pub unsafe fn set_verify_owner_validation(enabled: bool) -> Result<(), Error> {
     Ok(())
 }
 
-/// Set the SSL certificate-authority locations. `file` is the location of a file containing
-/// several certificates concatenated together. `path` is the location of a directory holding
-/// several certificates, one per file. Either parameter may be `None`, but not both.
-pub unsafe fn set_ssl_cert_locations<P>(file: Option<P>, path: Option<P>) -> Result<(), Error>
+/// Set the SSL certificate-authority location to `file`. `file` is the location
+/// of a file containing several certificates concatenated together.
+pub unsafe fn set_ssl_cert_file<P>(file: P) -> Result<(), Error>
 where
     P: IntoCString,
 {
     crate::init();
-    let file = crate::opt_cstr(file)?;
-    let path = crate::opt_cstr(path)?;
 
     unsafe {
         try_call!(raw::git_libgit2_opts(
             raw::GIT_OPT_SET_SSL_CERT_LOCATIONS as libc::c_int,
-            file,
-            path
+            file.into_c_string()?.as_ptr(),
+            core::ptr::null::<libc::c_char>()
+        ));
+    }
+
+    Ok(())
+}
+
+/// Set the SSL certificate-authority location to `path`. `path` is the location
+/// of a directory holding several certificates, one per file.
+pub unsafe fn set_ssl_cert_dir<P>(path: P) -> Result<(), Error>
+where
+    P: IntoCString,
+{
+    crate::init();
+
+    unsafe {
+        try_call!(raw::git_libgit2_opts(
+            raw::GIT_OPT_SET_SSL_CERT_LOCATIONS as libc::c_int,
+            core::ptr::null::<libc::c_char>(),
+            path.into_c_string()?.as_ptr()
         ));
     }
 

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -195,6 +195,28 @@ pub unsafe fn set_verify_owner_validation(enabled: bool) -> Result<(), Error> {
     Ok(())
 }
 
+/// Set the SSL certificate-authority locations. `file` is the location of a file containing
+/// several certificates concatenated together. `path` is the location of a directory holding
+/// several certificates, one per file. Either parameter may be `None`, but not both.
+pub unsafe fn set_ssl_cert_locations<P>(file: Option<P>, path: Option<P>) -> Result<(), Error>
+where
+    P: IntoCString,
+{
+    crate::init();
+    let file = crate::opt_cstr(file)?;
+    let path = crate::opt_cstr(path)?;
+
+    unsafe {
+        try_call!(raw::git_libgit2_opts(
+            raw::GIT_OPT_SET_SSL_CERT_LOCATIONS as libc::c_int,
+            file,
+            path
+        ));
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
Adds a binding for `git_libgit2_opts` key `GIT_OPT_SET_SSL_CERT_LOCATIONS` in `opts` module.

https://github.com/rust-lang/git2-rs/issues/995