### PR TITLE
Fix CredentialHelper::add_command

### DIFF
--- a/src/cred.rs
+++ b/src/cred.rs
@@ -578,13 +578,13 @@ echo username=c
             return;
         } // shell scripts don't work on Windows
         let td = TempDir::new().unwrap();
-        let path = td.path().join("git-credential-script");
+        let path = td.path().join("git-credential-some-script");
         File::create(&path)
             .unwrap()
             .write(
                 br"\
 #!/bin/sh
-echo username=c
+echo username=$1
 ",
             )
             .unwrap();
@@ -596,14 +596,14 @@ echo username=c
         env::set_var("PATH", &env::join_paths(paths).unwrap());
 
         let cfg = test_cfg! {
-            "credential.https://example.com.helper" => "script",
+            "credential.https://example.com.helper" => "some-script \"value/with\\slashes\"",
             "credential.helper" => "!f() { echo username=a; echo password=b; }; f"
         };
         let (u, p) = CredentialHelper::new("https://example.com/foo/bar")
             .config(&cfg)
             .execute()
             .unwrap();
-        assert_eq!(u, "c");
+        assert_eq!(u, "value/with\\slashes");
         assert_eq!(p, "b");
     }
 

--- a/src/cred.rs
+++ b/src/cred.rs
@@ -299,7 +299,7 @@ impl CredentialHelper {
 
         if cmd.starts_with('!') {
             self.commands.push(cmd[1..].to_string());
-        } else if cmd.contains("/") || cmd.contains("\\") {
+        } else if is_absolute_path(cmd) {
             self.commands.push(cmd.to_string());
         } else {
             self.commands.push(format!("git credential-{}", cmd));
@@ -479,6 +479,12 @@ impl CredentialHelper {
         }
         (username, password)
     }
+}
+
+fn is_absolute_path(path: &str) -> bool {
+    path.starts_with('/')
+        || path.starts_with('\\')
+        || cfg!(windows) && path.chars().nth(1).is_some_and(|x| x == ':')
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Previously the add_helper function would check whether the command contains a `\` or `/` character to determine whether it is absolute. It should have used starts_with instead of contains. In addition an absolute on Windows a path my start with a drive letter. The git cli implements this by checking if the second character is a ':'.

See also: https://github.com/git/git/blob/6a64ac7b014fa2cfa7a69af3c253bcd53a94b428/credential.c#L492-L493

Fixes https://github.com/rust-lang/git2-rs/issues/1136