### PR TITLE
Allow find commit by short hash prefix

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -2827,6 +2827,12 @@ extern "C" {
         repo: *mut git_repository,
         id: *const git_oid,
     ) -> c_int;
+    pub fn git_commit_lookup_prefix(
+        commit: *mut *mut git_commit,
+        repo: *mut git_repository,
+        id: *const git_oid,
+        len: size_t,
+    ) -> c_int;
     pub fn git_commit_message(commit: *const git_commit) -> *const c_char;
     pub fn git_commit_message_encoding(commit: *const git_commit) -> *const c_char;
     pub fn git_commit_message_raw(commit: *const git_commit) -> *const c_char;

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1418,6 +1418,20 @@ impl Repository {
         }
     }
 
+    /// Lookup a reference to one of the commits in a repository by short hash.
+    pub fn find_commit_by_prefix(&self, prefix_hash: &str) -> Result<Commit<'_>, Error> {
+        let mut raw = ptr::null_mut();
+        unsafe {
+            try_call!(raw::git_commit_lookup_prefix(
+                &mut raw,
+                self.raw(),
+                Oid::from_str(prefix_hash)?.raw(),
+                prefix_hash.len()
+            ));
+            Ok(Binding::from_raw(raw))
+        }
+    }
+
     /// Creates an `AnnotatedCommit` from the given commit id.
     pub fn find_annotated_commit(&self, id: Oid) -> Result<AnnotatedCommit<'_>, Error> {
         unsafe {


### PR DESCRIPTION
This API allow to find a commit by short hash:

```rs
repo.find_commit_by_prefix("4e2c95a")
```