### PR TITLE
Fix syntax of example `git fetch`

### DIFF
--- a/src/remote.rs
+++ b/src/remote.rs
@@ -290,7 +290,7 @@ impl<'repo> Remote<'repo> {
     ///
     /// # Examples
     ///
-    /// Example of functionality similar to `git fetch origin/main`:
+    /// Example of functionality similar to `git fetch origin main`:
     ///
     /// ```no_run
     /// fn fetch_origin_main(repo: git2::Repository) -> Result<(), git2::Error> {


### PR DESCRIPTION
Fix for a minor typo in `remote.rs` that tripped me up while reading through the documentation.