### PR TITLE
Update url to min `2.5.4`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["api-bindings"]
 edition = "2018"
 
 [dependencies]
-url = "2.0"
+url = "2.5.4"
 bitflags = "2.1.0"
 libc = "0.2"
 log = "0.4.8"

--- a/git2-curl/Cargo.toml
+++ b/git2-curl/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 
 [dependencies]
 curl = "0.4.33"
-url = "2.0"
+url = "2.5.4"
 log = "0.4"
 git2 = { path = "..", version = "0.20", default-features = false }
 


### PR DESCRIPTION
This also resolves the security warning that comes from idna 0.5.0 being vulnerable.