### PR TITLE
repo: add branch_upstream_remote refname doc (#1055)

### DIFF
--- a/src/repo.rs
+++ b/src/repo.rs
@@ -3060,6 +3060,8 @@ impl Repository {
     }
 
     /// Retrieve the name of the upstream remote of a local branch.
+    ///
+    /// `refname` must be in the form `refs/heads/{branch_name}`
     pub fn branch_upstream_remote(&self, refname: &str) -> Result<Buf, Error> {
         let refname = CString::new(refname)?;
         unsafe {


### PR DESCRIPTION
Adds the full refname format for the documentation

Closes #1055