### PR TITLE
Revert "Merge pull request #1021 from ehuss/stable-ctest2"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,11 +35,7 @@ jobs:
       shell: bash
     - run: cargo test --no-default-features
     - run: cargo test
-    # NOTE: ctest2 is currently failing on 1.78 nightly. Pinning the toolchain
-    # for now, but we'll need either a new release of ctest2 or some other
-    # solution soon.
     - run: cargo run -p systest
-      if: matrix.rust == 'stable'
     - run: cargo test -p git2-curl
 
   rustfmt:


### PR DESCRIPTION
This reverts commit 81a1f16b81e1248df8e3399894af8c4f38dcc3fb, reversing changes made to 987c4e60d3e0e69d58e830527e4c727c776c2c9e.

Reverting since a new release of ctest2 has been published which seems to resolve the issue.