### PR TITLE
Don't show console on Windows

### DIFF
--- a/src/cred.rs
+++ b/src/cred.rs
@@ -372,6 +372,12 @@ impl CredentialHelper {
         // If that fails then it's up to the user to put `sh` in path and make
         // sure it works.
         let mut c = Command::new("sh");
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            const CREATE_NO_WINDOW: u32 = 0x08000000;
+            c.creation_flags(CREATE_NO_WINDOW);
+        }
         c.arg("-c")
             .arg(&format!("{} get", cmd))
             .stdin(Stdio::piped())
@@ -384,6 +390,12 @@ impl CredentialHelper {
                 debug!("`sh` failed to spawn: {}", e);
                 let mut parts = cmd.split_whitespace();
                 let mut c = Command::new(parts.next().unwrap());
+                #[cfg(windows)]
+                {
+                    use std::os::windows::process::CommandExt;
+                    const CREATE_NO_WINDOW: u32 = 0x08000000;
+                    c.creation_flags(CREATE_NO_WINDOW);
+                }
                 for arg in parts {
                     c.arg(arg);
                 }


### PR DESCRIPTION
When used inside GUI application, git2 causes console window to appear temporarily, due to execution of sh.

Command needs special flags to prevent that. More details: https://stackoverflow.com/a/60958956

(For context - similar change in gitoxide: https://github.com/Byron/gitoxide/pull/1506)