### PR TITLE
 odb: fix OdbReader read return value

### DIFF
--- a/src/odb.rs
+++ b/src/odb.rs
@@ -364,7 +364,7 @@ impl<'repo> io::Read for OdbReader<'repo> {
             if res < 0 {
                 Err(io::Error::new(io::ErrorKind::Other, "Read error"))
             } else {
-                Ok(len)
+                Ok(res as _)
             }
         }
     }


### PR DESCRIPTION
 git_odb_stream_read return the number of bytes read.


This should be a typo, and will cuase [Read.read_to_end](https://doc.rust-lang.org/std/io/trait.Read.html#method.read_to_end) to read for ever since it will continuously call  `read` to append more data to buf until `read` returns either `Ok(0)`
 or an error of non-ErrorKind::Interrupted kind.