### PR TITLE
fix: add a backtick

### DIFF
--- a/src/repo.rs
+++ b/src/repo.rs
@@ -2137,7 +2137,7 @@ impl Repository {
     ///
     /// For compatibility with git, the repository is put into a merging state.
     /// Once the commit is done (or if the user wishes to abort), you should
-    /// clear this state by calling `cleanup_state()`.
+    /// clear this state by calling [`cleanup_state()`][Repository::cleanup_state].
     pub fn merge(
         &self,
         annotated_commits: &[&AnnotatedCommit<'_>],

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -2137,7 +2137,7 @@ impl Repository {
     ///
     /// For compatibility with git, the repository is put into a merging state.
     /// Once the commit is done (or if the user wishes to abort), you should
-    /// clear this state by calling cleanup_state().
+    /// clear this state by calling `cleanup_state()`.
     pub fn merge(
         &self,
         annotated_commits: &[&AnnotatedCommit<'_>],


### PR DESCRIPTION
**cleanup_state()** is the method name, but it is not highlighted.