### PR TITLE
libgit2-sys: Add `git_odb_backend_data_malloc` and `git_odb_backend_data_free`

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -4115,7 +4115,11 @@ extern "C" {
         priority: c_int,
     ) -> c_int;
 
+    #[deprecated(note = "only kept for compatibility; prefer git_odb_backend_data_alloc")]
     pub fn git_odb_backend_malloc(backend: *mut git_odb_backend, len: size_t) -> *mut c_void;
+
+    pub fn git_odb_backend_data_alloc(backend: *mut git_odb_backend, len: size_t) -> *mut c_void;
+    pub fn git_odb_backend_data_free(backend: *mut git_odb_backend, data: *mut c_void);
 
     pub fn git_odb_num_backends(odb: *mut git_odb) -> size_t;
     pub fn git_odb_get_backend(
@@ -4123,6 +4127,7 @@ extern "C" {
         odb: *mut git_odb,
         position: size_t,
     ) -> c_int;
+
 
     // mempack
     pub fn git_mempack_new(out: *mut *mut git_odb_backend) -> c_int;

--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -4128,7 +4128,6 @@ extern "C" {
         position: size_t,
     ) -> c_int;
 
-
     // mempack
     pub fn git_mempack_new(out: *mut *mut git_odb_backend) -> c_int;
     pub fn git_mempack_reset(backend: *mut git_odb_backend) -> c_int;


### PR DESCRIPTION
Added `git_odb_backend_data_malloc` and `git_odb_backend_data_free` to libgit2-sys.

Deprecated `git_odb_backend_malloc` in favour of the above two functions as it has been deprecated for over 6 years.