### PR TITLE
Fix normal merge in examples/pull.rs

### DIFF
--- a/examples/pull.rs
+++ b/examples/pull.rs
@@ -188,7 +188,7 @@ fn do_merge<'a>(
         checkout_options.conflict_style_merge(true);
         checkout_options.force();
 
-        let mut merge_options = MergeOptions::new();
+        let mut merge_options = git2::MergeOptions::new();
         merge_options.diff3_style(true);
 
         repo.merge(


### PR DESCRIPTION
`Repository::commit` needs to be called, otherwise the index gets goofed up.

In my specific case, it resulted in a file created in a fetched commit being staged for deletion.

https://libgit2.org/libgit2/ex/HEAD/merge.html was referenced for this fix.

I also added a call to `Repository::cleanup_state` that was used in the libgit2 example. They did not call `Repository::checkout_head` so I've removed that.