### PR TITLE
Make `transport::Service` `Debug` and add some HTTP constants from libgit2.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ bitflags = "2.1.0"
 libc = "0.2"
 log = "0.4.8"
 libgit2-sys = { path = "libgit2-sys", version = "0.17.0" }
+http = "1.1"
 
 [target."cfg(all(unix, not(target_os = \"macos\")))".dependencies]
 openssl-sys = { version = "0.9.45", optional = true }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -64,9 +64,9 @@ pub enum Service {
 }
 
 /// HTTP implementation related info for various services.
-/// 
-/// This information was pulled from 
-/// <https://github.com/libgit2/libgit2/blob/2ecc8586f7eec4063b5da1563d0a33f9e9f9fcf7/src/libgit2/transports/http.c#L68-L95>. 
+///
+/// This information was pulled from
+/// <https://github.com/libgit2/libgit2/blob/2ecc8586f7eec4063b5da1563d0a33f9e9f9fcf7/src/libgit2/transports/http.c#L68-L95>.
 impl Service {
     /// The HTTP Method used by libgit2's implementation for http(s) transport.
     pub const fn http_method(self) -> http::Method {


### PR DESCRIPTION
This PR adds a dependency on the `http` crate for the `http::Method` type, and adds some HTTP related constants defined in `libgit2` at https://github.com/libgit2/libgit2/blob/2ecc8586f7eec4063b5da1563d0a33f9e9f9fcf7/src/libgit2/transports/http.c#L68-L95.