### PR TITLE
Tree iteration: Make skipping ahead more efficient

### DIFF
--- a/src/tree.rs
+++ b/src/tree.rs
@@ -482,6 +482,24 @@ mod tests {
         }
     }
 
+    #[test]
+    fn smoke_tree_nth() {
+        let (td, repo) = crate::test::repo_init();
+
+        setup_repo(&td, &repo);
+
+        let head = repo.head().unwrap();
+        let target = head.target().unwrap();
+        let commit = repo.find_commit(target).unwrap();
+
+        let tree = repo.find_tree(commit.tree_id()).unwrap();
+        assert_eq!(tree.id(), commit.tree_id());
+        assert_eq!(tree.len(), 8);
+        let mut it = tree.iter();
+        let e = it.nth(4).unwrap();
+        assert_eq!(e.name(), Some("f4"));
+    }
+
     fn setup_repo(td: &TempDir, repo: &Repository) {
         let mut index = repo.index().unwrap();
         for n in 0..8 {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -397,6 +397,9 @@ impl<'tree> Iterator for TreeIter<'tree> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.range.size_hint()
     }
+    fn nth(&mut self, n: usize) -> Option<TreeEntry<'tree>> {
+        self.range.nth(n).and_then(|i| self.tree.get(i))
+    }
 }
 impl<'tree> DoubleEndedIterator for TreeIter<'tree> {
     fn next_back(&mut self) -> Option<TreeEntry<'tree>> {


### PR DESCRIPTION
Implement `TreeIter::nth` to make jumping ahead more efficient, and add tests for it.

Might be easiest to read the three commits separately.
