### PR TITLE
Implement valid parameter for RemoteCallbacks::certificate_check

### DIFF
--- a/src/remote_callbacks.rs
+++ b/src/remote_callbacks.rs
@@ -417,7 +417,7 @@ extern "C" fn certificate_check_cb(
     data: *mut c_void,
 ) -> c_int {
     match valid {
-        -1 => valid,
+        1 => valid,
         _ => {
             let ok = panic::wrap(|| unsafe {
                 let payload = &mut *(data as *mut RemoteCallbacks<'_>);

--- a/src/remote_callbacks.rs
+++ b/src/remote_callbacks.rs
@@ -431,7 +431,9 @@ extern "C" fn certificate_check_cb(
             });
             match ok {
                 Some(Ok(CertificateCheckStatus::CertificateOk)) => 0,
-                Some(Ok(CertificateCheckStatus::CertificatePassthrough)) => raw::GIT_PASSTHROUGH as c_int,
+                Some(Ok(CertificateCheckStatus::CertificatePassthrough)) => {
+                    raw::GIT_PASSTHROUGH as c_int
+                }
                 Some(Err(e)) => unsafe { e.raw_set_git_error() },
                 None => {
                     // Panic. The *should* get resumed by some future call to check().

--- a/src/remote_callbacks.rs
+++ b/src/remote_callbacks.rs
@@ -412,27 +412,32 @@ extern "C" fn update_tips_cb(
 
 extern "C" fn certificate_check_cb(
     cert: *mut raw::git_cert,
-    _valid: c_int,
+    valid: c_int,
     hostname: *const c_char,
     data: *mut c_void,
 ) -> c_int {
-    let ok = panic::wrap(|| unsafe {
-        let payload = &mut *(data as *mut RemoteCallbacks<'_>);
-        let callback = match payload.certificate_check {
-            Some(ref mut c) => c,
-            None => return Ok(CertificateCheckStatus::CertificatePassthrough),
-        };
-        let cert = Binding::from_raw(cert);
-        let hostname = str::from_utf8(CStr::from_ptr(hostname).to_bytes()).unwrap();
-        callback(&cert, hostname)
-    });
-    match ok {
-        Some(Ok(CertificateCheckStatus::CertificateOk)) => 0,
-        Some(Ok(CertificateCheckStatus::CertificatePassthrough)) => raw::GIT_PASSTHROUGH as c_int,
-        Some(Err(e)) => unsafe { e.raw_set_git_error() },
-        None => {
-            // Panic. The *should* get resumed by some future call to check().
-            -1
+    match valid {
+        -1 => valid,
+        _ => {
+            let ok = panic::wrap(|| unsafe {
+                let payload = &mut *(data as *mut RemoteCallbacks<'_>);
+                let callback = match payload.certificate_check {
+                    Some(ref mut c) => c,
+                    None => return Ok(CertificateCheckStatus::CertificatePassthrough),
+                };
+                let cert = Binding::from_raw(cert);
+                let hostname = str::from_utf8(CStr::from_ptr(hostname).to_bytes()).unwrap();
+                callback(&cert, hostname)
+            });
+            match ok {
+                Some(Ok(CertificateCheckStatus::CertificateOk)) => 0,
+                Some(Ok(CertificateCheckStatus::CertificatePassthrough)) => raw::GIT_PASSTHROUGH as c_int,
+                Some(Err(e)) => unsafe { e.raw_set_git_error() },
+                None => {
+                    // Panic. The *should* get resumed by some future call to check().
+                    -1
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
In the RemoteCallbacks struct documentation, the [certificate_check](https://docs.rs/git2/latest/git2/struct.RemoteCallbacks.html#method.certificate_check) function has this description:

> If certificate verification fails, then this callback will be invoked to let the caller make the final decision of whether to allow the connection to proceed.

However, this statement is false. It turns out that this function never actually checks if the certificate is valid using the `cert_valid` parameter passed into `certificate_check_cb` from the `check_certificate` function in [libgit2](https://github.com/libgit2/libgit2/blob/338e6fb681369ff0537719095e22ce9dc602dbf0/src/libgit2/transports/ssh_libssh2.c#L749). As a result, when a callback function is specified, the function will always run regardless if libgit2 marks it valid.

I made the change in the function specified to skip the callback if the certificate is valid (`valid = 1`). Before, any SSH remotes would run this callback, and now only hosts that do not appear in my hosts file (`~/.ssh/known_hosts`) will result in the callback being ran.

If there are any changes I need to make, let me know! :)