### PR TITLE
Fix advapi32 linking on Windows

### DIFF
--- a/libgit2-sys/build.rs
+++ b/libgit2-sys/build.rs
@@ -252,6 +252,7 @@ The build is now aborting. To disable, unset the variable or use `LIBGIT2_NO_VEN
         println!("cargo:rustc-link-lib=ole32");
         println!("cargo:rustc-link-lib=crypt32");
         println!("cargo:rustc-link-lib=secur32");
+        println!("cargo:rustc-link-lib=advapi32");
     }
 
     if target.contains("apple") {


### PR DESCRIPTION
This fixes the build on Windows on the latest nightly. Since https://github.com/rust-lang/rust/pull/138233, Rust no longer links advapi32 via the standard library. However, libgit2 uses several functions from advapi32, so we need to explicitly include it here.

Fixes https://github.com/rust-lang/git2-rs/issues/1142