### PR TITLE
Add triagebot

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,0 +1,26 @@
+[relabel]
+allow-unauthenticated = [
+    "*",
+]
+
+[assign]
+
+[shortcut]
+
+[transfer]
+
+[merge-conflicts]
+remove = []
+add = ["S-waiting-on-author"]
+unless = ["S-blocked", "S-waiting-on-review"]
+
+[autolabel."S-waiting-on-review"]
+new_pr = true
+
+[review-submitted]
+reviewed_label = "S-waiting-on-author"
+review_labels = ["S-waiting-on-review"]
+
+[review-requested]
+remove_labels = ["S-waiting-on-author"]
+add_labels = ["S-waiting-on-review"]


### PR DESCRIPTION
This adds [triagebot](https://forge.rust-lang.org/triagebot/index.html) support to this repo.
