### PR TITLE
Drop civet/conduit from dev dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 4
 
 [[package]]
-name = "aho-corasick"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
-dependencies = [
- "memchr 0.1.11",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,27 +87,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "civet"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9eff374cee04626041189bff6944fc204242250fe1c03c4feac5202fe6cc3fd"
-dependencies = [
- "civet-sys",
- "conduit",
- "libc",
- "semver 0.5.1",
-]
-
-[[package]]
-name = "civet-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876910de2615a24211fee8b88e62e2d5f81183ef1af2d827df4471c20319c4a2"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "clap"
 version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,25 +140,6 @@ name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
-
-[[package]]
-name = "conduit"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0caa30f78c207dc14c071b62512253ece5c4459897815682786aff1028bc82"
-dependencies = [
- "semver 0.5.1",
-]
-
-[[package]]
-name = "conduit-git-http-backend"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "027a1900afd70becd52b5061afc85a24de6af0d9199f39d4e1af8b7ac55fbe6e"
-dependencies = [
- "conduit",
- "flate2",
-]
 
 [[package]]
 name = "ctest2"
@@ -258,7 +209,7 @@ checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
 dependencies = [
  "libc",
  "redox_users",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -287,16 +238,6 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "flate2"
-version = "0.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6234dd4468ae5d1e2dbb06fe2b058696fdc50a339c68a393aefbf00bc81e423"
-dependencies = [
- "libc",
- "miniz-sys",
-]
 
 [[package]]
 name = "form_urlencoded"
@@ -375,9 +316,6 @@ dependencies = [
 name = "git2-curl"
 version = "0.21.0"
 dependencies = [
- "civet",
- "conduit",
- "conduit-git-http-backend",
  "curl",
  "git2",
  "log",
@@ -552,22 +490,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
-
-[[package]]
-name = "lazy_static"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
-
-[[package]]
 name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -642,28 +564,9 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "memchr"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "miniz-sys"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9e3ae51cea1576ceba0dde3d484d30e6e5b86dee0b2d412fe3a16a15c98202"
-dependencies = [
- "cc",
- "libc",
-]
 
 [[package]]
 name = "num-conv"
@@ -753,31 +656,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "0.1.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
-dependencies = [
- "aho-corasick",
- "memchr 0.1.11",
- "regex-syntax",
- "thread_local",
- "utf8-ranges",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.24",
+ "semver",
 ]
 
 [[package]]
@@ -810,28 +694,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae2ff60ecdb19c255841c066cbfa5f8c2a4ada1eb3ae47c77ab6667128da71f5"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
-
-[[package]]
-name = "semver-parser"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8fff3c9c5a54636ab95acd8c1349926e04cb1eb8cd70b5adced8a1d1f703a67"
-dependencies = [
- "lazy_static",
- "regex",
-]
 
 [[package]]
 name = "serde"
@@ -860,7 +725,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
 dependencies = [
  "itoa",
- "memchr 2.7.4",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -951,7 +816,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0863a3345e70f61d613eab32ee046ccd1bcc5f9105fe402c61fcd0c13eeb8b5"
 dependencies = [
  "dirs",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -972,25 +837,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "thread-id"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
-dependencies = [
- "kernel32-sys",
- "libc",
-]
-
-[[package]]
-name = "thread_local"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
-dependencies = [
- "thread-id",
 ]
 
 [[package]]
@@ -1064,12 +910,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
-name = "utf8-ranges"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1095,12 +935,6 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-
-[[package]]
-name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -1108,12 +942,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"

--- a/git2-curl/Cargo.toml
+++ b/git2-curl/Cargo.toml
@@ -19,9 +19,6 @@ log = "0.4"
 git2 = { path = "..", version = "0.20", default-features = false }
 
 [dev-dependencies]
-civet = "0.11"
-conduit = "0.8"
-conduit-git-http-backend = "0.8"
 tempfile = "3.0"
 
 [features]

--- a/git2-curl/tests/all.rs
+++ b/git2-curl/tests/all.rs
@@ -1,21 +1,140 @@
-use civet::{Config, Server};
-use conduit_git_http_backend as git_backend;
+//! A simple test to verify that git2-curl can communicate to git over HTTP.
+
 use std::fs::File;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{TcpListener, TcpStream};
 use std::path::Path;
+use std::process::{Command, Stdio};
 use tempfile::TempDir;
 
 const PORT: u16 = 7848;
 
+/// This is a very bare-bones HTTP server, enough to run git-http-backend as a CGI.
+fn handle_client(stream: TcpStream, working_dir: &Path) {
+    let mut buf = BufReader::new(stream);
+    let mut line = String::new();
+    if buf.read_line(&mut line).unwrap() == 0 {
+        panic!("unexpected termination");
+    }
+    // Read the "METHOD path HTTP/1.1" line.
+    let mut parts = line.split_ascii_whitespace();
+    let method = parts.next().unwrap();
+    let path = parts.next().unwrap();
+    let (path, query) = path.split_once('?').unwrap_or_else(|| (path, ""));
+    let mut content_length = 0;
+    let mut content_type = String::new();
+    // Read headers.
+    loop {
+        let mut header = String::new();
+        if buf.read_line(&mut header).unwrap() == 0 {
+            panic!("unexpected header");
+        }
+        if header == "\r\n" {
+            break;
+        }
+        let (name, value) = header.split_once(':').unwrap();
+        let name = name.to_ascii_lowercase();
+        match name.as_str() {
+            "content-length" => content_length = value.trim().parse().unwrap_or(0),
+            "content-type" => content_type = value.trim().to_owned(),
+            _ => {}
+        }
+    }
+    let mut body = vec![0u8; content_length];
+    if content_length > 0 {
+        buf.read_exact(&mut body).unwrap();
+    }
+
+    let mut cgi_env = vec![
+        ("GIT_PROJECT_ROOT", "."),
+        ("GIT_HTTP_EXPORT_ALL", "1"),
+        ("REQUEST_METHOD", method),
+        ("PATH_INFO", path),
+        ("QUERY_STRING", query),
+        ("CONTENT_TYPE", &content_type),
+        ("REMOTE_USER", ""),
+        ("REMOTE_ADDR", "127.0.0.1"),
+        ("AUTH_TYPE", ""),
+        ("REMOTE_HOST", ""),
+        ("SERVER_PROTOCOL", "HTTP/1.1"),
+        ("REQUEST_URI", path),
+    ];
+
+    let cl = content_length.to_string();
+    cgi_env.push(("CONTENT_LENGTH", cl.as_str()));
+
+    // Spawn git-http-backend
+    let mut cmd = Command::new("git");
+    cmd.current_dir(working_dir);
+    cmd.arg("http-backend");
+    for (k, v) in &cgi_env {
+        cmd.env(k, v);
+    }
+    cmd.stdin(Stdio::piped()).stdout(Stdio::piped());
+
+    let mut child = cmd.spawn().expect("failed to spawn git-http-backend");
+
+    if content_length > 0 {
+        child.stdin.as_mut().unwrap().write_all(&body).unwrap();
+    }
+
+    let mut cgi_output = Vec::new();
+    child
+        .stdout
+        .as_mut()
+        .unwrap()
+        .read_to_end(&mut cgi_output)
+        .unwrap();
+
+    // Split CGI output into headers and body.
+    let index = cgi_output
+        .windows(4)
+        .position(|w| w == b"\r\n\r\n")
+        .unwrap_or(0);
+    let (headers, body) = (&cgi_output[..index], &cgi_output[index + 4..]);
+    let content_length = body.len();
+
+    // Write HTTP response
+    let mut stream = buf.into_inner();
+    stream
+        .write_all(
+            &format!(
+                "HTTP/1.1 200 ok\r\n\
+                Connection: close\r\n\
+                Content-Length: {content_length}\r\n"
+            )
+            .into_bytes(),
+        )
+        .unwrap();
+    stream.write_all(headers).unwrap();
+    stream.write_all(b"\r\n\r\n").unwrap();
+    stream.write_all(body).unwrap();
+    stream.flush().unwrap();
+}
+
 fn main() {
+    let td = TempDir::new().unwrap();
+    let td_path = td.path().to_owned();
+
+    // Spin up a server for git-http-backend
+    std::thread::spawn(move || {
+        let listener = TcpListener::bind(("localhost", PORT)).unwrap();
+        for stream in listener.incoming() {
+            match stream {
+                Ok(stream) => {
+                    let td_path = td_path.clone();
+                    std::thread::spawn(move || handle_client(stream, &td_path));
+                }
+                Err(e) => {
+                    panic!("Connection failed: {}", e);
+                }
+            }
+        }
+    });
+
     unsafe {
         git2_curl::register(curl::easy::Easy::new());
     }
-
-    // Spin up a server for git-http-backend
-    let td = TempDir::new().unwrap();
-    let mut cfg = Config::new();
-    cfg.port(PORT).threads(1);
-    let _a = Server::start(cfg, git_backend::Serve(td.path().to_path_buf()));
 
     // Prep a repo with one file called `foo`
     let sig = git2::Signature::now("foo", "bar").unwrap();


### PR DESCRIPTION
These don't seem to be maintained anymore, and they brought a lot of weight for just one test. I replaced them with a bare-bones http/cgi server using just the standard library.