### PR TITLE
docs(config): improve docs of `Config::get_str`/`Config::get_bytes`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -237,7 +237,10 @@ impl Config {
     /// This is the same as `get_bytes` except that it may return `Err` if
     /// the bytes are not valid utf-8.
     ///
-    /// This method will return an error if this `Config` is not a snapshot.
+    /// For consistency reasons, this method can only be called on a [`snapshot`].
+    /// An error will be returned otherwise.
+    ///
+    /// [`snapshot`]: `crate::Config::snapshot`
     pub fn get_str(&self, name: &str) -> Result<&str, Error> {
         str::from_utf8(self.get_bytes(name)?)
             .map_err(|_| Error::from_str("configuration value is not valid utf8"))
@@ -245,7 +248,10 @@ impl Config {
 
     /// Get the value of a string config variable as a byte slice.
     ///
-    /// This method will return an error if this `Config` is not a snapshot.
+    /// For consistency reasons, this method can only be called on a [`snapshot`].
+    /// An error will be returned otherwise.
+    ///
+    /// [`snapshot`]: `crate::Config::snapshot`
     pub fn get_bytes(&self, name: &str) -> Result<&[u8], Error> {
         let mut ret = ptr::null();
         let name = CString::new(name)?;


### PR DESCRIPTION
We noticed that the docs around config are not as helpful yet as they could be. Newer rust users tend to assume that using `get_str` wouldn't be as hard to use and that it instead would work the same way as the other getters. This commit:

- Adds a link to `snapshot` method documentation to provide additional guidance for newer Rust users
- Extends the error explanation with a vague reason to enhance understanding of the current behavior