### PR TITLE
docs: Update link to libgit2 homepage

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //! to manage git repositories. The library itself is a work in progress and is
 //! likely lacking some bindings here and there, so be warned.
 //!
-//! [1]: https://libgit2.github.com/
+//! [1]: https://libgit2.org/
 //!
 //! The git2-rs library strives to be as close to libgit2 as possible, but also
 //! strives to make using libgit2 as safe as possible. All resource management


### PR DESCRIPTION
This PR updates the link to the libgit2 homepage, as the current link does not work anymore and <https://libgit2.org> seems to be the new permanent home. [Wayback Machine's latest crawl](https://web.archive.org/web/20250112183109/https://libgit2.github.com/) also indicates the page was permanently moved and the [libgit organization](https://github.com/libgit2) also links to the new webpage.