### PR TITLE
fix: prevent crash when repository url is empty

### DIFF
--- a/src/remote.rs
+++ b/src/remote.rs
@@ -147,7 +147,7 @@ impl<'repo> Remote<'repo> {
 
     /// Get the remote's URL as a byte array.
     pub fn url_bytes(&self) -> &[u8] {
-        unsafe { crate::opt_bytes(self, raw::git_remote_url(&*self.raw)).unwrap() }
+        unsafe { crate::opt_bytes(self, raw::git_remote_url(&*self.raw)).unwrap_or(&[]) }
     }
 
     /// Get the remote's pushurl.


### PR DESCRIPTION
This is a fix for [#23453](https://github.com/zed-industries/zed/issues/23453)

When git remote URL is a blank it's panicking.