### PR TITLE
Fix lifetimes of outputs for Patch

### DIFF
--- a/src/patch.rs
+++ b/src/patch.rs
@@ -125,7 +125,7 @@ impl<'buffers> Patch<'buffers> {
     }
 
     /// Get the DiffDelta associated with the Patch.
-    pub fn delta(&self) -> DiffDelta<'buffers> {
+    pub fn delta<'a>(&'a self) -> DiffDelta<'a> {
         unsafe { Binding::from_raw(raw::git_patch_get_delta(self.raw) as *mut _) }
     }
 
@@ -151,7 +151,7 @@ impl<'buffers> Patch<'buffers> {
     }
 
     /// Get a DiffHunk and its total line count from the Patch.
-    pub fn hunk(&self, hunk_idx: usize) -> Result<(DiffHunk<'buffers>, usize), Error> {
+    pub fn hunk<'a>(&'a self, hunk_idx: usize) -> Result<(DiffHunk<'a>, usize), Error> {
         let mut ret = ptr::null();
         let mut lines = 0;
         unsafe {
@@ -168,11 +168,11 @@ impl<'buffers> Patch<'buffers> {
     }
 
     /// Get a DiffLine from a hunk of the Patch.
-    pub fn line_in_hunk(
-        &self,
+    pub fn line_in_hunk<'a>(
+        &'a self,
         hunk_idx: usize,
         line_of_hunk: usize,
-    ) -> Result<DiffLine<'buffers>, Error> {
+    ) -> Result<DiffLine<'a>, Error> {
         let mut ret = ptr::null();
         unsafe {
             try_call!(raw::git_patch_get_line_in_hunk(


### PR DESCRIPTION
This fixes the lifetimes for the functions that return data from a `Patch`. From what I can tell, these are returning data owned by the `Patch` object itself. Previously they had lifetimes tied to the values that *created* the `Patch`, but that allows these outputs to outlive the patch, allowing a use-after-free.

Note that there was a previous fix here in https://github.com/rust-lang/git2-rs/pull/523, but I think that was mistake to change these accessor functions. The `Patch` itself still has a lifetime tied to its inputs introduced in #523.

Fixes #1135