### PR TITLE
examples: replace structopt with clap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ openssl-sys = { version = "0.9.45", optional = true }
 openssl-probe = { version = "0.1", optional = true }
 
 [dev-dependencies]
-structopt = "0.3"
+clap = { version = "4.4.13", features = ["derive"] }
 time = "0.1.39"
 tempfile = "3.1.0"
 

--- a/examples/add.rs
+++ b/examples/add.rs
@@ -15,15 +15,15 @@
 #![deny(warnings)]
 #![allow(trivial_casts)]
 
+use clap::Parser;
 use git2::Repository;
 use std::path::Path;
-use structopt::StructOpt;
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 struct Args {
     #[structopt(name = "spec")]
     arg_spec: Vec<String>,
-    #[structopt(name = "dry_run", short = "n", long)]
+    #[structopt(name = "dry_run", short = 'n', long)]
     /// dry run
     flag_dry_run: bool,
     #[structopt(name = "verbose", short, long)]
@@ -73,7 +73,7 @@ fn run(args: &Args) -> Result<(), git2::Error> {
 }
 
 fn main() {
-    let args = Args::from_args();
+    let args = Args::parse();
     match run(&args) {
         Ok(()) => {}
         Err(e) => println!("error: {}", e),

--- a/examples/blame.rs
+++ b/examples/blame.rs
@@ -14,25 +14,25 @@
 
 #![deny(warnings)]
 
+use clap::Parser;
 use git2::{BlameOptions, Repository};
 use std::io::{BufRead, BufReader};
 use std::path::Path;
-use structopt::StructOpt;
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 #[allow(non_snake_case)]
 struct Args {
     #[structopt(name = "path")]
     arg_path: String,
     #[structopt(name = "spec")]
     arg_spec: Option<String>,
-    #[structopt(short = "M")]
+    #[structopt(short = 'M')]
     /// find line moves within and across files
     flag_M: bool,
-    #[structopt(short = "C")]
+    #[structopt(short = 'C')]
     /// find line copies within and across files
     flag_C: bool,
-    #[structopt(short = "F")]
+    #[structopt(short = 'F')]
     /// follow only the first parent commits
     flag_F: bool,
 }
@@ -96,7 +96,7 @@ fn run(args: &Args) -> Result<(), git2::Error> {
 }
 
 fn main() {
-    let args = Args::from_args();
+    let args = Args::parse();
     match run(&args) {
         Ok(()) => {}
         Err(e) => println!("error: {}", e),

--- a/examples/cat-file.rs
+++ b/examples/cat-file.rs
@@ -16,23 +16,23 @@
 
 use std::io::{self, Write};
 
+use clap::Parser;
 use git2::{Blob, Commit, ObjectType, Repository, Signature, Tag, Tree};
-use structopt::StructOpt;
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 struct Args {
     #[structopt(name = "object")]
     arg_object: String,
-    #[structopt(short = "t")]
+    #[structopt(short = 't')]
     /// show the object type
     flag_t: bool,
-    #[structopt(short = "s")]
+    #[structopt(short = 's')]
     /// show the object size
     flag_s: bool,
-    #[structopt(short = "e")]
+    #[structopt(short = 'e')]
     /// suppress all output
     flag_e: bool,
-    #[structopt(short = "p")]
+    #[structopt(short = 'p')]
     /// pretty print the contents of the object
     flag_p: bool,
     #[structopt(name = "quiet", short, long)]
@@ -141,7 +141,7 @@ fn show_sig(header: &str, sig: Option<Signature>) {
 }
 
 fn main() {
-    let args = Args::from_args();
+    let args = Args::parse();
     match run(&args) {
         Ok(()) => {}
         Err(e) => println!("error: {}", e),

--- a/examples/clone.rs
+++ b/examples/clone.rs
@@ -14,14 +14,14 @@
 
 #![deny(warnings)]
 
+use clap::Parser;
 use git2::build::{CheckoutBuilder, RepoBuilder};
 use git2::{FetchOptions, Progress, RemoteCallbacks};
 use std::cell::RefCell;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
-use structopt::StructOpt;
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 struct Args {
     #[structopt(name = "url")]
     arg_url: String,
@@ -118,7 +118,7 @@ fn run(args: &Args) -> Result<(), git2::Error> {
 }
 
 fn main() {
-    let args = Args::from_args();
+    let args = Args::parse();
     match run(&args) {
         Ok(()) => {}
         Err(e) => println!("error: {}", e),

--- a/examples/diff.rs
+++ b/examples/diff.rs
@@ -14,12 +14,12 @@
 
 #![deny(warnings)]
 
+use clap::Parser;
 use git2::{Blob, Diff, DiffOptions, Error, Object, ObjectType, Oid, Repository};
 use git2::{DiffDelta, DiffFindOptions, DiffFormat, DiffHunk, DiffLine};
 use std::str;
-use structopt::StructOpt;
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 #[allow(non_snake_case)]
 struct Args {
     #[structopt(name = "from_oid")]
@@ -56,19 +56,19 @@ struct Args {
     #[structopt(name = "no-color", long)]
     /// never use color output
     flag_no_color: bool,
-    #[structopt(short = "R")]
+    #[structopt(short = 'R')]
     /// swap two inputs
     flag_R: bool,
-    #[structopt(name = "text", short = "a", long)]
+    #[structopt(name = "text", short = 'a', long)]
     /// treat all files as text
     flag_text: bool,
     #[structopt(name = "ignore-space-at-eol", long)]
     /// ignore changes in whitespace at EOL
     flag_ignore_space_at_eol: bool,
-    #[structopt(name = "ignore-space-change", short = "b", long)]
+    #[structopt(name = "ignore-space-change", short = 'b', long)]
     /// ignore changes in amount of whitespace
     flag_ignore_space_change: bool,
-    #[structopt(name = "ignore-all-space", short = "w", long)]
+    #[structopt(name = "ignore-all-space", short = 'w', long)]
     /// ignore whitespace when comparing lines
     flag_ignore_all_space: bool,
     #[structopt(name = "ignored", long)]
@@ -95,19 +95,19 @@ struct Args {
     #[structopt(name = "summary", long)]
     /// output condensed summary of header info
     flag_summary: bool,
-    #[structopt(name = "find-renames", short = "M", long)]
+    #[structopt(name = "find-renames", short = 'M', long)]
     /// set threshold for finding renames (default 50)
     flag_find_renames: Option<u16>,
-    #[structopt(name = "find-copies", short = "C", long)]
+    #[structopt(name = "find-copies", short = 'C', long)]
     /// set threshold for finding copies (default 50)
     flag_find_copies: Option<u16>,
     #[structopt(name = "find-copies-harder", long)]
     /// inspect unmodified files for sources of copies
     flag_find_copies_harder: bool,
-    #[structopt(name = "break_rewrites", short = "B", long)]
+    #[structopt(name = "break_rewrites", short = 'B', long)]
     /// break complete rewrite changes into pairs
     flag_break_rewrites: bool,
-    #[structopt(name = "unified", short = "U", long)]
+    #[structopt(name = "unified", short = 'U', long)]
     /// lints of context to show
     flag_unified: Option<u32>,
     #[structopt(name = "inter-hunk-context", long)]
@@ -360,7 +360,7 @@ impl Args {
 }
 
 fn main() {
-    let args = Args::from_args();
+    let args = Args::parse();
     match run(&args) {
         Ok(()) => {}
         Err(e) => println!("error: {}", e),

--- a/examples/fetch.rs
+++ b/examples/fetch.rs
@@ -14,12 +14,12 @@
 
 #![deny(warnings)]
 
+use clap::Parser;
 use git2::{AutotagOption, FetchOptions, RemoteCallbacks, Repository};
 use std::io::{self, Write};
 use std::str;
-use structopt::StructOpt;
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 struct Args {
     #[structopt(name = "remote")]
     arg_remote: Option<String>,
@@ -119,7 +119,7 @@ fn run(args: &Args) -> Result<(), git2::Error> {
 }
 
 fn main() {
-    let args = Args::from_args();
+    let args = Args::parse();
     match run(&args) {
         Ok(()) => {}
         Err(e) => println!("error: {}", e),

--- a/examples/init.rs
+++ b/examples/init.rs
@@ -14,11 +14,11 @@
 
 #![deny(warnings)]
 
+use clap::Parser;
 use git2::{Error, Repository, RepositoryInitMode, RepositoryInitOptions};
 use std::path::{Path, PathBuf};
-use structopt::StructOpt;
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 struct Args {
     #[structopt(name = "directory")]
     arg_directory: String,
@@ -137,7 +137,7 @@ fn parse_shared(shared: &str) -> Result<RepositoryInitMode, Error> {
 }
 
 fn main() {
-    let args = Args::from_args();
+    let args = Args::parse();
     match run(&args) {
         Ok(()) => {}
         Err(e) => println!("error: {}", e),

--- a/examples/log.rs
+++ b/examples/log.rs
@@ -14,12 +14,12 @@
 
 #![deny(warnings)]
 
+use clap::Parser;
 use git2::{Commit, DiffOptions, ObjectType, Repository, Signature, Time};
 use git2::{DiffFormat, Error, Pathspec};
 use std::str;
-use structopt::StructOpt;
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 struct Args {
     #[structopt(name = "topo-order", long)]
     /// sort commits in topological order
@@ -45,7 +45,7 @@ struct Args {
     #[structopt(name = "skip", long)]
     /// number of commits to skip
     flag_skip: Option<usize>,
-    #[structopt(name = "max-count", short = "n", long)]
+    #[structopt(name = "max-count", short = 'n', long)]
     /// maximum number of commits to show
     flag_max_count: Option<usize>,
     #[structopt(name = "merges", long)]
@@ -302,7 +302,7 @@ impl Args {
 }
 
 fn main() {
-    let args = Args::from_args();
+    let args = Args::parse();
     match run(&args) {
         Ok(()) => {}
         Err(e) => println!("error: {}", e),

--- a/examples/ls-remote.rs
+++ b/examples/ls-remote.rs
@@ -14,10 +14,10 @@
 
 #![deny(warnings)]
 
+use clap::Parser;
 use git2::{Direction, Repository};
-use structopt::StructOpt;
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 struct Args {
     #[structopt(name = "remote")]
     arg_remote: String,
@@ -43,7 +43,7 @@ fn run(args: &Args) -> Result<(), git2::Error> {
 }
 
 fn main() {
-    let args = Args::from_args();
+    let args = Args::parse();
     match run(&args) {
         Ok(()) => {}
         Err(e) => println!("error: {}", e),

--- a/examples/pull.rs
+++ b/examples/pull.rs
@@ -12,12 +12,12 @@
  * <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
 
+use clap::Parser;
 use git2::Repository;
 use std::io::{self, Write};
 use std::str;
-use structopt::StructOpt;
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 struct Args {
     arg_remote: Option<String>,
     arg_branch: Option<String>,
@@ -200,7 +200,7 @@ fn run(args: &Args) -> Result<(), git2::Error> {
 }
 
 fn main() {
-    let args = Args::from_args();
+    let args = Args::parse();
     match run(&args) {
         Ok(()) => {}
         Err(e) => println!("error: {}", e),

--- a/examples/rev-list.rs
+++ b/examples/rev-list.rs
@@ -15,10 +15,10 @@
 
 #![deny(warnings)]
 
+use clap::Parser;
 use git2::{Error, Oid, Repository, Revwalk};
-use structopt::StructOpt;
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 struct Args {
     #[structopt(name = "topo-order", long)]
     /// sort commits in topological order
@@ -97,7 +97,7 @@ fn push(revwalk: &mut Revwalk, id: Oid, hide: bool) -> Result<(), Error> {
 }
 
 fn main() {
-    let args = Args::from_args();
+    let args = Args::parse();
     match run(&args) {
         Ok(()) => {}
         Err(e) => println!("error: {}", e),

--- a/examples/rev-parse.rs
+++ b/examples/rev-parse.rs
@@ -14,10 +14,10 @@
 
 #![deny(warnings)]
 
+use clap::Parser;
 use git2::Repository;
-use structopt::StructOpt;
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 struct Args {
     #[structopt(name = "spec")]
     arg_spec: String,
@@ -52,7 +52,7 @@ fn run(args: &Args) -> Result<(), git2::Error> {
 }
 
 fn main() {
-    let args = Args::from_args();
+    let args = Args::parse();
     match run(&args) {
         Ok(()) => {}
         Err(e) => println!("error: {}", e),

--- a/examples/status.rs
+++ b/examples/status.rs
@@ -14,12 +14,12 @@
 
 #![deny(warnings)]
 
+use clap::Parser;
 use git2::{Error, ErrorCode, Repository, StatusOptions, SubmoduleIgnore};
 use std::str;
 use std::time::Duration;
-use structopt::StructOpt;
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 struct Args {
     arg_spec: Vec<String>,
     #[structopt(name = "long", long)]
@@ -433,7 +433,7 @@ impl Args {
 }
 
 fn main() {
-    let args = Args::from_args();
+    let args = Args::parse();
     match run(&args) {
         Ok(()) => {}
         Err(e) => println!("error: {}", e),

--- a/examples/tag.rs
+++ b/examples/tag.rs
@@ -14,11 +14,11 @@
 
 #![deny(warnings)]
 
+use clap::Parser;
 use git2::{Commit, Error, Repository, Tag};
 use std::str;
-use structopt::StructOpt;
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 struct Args {
     arg_tagname: Option<String>,
     arg_object: Option<String>,
@@ -119,7 +119,7 @@ fn print_list_lines(message: Option<&str>, args: &Args) {
 }
 
 fn main() {
-    let args = Args::from_args();
+    let args = Args::parse();
     match run(&args) {
         Ok(()) => {}
         Err(e) => println!("error: {}", e),


### PR DESCRIPTION
See https://github.com/TeXitoi/structopt/issues/525.

Currently git2 is the most downloaded dependent of structopt:
https://crates.io/crates/structopt/reverse_dependencies.
