### PR TITLE
Add bindings for mwindow opts

### DIFF
--- a/src/opts.rs
+++ b/src/opts.rs
@@ -234,94 +234,106 @@ where
 }
 
 /// Get the maximum mmap window size
-pub fn get_mwindow_size() -> Result<libc::size_t, Error> {
+///
+/// # Safety
+/// This function is reading a C global without synchronization, so it is not
+/// thread safe, and should only be called before any thread is spawned.
+pub unsafe fn get_mwindow_size() -> Result<libc::size_t, Error> {
     crate::init();
 
     let mut size = 0;
 
-    unsafe {
-        try_call!(raw::git_libgit2_opts(
-            raw::GIT_OPT_GET_MWINDOW_SIZE as libc::c_int,
-            &mut size
-        ));
-    }
+    try_call!(raw::git_libgit2_opts(
+        raw::GIT_OPT_GET_MWINDOW_SIZE as libc::c_int,
+        &mut size
+    ));
 
     Ok(size)
 }
 
 /// Set the maximum mmap window size
-pub fn set_mwindow_size(size: libc::size_t) -> Result<(), Error> {
+///
+/// # Safety
+/// This function is modifying a C global without synchronization, so it is not
+/// thread safe, and should only be called before any thread is spawned.
+pub unsafe fn set_mwindow_size(size: libc::size_t) -> Result<(), Error> {
     crate::init();
 
-    unsafe {
-        try_call!(raw::git_libgit2_opts(
-            raw::GIT_OPT_SET_MWINDOW_SIZE as libc::c_int,
-            size
-        ));
-    }
+    try_call!(raw::git_libgit2_opts(
+        raw::GIT_OPT_SET_MWINDOW_SIZE as libc::c_int,
+        size
+    ));
 
     Ok(())
 }
 
 /// Get the maximum memory that will be mapped in total by the library
-pub fn get_mwindow_mapped_limit() -> Result<libc::size_t, Error> {
+///
+/// # Safety
+/// This function is reading a C global without synchronization, so it is not
+/// thread safe, and should only be called before any thread is spawned.
+pub unsafe fn get_mwindow_mapped_limit() -> Result<libc::size_t, Error> {
     crate::init();
 
     let mut limit = 0;
 
-    unsafe {
-        try_call!(raw::git_libgit2_opts(
-            raw::GIT_OPT_GET_MWINDOW_MAPPED_LIMIT as libc::c_int,
-            &mut limit
-        ));
-    }
+    try_call!(raw::git_libgit2_opts(
+        raw::GIT_OPT_GET_MWINDOW_MAPPED_LIMIT as libc::c_int,
+        &mut limit
+    ));
 
     Ok(limit)
 }
 
 /// Set the maximum amount of memory that can be mapped at any time
 /// by the library.
-pub fn set_mwindow_mapped_limit(limit: libc::size_t) -> Result<(), Error> {
+///
+/// # Safety
+/// This function is modifying a C global without synchronization, so it is not
+/// thread safe, and should only be called before any thread is spawned.
+pub unsafe fn set_mwindow_mapped_limit(limit: libc::size_t) -> Result<(), Error> {
     crate::init();
 
-    unsafe {
-        try_call!(raw::git_libgit2_opts(
-            raw::GIT_OPT_SET_MWINDOW_MAPPED_LIMIT as libc::c_int,
-            limit
-        ));
-    }
+    try_call!(raw::git_libgit2_opts(
+        raw::GIT_OPT_SET_MWINDOW_MAPPED_LIMIT as libc::c_int,
+        limit
+    ));
 
     Ok(())
 }
 
 /// Get the maximum number of files that will be mapped at any time by the
 /// library.
-pub fn get_mwindow_file_limit() -> Result<libc::size_t, Error> {
+///
+/// # Safety
+/// This function is reading a C global without synchronization, so it is not
+/// thread safe, and should only be called before any thread is spawned.
+pub unsafe fn get_mwindow_file_limit() -> Result<libc::size_t, Error> {
     crate::init();
 
     let mut limit = 0;
 
-    unsafe {
-        try_call!(raw::git_libgit2_opts(
-            raw::GIT_OPT_GET_MWINDOW_FILE_LIMIT as libc::c_int,
-            &mut limit
-        ));
-    }
+    try_call!(raw::git_libgit2_opts(
+        raw::GIT_OPT_GET_MWINDOW_FILE_LIMIT as libc::c_int,
+        &mut limit
+    ));
 
     Ok(limit)
 }
 
 /// Set the maximum number of files that can be mapped at any time
 /// by the library. The default (0) is unlimited.
-pub fn set_mwindow_file_limit(limit: libc::size_t) -> Result<(), Error> {
+///
+/// # Safety
+/// This function is modifying a C global without synchronization, so it is not
+/// thread safe, and should only be called before any thread is spawned.
+pub unsafe fn set_mwindow_file_limit(limit: libc::size_t) -> Result<(), Error> {
     crate::init();
 
-    unsafe {
-        try_call!(raw::git_libgit2_opts(
-            raw::GIT_OPT_SET_MWINDOW_FILE_LIMIT as libc::c_int,
-            limit
-        ));
-    }
+    try_call!(raw::git_libgit2_opts(
+        raw::GIT_OPT_SET_MWINDOW_FILE_LIMIT as libc::c_int,
+        limit
+    ));
 
     Ok(())
 }
@@ -337,19 +349,25 @@ mod test {
 
     #[test]
     fn mwindow_size() {
-        assert!(set_mwindow_size(1024).is_ok());
-        assert!(get_mwindow_size().unwrap() == 1024);
+        unsafe {
+            assert!(set_mwindow_size(1024).is_ok());
+            assert!(get_mwindow_size().unwrap() == 1024);
+        }
     }
 
     #[test]
     fn mwindow_mapped_limit() {
-        assert!(set_mwindow_mapped_limit(1024).is_ok());
-        assert!(get_mwindow_mapped_limit().unwrap() == 1024);
+        unsafe {
+            assert!(set_mwindow_mapped_limit(1024).is_ok());
+            assert!(get_mwindow_mapped_limit().unwrap() == 1024);
+        }
     }
 
     #[test]
     fn mwindow_file_limit() {
-        assert!(set_mwindow_file_limit(1024).is_ok());
-        assert!(get_mwindow_file_limit().unwrap() == 1024);
+        unsafe {
+            assert!(set_mwindow_file_limit(1024).is_ok());
+            assert!(get_mwindow_file_limit().unwrap() == 1024);
+        }
     }
 }

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -234,7 +234,7 @@ where
 }
 
 /// Get the maximum mmap window size
-pub fn get_mwindow_size() -> Result<usize, Error> {
+pub fn get_mwindow_size() -> Result<libc::size_t, Error> {
     crate::init();
 
     let mut size = 0;
@@ -250,7 +250,7 @@ pub fn get_mwindow_size() -> Result<usize, Error> {
 }
 
 /// Set the maximum mmap window size
-pub fn set_mwindow_size(size: usize) -> Result<(), Error> {
+pub fn set_mwindow_size(size: libc::size_t) -> Result<(), Error> {
     crate::init();
 
     unsafe {
@@ -264,7 +264,7 @@ pub fn set_mwindow_size(size: usize) -> Result<(), Error> {
 }
 
 /// Get the maximum memory that will be mapped in total by the library
-pub fn get_mwindow_mapped_limit() -> Result<usize, Error> {
+pub fn get_mwindow_mapped_limit() -> Result<libc::size_t, Error> {
     crate::init();
 
     let mut limit = 0;
@@ -281,7 +281,7 @@ pub fn get_mwindow_mapped_limit() -> Result<usize, Error> {
 
 /// Set the maximum amount of memory that can be mapped at any time
 /// by the library.
-pub fn set_mwindow_mapped_limit(limit: usize) -> Result<(), Error> {
+pub fn set_mwindow_mapped_limit(limit: libc::size_t) -> Result<(), Error> {
     crate::init();
 
     unsafe {
@@ -296,7 +296,7 @@ pub fn set_mwindow_mapped_limit(limit: usize) -> Result<(), Error> {
 
 /// Get the maximum number of files that will be mapped at any time by the
 /// library.
-pub fn get_mwindow_file_limit() -> Result<usize, Error> {
+pub fn get_mwindow_file_limit() -> Result<libc::size_t, Error> {
     crate::init();
 
     let mut limit = 0;
@@ -313,7 +313,7 @@ pub fn get_mwindow_file_limit() -> Result<usize, Error> {
 
 /// Set the maximum number of files that can be mapped at any time
 /// by the library. The default (0) is unlimited.
-pub fn set_mwindow_file_limit(limit: usize) -> Result<(), Error> {
+pub fn set_mwindow_file_limit(limit: libc::size_t) -> Result<(), Error> {
     crate::init();
 
     unsafe {

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -233,6 +233,99 @@ where
     Ok(())
 }
 
+/// Get the maximum mmap window size
+pub fn get_mwindow_size() -> Result<usize, Error> {
+    crate::init();
+
+    let mut size = 0;
+
+    unsafe {
+        try_call!(raw::git_libgit2_opts(
+            raw::GIT_OPT_GET_MWINDOW_SIZE as libc::c_int,
+            &mut size
+        ));
+    }
+
+    Ok(size)
+}
+
+/// Set the maximum mmap window size
+pub fn set_mwindow_size(size: usize) -> Result<(), Error> {
+    crate::init();
+
+    unsafe {
+        try_call!(raw::git_libgit2_opts(
+            raw::GIT_OPT_SET_MWINDOW_SIZE as libc::c_int,
+            size
+        ));
+    }
+
+    Ok(())
+}
+
+/// Get the maximum memory that will be mapped in total by the library
+pub fn get_mwindow_mapped_limit() -> Result<usize, Error> {
+    crate::init();
+
+    let mut limit = 0;
+
+    unsafe {
+        try_call!(raw::git_libgit2_opts(
+            raw::GIT_OPT_GET_MWINDOW_MAPPED_LIMIT as libc::c_int,
+            &mut limit
+        ));
+    }
+
+    Ok(limit)
+}
+
+/// Set the maximum amount of memory that can be mapped at any time
+/// by the library.
+pub fn set_mwindow_mapped_limit(limit: usize) -> Result<(), Error> {
+    crate::init();
+
+    unsafe {
+        try_call!(raw::git_libgit2_opts(
+            raw::GIT_OPT_SET_MWINDOW_MAPPED_LIMIT as libc::c_int,
+            limit
+        ));
+    }
+
+    Ok(())
+}
+
+/// Get the maximum number of files that will be mapped at any time by the
+/// library.
+pub fn get_mwindow_file_limit() -> Result<usize, Error> {
+    crate::init();
+
+    let mut limit = 0;
+
+    unsafe {
+        try_call!(raw::git_libgit2_opts(
+            raw::GIT_OPT_GET_MWINDOW_FILE_LIMIT as libc::c_int,
+            &mut limit
+        ));
+    }
+
+    Ok(limit)
+}
+
+/// Set the maximum number of files that can be mapped at any time
+/// by the library. The default (0) is unlimited.
+pub fn set_mwindow_file_limit(limit: usize) -> Result<(), Error> {
+    crate::init();
+
+    unsafe {
+        try_call!(raw::git_libgit2_opts(
+            raw::GIT_OPT_SET_MWINDOW_FILE_LIMIT as libc::c_int,
+            limit
+        ));
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -240,5 +333,23 @@ mod test {
     #[test]
     fn smoke() {
         strict_hash_verification(false);
+    }
+
+    #[test]
+    fn mwindow_size() {
+        assert!(set_mwindow_size(1024).is_ok());
+        assert!(get_mwindow_size().unwrap() == 1024);
+    }
+
+    #[test]
+    fn mwindow_mapped_limit() {
+        assert!(set_mwindow_mapped_limit(1024).is_ok());
+        assert!(get_mwindow_mapped_limit().unwrap() == 1024);
+    }
+
+    #[test]
+    fn mwindow_file_limit() {
+        assert!(set_mwindow_file_limit(1024).is_ok());
+        assert!(get_mwindow_file_limit().unwrap() == 1024);
     }
 }


### PR DESCRIPTION
This adds bindings for the mwindow options (https://libgit2.org/libgit2/#HEAD/group/libgit2/git_libgit2_opts)

This will avoid calling libgit2-sys directly to set these options, see related issues where this would be useful:
- https://github.com/rust-lang/git2-rs/issues/626#issuecomment-765654455
- https://github.com/rust-lang/git2-rs/issues/904#issuecomment-1382129456