### PR TITLE
Release 0.18.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+
+## 0.18.3 - 2024-03-18
+[0.18.2...0.18.3](https://github.com/rust-lang/git2-rs/compare/git2-0.18.2...git2-0.18.3)
+
+### Added
+
+- Added `opts::` functions to get / set libgit2 mwindow options
+  [#1035](https://github.com/rust-lang/git2-rs/pull/1035)
+
+
+### Changed
+
+- Updated examples to use clap instead of structopt
+  [#1007](https://github.com/rust-lang/git2-rs/pull/1007)
+
 ## 0.18.2 - 2024-02-06
 [0.18.1...0.18.2](https://github.com/rust-lang/git2-rs/compare/git2-0.18.1...git2-0.18.2)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git2"
-version = "0.18.2"
+version = "0.18.3"
 authors = ["Josh Triplett <josh@joshtriplett.org>", "Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ libgit2 bindings for Rust.
 
 ```toml
 [dependencies]
-git2 = "0.18.2"
+git2 = "0.18.3"
 ```
 
 ## Rust version requirements


### PR DESCRIPTION
Release containing #1007 and #1035. 

All other changes seem to be unnecessary imports removal & FUNDING.json, not sure if worth mentioning in the Changelog.