### PR TITLE
Remove redundant imports.

### DIFF
--- a/src/call.rs
+++ b/src/call.rs
@@ -1,5 +1,4 @@
 #![macro_use]
-use libc;
 
 use crate::Error;
 
@@ -53,8 +52,6 @@ pub fn last_error(code: libc::c_int) -> Error {
 mod impls {
     use std::ffi::CString;
     use std::ptr;
-
-    use libc;
 
     use crate::call::Convert;
     use crate::{raw, BranchType, ConfigLevel, Direction, ObjectType, ResetType};

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -1,4 +1,3 @@
-use libc;
 use std::iter::FusedIterator;
 use std::marker;
 use std::mem;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,3 @@
-use libc;
 use std::ffi::CString;
 use std::marker;
 use std::path::{Path, PathBuf};

--- a/src/cred.rs
+++ b/src/cred.rs
@@ -5,7 +5,6 @@ use std::mem;
 use std::path::Path;
 use std::process::{Command, Stdio};
 use std::ptr;
-use url;
 
 use crate::util::Binding;
 use crate::{raw, Config, Error, IntoCString};

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -1,4 +1,3 @@
-use libc;
 use std::cmp::Ordering;
 use std::fmt;
 use std::hash::{Hash, Hasher};

--- a/src/pathspec.rs
+++ b/src/pathspec.rs
@@ -1,5 +1,5 @@
 use libc::size_t;
-use std::iter::{FusedIterator, IntoIterator};
+use std::iter::FusedIterator;
 use std::marker;
 use std::ops::Range;
 use std::path::Path;

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -1,4 +1,3 @@
-use libc;
 use raw::git_strarray;
 use std::iter::FusedIterator;
 use std::marker;

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1,7 +1,6 @@
 use libc::{c_char, c_int, c_uint, c_void, size_t};
 use std::env;
 use std::ffi::{CStr, CString, OsStr};
-use std::iter::IntoIterator;
 use std::mem;
 use std::path::{Path, PathBuf};
 use std::ptr;

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -1,4 +1,3 @@
-use libc;
 use std::ffi::CString;
 use std::fmt;
 use std::marker;

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,4 +1,4 @@
-use libc::{self, c_char, c_int, c_void};
+use libc::{c_char, c_int, c_void};
 use std::cmp::Ordering;
 use std::ffi::{CStr, CString};
 use std::iter::FusedIterator;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,6 @@
 use libc::{c_char, c_int, size_t};
 use std::cmp::Ordering;
 use std::ffi::{CString, OsStr, OsString};
-use std::iter::IntoIterator;
 use std::path::{Component, Path, PathBuf};
 
 use crate::{raw, Error};


### PR DESCRIPTION
The latest nightly has started to produce a warning for redundant imports.