### PR TITLE
adding credential fill to the executed commands in the CredentialHelper

### DIFF
--- a/src/cred.rs
+++ b/src/cred.rs
@@ -303,7 +303,7 @@ impl CredentialHelper {
         } else if cmd.contains("/") || cmd.contains("\\") {
             self.commands.push(cmd.to_string());
         } else {
-            self.commands.push(format!("git credential-{}", cmd));
+            self.commands.push(format!("git credential-{} get", cmd));
         }
     }
 
@@ -374,7 +374,7 @@ impl CredentialHelper {
         // sure it works.
         let mut c = Command::new("sh");
         c.arg("-c")
-            .arg(&format!("{} get", cmd))
+            .arg(cmd)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());

--- a/src/cred.rs
+++ b/src/cred.rs
@@ -332,8 +332,11 @@ impl CredentialHelper {
         let mut password = None;
         for cmd in &self.commands {
             let (u, p) = self.execute_cmd(cmd, &username);
-            if u.is_some() && username.is_none() {
-                username = u;
+            #[allow(clippy::collapsible_if)]
+            if let Some(u) = u {
+                if !u.is_empty() && username.is_none() {
+                    username = Some(u);
+                }
             }
             if p.is_some() && password.is_none() {
                 password = p;

--- a/src/cred.rs
+++ b/src/cred.rs
@@ -263,6 +263,9 @@ impl CredentialHelper {
         }
         let global = config.get_string("credential.helper");
         self.add_command(global.as_ref().ok().map(|s| &s[..]));
+
+        // add the "fill" command
+        self.add_command(Some("!git credential fill"));
     }
 
     // Discover `useHttpPath` from `config`


### PR DESCRIPTION
This PR adds the functionality of the "git credential fill" command to the git credential helper.
This allows for better retrieval of credentials.

The PR is in 3 commits:
- repositioning a trailing "get" that got added to all commands, when it shouldn't have
- adding the aforementioned command in the function "config_helper" (this position is definitely debatable)
- checking if the returned username is empty, since "git credential fill" seems to always return something