### PR TITLE
chore: update libgit2 submodule to 1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.18.2 - 2024-02-06
+[0.18.1...0.18.2](https://github.com/rust-lang/git2-rs/compare/git2-0.18.1...git2-0.18.2)
+
+### Changed
+
+- Updated to libgit2 [1.7.2](https://github.com/libgit2/libgit2/releases/tag/v1.7.2).
+  [#1017](https://github.com/rust-lang/git2-rs/pull/1017)
+
 ## 0.18.1 - 2023-09-20
 [0.18.0...0.18.1](https://github.com/rust-lang/git2-rs/compare/git2-0.18.0...git2-0.18.1)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git2"
-version = "0.18.1"
+version = "0.18.2"
 authors = ["Josh Triplett <josh@joshtriplett.org>", "Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -20,7 +20,7 @@ url = "2.0"
 bitflags = "2.1.0"
 libc = "0.2"
 log = "0.4.8"
-libgit2-sys = { path = "libgit2-sys", version = "0.16.0" }
+libgit2-sys = { path = "libgit2-sys", version = "0.16.2" }
 
 [target."cfg(all(unix, not(target_os = \"macos\")))".dependencies]
 openssl-sys = { version = "0.9.45", optional = true }

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ libgit2 bindings for Rust.
 
 ```toml
 [dependencies]
-git2 = "0.18.1"
+git2 = "0.18.2"
 ```
 
 ## Rust version requirements
@@ -16,7 +16,7 @@ stable release as well.
 
 ## Version of libgit2
 
-Currently this library requires libgit2 1.7.1 (or newer patch versions). The
+Currently this library requires libgit2 1.7.2 (or newer patch versions). The
 source for libgit2 is included in the libgit2-sys crate so there's no need to
 pre-install the libgit2 library, the libgit2-sys crate will figure that and/or
 build that for you.

--- a/libgit2-sys/CHANGELOG.md
+++ b/libgit2-sys/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 0.16.2+1.7.2 - 2024-02-06
 [0.16.1...0.16.2](https://github.com/rust-lang/git2-rs/compare/libgit2-sys-0.16.1+1.7.1...libgit2-sys-0.16.2+1.7.2)
 
+- Updated to libgit2 [1.7.2](https://github.com/libgit2/libgit2/releases/tag/v1.7.2).
+  [#1017](https://github.com/rust-lang/git2-rs/pull/1017)
+
 ## 0.16.1+1.7.1 - 2023-08-28
 [0.16.0...0.16.1](https://github.com/rust-lang/git2-rs/compare/libgit2-sys-0.16.0+1.7.1...libgit2-sys-0.16.1+1.7.1)
 

--- a/libgit2-sys/CHANGELOG.md
+++ b/libgit2-sys/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.16.2+1.7.2 - 2024-02-06
+[0.16.1...0.16.2](https://github.com/rust-lang/git2-rs/compare/libgit2-sys-0.16.1+1.7.1...libgit2-sys-0.16.2+1.7.2)
+
 ## 0.16.1+1.7.1 - 2023-08-28
 [0.16.0...0.16.1](https://github.com/rust-lang/git2-rs/compare/libgit2-sys-0.16.0+1.7.1...libgit2-sys-0.16.1+1.7.1)
 

--- a/libgit2-sys/Cargo.toml
+++ b/libgit2-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libgit2-sys"
-version = "0.16.1+1.7.1"
+version = "0.16.2+1.7.2"
 authors = ["Josh Triplett <josh@joshtriplett.org>", "Alex Crichton <alex@alexcrichton.com>"]
 links = "git2"
 build = "build.rs"

--- a/libgit2-sys/build.rs
+++ b/libgit2-sys/build.rs
@@ -7,7 +7,7 @@ use std::process::Command;
 /// Tries to use system libgit2 and emits necessary build script instructions.
 fn try_system_libgit2() -> Result<pkg_config::Library, pkg_config::Error> {
     let mut cfg = pkg_config::Config::new();
-    match cfg.range_version("1.7.1".."1.8.0").probe("libgit2") {
+    match cfg.range_version("1.7.2".."1.8.0").probe("libgit2") {
         Ok(lib) => {
             for include in &lib.include_paths {
                 println!("cargo:root={}", include.display());


### PR DESCRIPTION
libgit2 v1.7.2 includes two CVE fixes:

* CVE-2024-24575: https://github.com/libgit2/libgit2/security/advisories/GHSA-54mf-x2rh-hq9v
* CVE-2024-24577: https://github.com/libgit2/libgit2/security/advisories/GHSA-j2v7-4f6v-gpg8