### PR TITLE
repo: implement git_repository_commondir

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -2148,6 +2148,7 @@ extern "C" {
     pub fn git_repository_is_empty(repo: *mut git_repository) -> c_int;
     pub fn git_repository_is_shallow(repo: *mut git_repository) -> c_int;
     pub fn git_repository_path(repo: *const git_repository) -> *const c_char;
+    pub fn git_repository_commondir(repo: *const git_repository) -> *const c_char;
     pub fn git_repository_state(repo: *mut git_repository) -> c_int;
     pub fn git_repository_workdir(repo: *const git_repository) -> *const c_char;
     pub fn git_repository_set_workdir(

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -456,6 +456,8 @@ impl Repository {
         }
     }
 
+    /// Returns the path of the shared common directory for this repository.
+    ///
     /// If the repository is bare, it is the root directory for the repository.
     /// If the repository is a worktree, it is the parent repo's gitdir.
     /// Otherwise, it is the gitdir.


### PR DESCRIPTION
Hey folks, thanks for maintaining bindings to libgit2.

I implemented `git_repository_commondir` because I'm currently using it in a side project.

I'm an open source maintainer/developer myself so I know the game. Critical and honest feedback is always welcome.