### PR TITLE
Fix publish not following redirect

### DIFF
--- a/ci/publish.sh
+++ b/ci/publish.sh
@@ -18,7 +18,7 @@ function publish {
 
     # Check crates.io if it is already published
     set +e
-    output=`curl --fail --silent --head  https://crates.io/api/v1/crates/$crate_name/$version/download`
+    output=`curl --fail --silent --head --location https://static.crates.io/crates/$crate_name/$version/download`
     res="$?"
     set -e
     case $res in


### PR DESCRIPTION
This fixes the publish script for the recent changes in crates.io which redirects to the CDN.