### PR TITLE
Temporarily limit systest to stable.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,11 @@ jobs:
       shell: bash
     - run: cargo test --no-default-features
     - run: cargo test
+    # NOTE: ctest2 is currently failing on 1.78 nightly. Pinning the toolchain
+    # for now, but we'll need either a new release of ctest2 or some other
+    # solution soon.
     - run: cargo run -p systest
+      if: matrix.rust == 'stable'
     - run: cargo test -p git2-curl
 
   rustfmt:


### PR DESCRIPTION
garando_syntax is currently failing on the latest 1.78 nightly. It looks like a fix is in the works (https://github.com/JohnTitor/garando/pull/22), but currently not yet available. In the meantime, this prevents CI from being gated on nightly for systest.
