### PR TITLE
Support global opts related to server timeouts

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -128,6 +128,7 @@ impl Error {
             raw::GIT_EINDEXDIRTY => super::ErrorCode::IndexDirty,
             raw::GIT_EAPPLYFAIL => super::ErrorCode::ApplyFail,
             raw::GIT_EOWNER => super::ErrorCode::Owner,
+            raw::GIT_TIMEOUT => super::ErrorCode::Timeout,
             _ => super::ErrorCode::GenericError,
         }
     }
@@ -165,6 +166,7 @@ impl Error {
             ErrorCode::IndexDirty => raw::GIT_EINDEXDIRTY,
             ErrorCode::ApplyFail => raw::GIT_EAPPLYFAIL,
             ErrorCode::Owner => raw::GIT_EOWNER,
+            ErrorCode::Timeout => raw::GIT_TIMEOUT,
         };
     }
 
@@ -296,6 +298,7 @@ impl Error {
             GIT_EINDEXDIRTY,
             GIT_EAPPLYFAIL,
             GIT_EOWNER,
+            GIT_TIMEOUT,
         )
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,6 +218,8 @@ pub enum ErrorCode {
     ApplyFail,
     /// The object is not owned by the current user
     Owner,
+    /// Timeout
+    Timeout,
 }
 
 /// An enumeration of possible categories of things that can have

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -338,6 +338,82 @@ pub unsafe fn set_mwindow_file_limit(limit: libc::size_t) -> Result<(), Error> {
     Ok(())
 }
 
+/// Get server connect timeout in milliseconds
+///
+/// # Safety
+/// This function is modifying a C global without synchronization, so it is not
+/// thread safe, and should only be called before any thread is spawned.
+pub unsafe fn get_server_connect_timeout_in_milliseconds() -> Result<libc::c_int, Error> {
+    crate::init();
+
+    let mut server_connect_timeout = 0;
+
+    try_call!(raw::git_libgit2_opts(
+        raw::GIT_OPT_GET_SERVER_CONNECT_TIMEOUT as libc::c_int,
+        &mut server_connect_timeout
+    ));
+
+    Ok(server_connect_timeout)
+}
+
+/// Set server connect timeout in milliseconds
+///
+/// # Safety
+/// This function is modifying a C global without synchronization, so it is not
+/// thread safe, and should only be called before any thread is spawned.
+pub unsafe fn set_server_connect_timeout_in_milliseconds(
+    timeout: libc::c_int,
+) -> Result<(), Error> {
+    crate::init();
+
+    let error = raw::git_libgit2_opts(
+        raw::GIT_OPT_SET_SERVER_CONNECT_TIMEOUT as libc::c_int,
+        timeout,
+    );
+    // This function cannot actually fail, but the function has an error return
+    // for other options that can.
+    debug_assert!(error >= 0);
+
+    Ok(())
+}
+
+/// Get server timeout in milliseconds
+///
+/// # Safety
+/// This function is modifying a C global without synchronization, so it is not
+/// thread safe, and should only be called before any thread is spawned.
+pub unsafe fn get_server_timeout_in_milliseconds() -> Result<libc::c_int, Error> {
+    crate::init();
+
+    let mut server_timeout = 0;
+
+    try_call!(raw::git_libgit2_opts(
+        raw::GIT_OPT_GET_SERVER_TIMEOUT as libc::c_int,
+        &mut server_timeout
+    ));
+
+    Ok(server_timeout)
+}
+
+/// Set server timeout in milliseconds
+///
+/// # Safety
+/// This function is modifying a C global without synchronization, so it is not
+/// thread safe, and should only be called before any thread is spawned.
+pub unsafe fn set_server_timeout_in_milliseconds(timeout: libc::c_int) -> Result<(), Error> {
+    crate::init();
+
+    let error = raw::git_libgit2_opts(
+        raw::GIT_OPT_SET_SERVER_TIMEOUT as libc::c_int,
+        timeout as libc::c_int,
+    );
+    // This function cannot actually fail, but the function has an error return
+    // for other options that can.
+    debug_assert!(error >= 0);
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -368,6 +444,22 @@ mod test {
         unsafe {
             assert!(set_mwindow_file_limit(1024).is_ok());
             assert!(get_mwindow_file_limit().unwrap() == 1024);
+        }
+    }
+
+    #[test]
+    fn server_connect_timeout() {
+        unsafe {
+            assert!(set_server_connect_timeout_in_milliseconds(5000).is_ok());
+            assert!(get_server_connect_timeout_in_milliseconds().unwrap() == 5000);
+        }
+    }
+
+    #[test]
+    fn server_timeout() {
+        unsafe {
+            assert!(set_server_timeout_in_milliseconds(10_000).is_ok());
+            assert!(get_server_timeout_in_milliseconds().unwrap() == 10_000);
         }
     }
 }


### PR DESCRIPTION
Hello,

We would like to apply some timeouts during git operations i.e git clone
The libgit2 provides 2 global options for that:
* `GIT_OPT_SET_SERVER_CONNECT_TIMEOUT`
* `GIT_OPT_SET_SERVER_TIMEOUT`

The purpose of this PR is to add the support for those options (along with their getters)
The link to libgit2 details: https://github.com/libgit2/libgit2/blob/main/include/git2/common.h#L508C38-L524