### PR TITLE
Add missing code checks to Error::raw_code()

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -286,6 +286,8 @@ impl Error {
             GIT_EEOF,
             GIT_EINVALID,
             GIT_EUNCOMMITTED,
+            GIT_EDIRECTORY,
+            GIT_EMERGECONFLICT,
             GIT_PASSTHROUGH,
             GIT_ITEROVER,
             GIT_RETRY,
@@ -294,6 +296,9 @@ impl Error {
             GIT_EAPPLYFAIL,
             GIT_EOWNER,
             GIT_TIMEOUT,
+            GIT_EUNCHANGED,
+            GIT_ENOTSUPPORTED,
+            GIT_EREADONLY,
         )
     }
 


### PR DESCRIPTION
These codes are both already handled by `Error::code()`, but because they weren't listed in `Error::raw_code()`, it would return -1, and so the paths in `Error::code()` for them would never be hit.  This fixes the code of errors from `Repository::merge_commits()` with fail_on_conflict set for me.