### PR TITLE
Make url optional via a new "cred" feature gate for credential helpers; disable default features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.20.2"
+version = "0.21.0"
 dependencies = [
  "bitflags 2.6.0",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["api-bindings"]
 edition = "2018"
 
 [dependencies]
-url = "2.5.4"
+url = { version = "2.5.4", optional = true }
 bitflags = "2.1.0"
 libc = "0.2"
 log = "0.4.8"
@@ -30,12 +30,15 @@ openssl-probe = { version = "0.1", optional = true }
 clap = { version = "4.4.13", features = ["derive"] }
 time = { version = "0.3.37", features = ["formatting"] }
 tempfile = "3.1.0"
+url = "2.5.4"
 
 [features]
 unstable = []
-default = ["ssh", "https"]
-ssh = ["libgit2-sys/ssh"]
-https = ["libgit2-sys/https", "openssl-sys", "openssl-probe"]
+default = ["ssh", "https", "cred"]
+ssh = ["libgit2-sys/ssh", "cred"]
+https = ["libgit2-sys/https", "openssl-sys", "openssl-probe", "cred"]
+# Include support for credentials, which pulls in the `url` crate and all its dependencies
+cred = ["dep:url"]
 vendored-libgit2 = ["libgit2-sys/vendored"]
 vendored-openssl = ["openssl-sys/vendored", "libgit2-sys/vendored-openssl"]
 zlib-ng-compat = ["libgit2-sys/zlib-ng-compat"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git2"
-version = "0.20.2"
+version = "0.21.0"
 authors = ["Josh Triplett <josh@joshtriplett.org>", "Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ url = "2.5.4"
 
 [features]
 unstable = []
-default = ["ssh", "https", "cred"]
+default = []
 ssh = ["libgit2-sys/ssh", "cred"]
 https = ["libgit2-sys/https", "openssl-sys", "openssl-probe", "cred"]
 # Include support for credentials, which pulls in the `url` crate and all its dependencies

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ libgit2 bindings for Rust.
 
 ```toml
 [dependencies]
-git2 = "0.20.2"
+git2 = "0.21"
 ```
 
 ## Rust version requirements

--- a/git2-curl/Cargo.toml
+++ b/git2-curl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git2-curl"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Josh Triplett <josh@joshtriplett.org>", "Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/git2-rs"
@@ -16,7 +16,7 @@ edition = "2018"
 curl = "0.4.33"
 url = "2.5.4"
 log = "0.4"
-git2 = { path = "..", version = "0.20", default-features = false }
+git2 = { path = "..", version = "0.21", default-features = false }
 
 [dev-dependencies]
 civet = "0.11"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@
 //! source `Repository`, to ensure that they do not outlive the repository
 //! itself.
 
-#![doc(html_root_url = "https://docs.rs/git2/0.20")]
+#![doc(html_root_url = "https://docs.rs/git2/0.21")]
 #![allow(trivial_numeric_casts, trivial_casts)]
 #![deny(missing_docs)]
 #![warn(rust_2018_idioms)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,9 @@ pub use crate::buf::Buf;
 pub use crate::cherrypick::CherrypickOptions;
 pub use crate::commit::{Commit, Parents};
 pub use crate::config::{Config, ConfigEntries, ConfigEntry};
-pub use crate::cred::{Cred, CredentialHelper};
+pub use crate::cred::Cred;
+#[cfg(feature = "cred")]
+pub use crate::cred::CredentialHelper;
 pub use crate::describe::{Describe, DescribeFormatOptions, DescribeOptions};
 pub use crate::diff::{Deltas, Diff, DiffDelta, DiffFile, DiffOptions};
 pub use crate::diff::{DiffBinary, DiffBinaryFile, DiffBinaryKind, DiffPatchidOptions};


### PR DESCRIPTION
Add a new feature flag for credential helpers, which are the only uses of the `url` crate. This reduces a build of git2 from 54 dependencies to 17, for a configuration that many tools (e.g. anything that only cares about local repositories) can happily use.

Make the "https" and "ssh" features depend on "cred".

Disable all of these features by default, to avoid extra dependencies in the common case of tools that only care about local repositories.

Bump the crate version to 0.21.