### PR TITLE
delete ineffective ssh_key_from_memory crate feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,12 +33,11 @@ tempfile = "3.1.0"
 
 [features]
 unstable = []
-default = ["ssh", "https", "ssh_key_from_memory"]
+default = ["ssh", "https"]
 ssh = ["libgit2-sys/ssh"]
 https = ["libgit2-sys/https", "openssl-sys", "openssl-probe"]
 vendored-libgit2 = ["libgit2-sys/vendored"]
 vendored-openssl = ["openssl-sys/vendored", "libgit2-sys/vendored-openssl"]
-ssh_key_from_memory = ["libgit2-sys/ssh_key_from_memory"]
 zlib-ng-compat = ["libgit2-sys/zlib-ng-compat"]
 
 [workspace]

--- a/libgit2-sys/Cargo.toml
+++ b/libgit2-sys/Cargo.toml
@@ -35,7 +35,6 @@ openssl-sys = { version = "0.9.45", optional = true }
 [features]
 ssh = ["libssh2-sys"]
 https = ["openssl-sys"]
-ssh_key_from_memory = []
 vendored = []
 vendored-openssl = ["openssl-sys/vendored"]
 zlib-ng-compat = ["libz-sys/zlib-ng", "libssh2-sys?/zlib-ng-compat"]


### PR DESCRIPTION
The ssh_key_from_memory crate feature was added in commit 8ca0e92 (2018-07-26). Then it was accidentally made always-on in commit 76f4b74 (2018-09013). Since it seems like no one has missed the ability to turn it off since then (not enough to send a PR anyway), let's just delete the crate feature.

Closes #363