### PR TITLE
CI: Fix lockfile verification

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,12 +33,10 @@ jobs:
     - name: Install Rust (rustup)
       run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
       shell: bash
-    - run: cargo test --no-default-features
+    - run: cargo test --no-default-features --locked
     - run: cargo test
     - run: cargo run -p systest
     - run: cargo test -p git2-curl
-    - name: Verify Cargo.lock is up-to-date
-      run: cargo update -p git2 --locked
 
   rustfmt:
     name: Rustfmt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "git2-curl"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "curl",
  "git2",


### PR DESCRIPTION
The lockfile verification step wasn't work because it was running after other commands which would have updated the lockfile. This just moves it to the front, and no need for a separate step.