### PR TITLE
Do not call openssl_probe::init_ssl_cert_env_vars() on FreeBSD (#1129)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -759,6 +759,7 @@ fn init() {
     unix,
     not(target_os = "macos"),
     not(target_os = "ios"),
+    not(target_os = "freebsd"),
     feature = "https"
 ))]
 fn openssl_env_init() {
@@ -880,6 +881,7 @@ fn openssl_env_init() {
     windows,
     target_os = "macos",
     target_os = "ios",
+    target_os = "freebsd",
     not(feature = "https")
 ))]
 fn openssl_env_init() {}


### PR DESCRIPTION
The heuristics in openssl-probe leave the process environment with an invalid value breaking the certificate validation on FreeBSD. FreeBSD has a system truststore managed by certctl(8). Leave it to OpenSSL to do the right thing.

Upstream issue: https://github.com/alexcrichton/openssl-probe/issues/37

This fixes #1129