### PR TITLE
Propagate errors on Tree::walk

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -742,7 +742,7 @@ git_enum! {
 }
 
 pub type git_treewalk_cb =
-    Option<extern "C" fn(*const c_char, *const git_tree_entry, *mut c_void) -> c_int>;
+    *const extern "C" fn(*const c_char, *const git_tree_entry, *mut c_void) -> c_int;
 pub type git_treebuilder_filter_cb =
     Option<extern "C" fn(*const git_tree_entry, *mut c_void) -> c_int>;
 

--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -742,7 +742,7 @@ git_enum! {
 }
 
 pub type git_treewalk_cb =
-    *const extern "C" fn(*const c_char, *const git_tree_entry, *mut c_void) -> c_int;
+    extern "C" fn(*const c_char, *const git_tree_entry, *mut c_void) -> c_int;
 pub type git_treebuilder_filter_cb =
     Option<extern "C" fn(*const git_tree_entry, *mut c_void) -> c_int>;
 

--- a/src/call.rs
+++ b/src/call.rs
@@ -116,6 +116,17 @@ mod impls {
         }
     }
 
+    impl Convert<raw::git_treewalk_mode> for crate::TreeWalkMode {
+        #[cfg(target_env = "msvc")]
+        fn convert(&self) -> raw::git_treewalk_mode {
+            *self as i32
+        }
+        #[cfg(not(target_env = "msvc"))]
+        fn convert(&self) -> raw::git_treewalk_mode {
+            *self as u32
+        }
+    }
+
     impl Convert<raw::git_direction> for Direction {
         fn convert(&self) -> raw::git_direction {
             match *self {

--- a/src/call.rs
+++ b/src/call.rs
@@ -116,17 +116,6 @@ mod impls {
         }
     }
 
-    impl Convert<raw::git_treewalk_mode> for crate::TreeWalkMode {
-        #[cfg(target_env = "msvc")]
-        fn convert(&self) -> raw::git_treewalk_mode {
-            *self as i32
-        }
-        #[cfg(not(target_env = "msvc"))]
-        fn convert(&self) -> raw::git_treewalk_mode {
-            *self as u32
-        }
-    }
-
     impl Convert<raw::git_direction> for Direction {
         fn convert(&self) -> raw::git_direction {
             match *self {


### PR DESCRIPTION
`Tree::walk` was ignoring errors coming from `libgit2`. This PR fixes that and adds a unit test.