### PR TITLE
add a missing `git2::Status::WT_UNREADABLE` field

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1049,6 +1049,8 @@ bitflags! {
         const WT_TYPECHANGE = raw::GIT_STATUS_WT_TYPECHANGE as u32;
         #[allow(missing_docs)]
         const WT_RENAMED = raw::GIT_STATUS_WT_RENAMED as u32;
+        #[allow(missing_docs)]
+        const WT_UNREADABLE = raw::GIT_STATUS_WT_UNREADABLE as u32;
 
         #[allow(missing_docs)]
         const IGNORED = raw::GIT_STATUS_IGNORED as u32;


### PR DESCRIPTION
This PR addes missing `git2::Status::WT_UNREADABLE` field, which exists in `git_status_t` binding.