### PR TITLE
Fix initialization with Indexer::new

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -122,6 +122,7 @@ impl<'a> Indexer<'a> {
     ///
     /// If `verify` is `false`, the indexer will bypass object connectivity checks.
     pub fn new(odb: Option<&Odb<'a>>, path: &Path, mode: u32, verify: bool) -> Result<Self, Error> {
+        crate::init();
         let path = path.into_c_string()?;
 
         let odb = odb.map(Binding::raw).unwrap_or_else(ptr::null_mut);

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -118,6 +118,8 @@ impl<'a> Indexer<'a> {
     /// can be `None` if no thin pack is expected, in which case missing bases
     /// will result in an error.
     ///
+    /// `path` is the directory where the packfile should be stored.
+    ///
     /// `mode` is the permissions to use for the output files, use `0` for defaults.
     ///
     /// If `verify` is `false`, the indexer will bypass object connectivity checks.


### PR DESCRIPTION
This fixes an issue where calling `Indexer::new` as the first thing in a program fails since libgit2 is not initialized, and would instead return "no error" errors.

This also clarifies that the path to `Indexer::new` is a directory.

Closes #1159