### PR TITLE
git2 feature: Custom Odb backends 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,10 +235,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -320,6 +338,7 @@ dependencies = [
  "log",
  "openssl-probe",
  "openssl-sys",
+ "rusqlite",
  "tempfile",
  "time",
  "url",
@@ -334,6 +353,24 @@ dependencies = [
  "log",
  "tempfile",
  "url",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown",
 ]
 
 [[package]]
@@ -500,6 +537,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "libssh2-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,6 +704,20 @@ dependencies = [
  "getrandom 0.2.16",
  "libredox",
  "thiserror",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
+dependencies = [
+ "bitflags 2.9.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ openssl-probe = { version = "0.1", optional = true }
 [dev-dependencies]
 clap = { version = "4.4.13", features = ["derive"] }
 time = { version = "0.3.37", features = ["formatting"] }
+rusqlite = { version = "0.37.0", features = ["bundled"] }
 tempfile = "3.1.0"
 url = "2.5.4"
 

--- a/examples/odb_backend_sqlite.rs
+++ b/examples/odb_backend_sqlite.rs
@@ -1,0 +1,137 @@
+//! # ODB backend implementation: SQLite
+//! The following is a port of libgit2-backends' `sqlite/sqlite.c` file.
+
+use git2::odb_backend::{OdbBackend, OdbBackendAllocation, OdbBackendContext, SupportedOperations};
+use git2::{Error, ErrorClass, ErrorCode, ObjectType, Oid};
+use libgit2_sys as raw;
+use rusqlite::Error as RusqliteError;
+use rusqlite::{params, OptionalExtension};
+use std::convert::Infallible;
+
+pub struct SqliteBackend {
+    conn: rusqlite::Connection,
+}
+
+const ST_READ: &str = "SELECT type, size, data FROM 'git2_odb' WHERE oid = ?;";
+const ST_READ_HEADER: &str = "SELECT type, size FROM 'git2_odb' WHERE `oid` = ?;";
+const ST_WRITE: &str = "INSERT OR IGNORE INTO 'git2_odb' VALUES (?, ?, ?, ?)";
+
+impl SqliteBackend {
+    pub fn new(conn: rusqlite::Connection) -> rusqlite::Result<Self> {
+        // Check if we need to create the git2_odb table
+        if conn.table_exists(None, "git2_odb")? {
+            // Table exists, do nothing
+        } else {
+            conn.execute("CREATE TABLE 'git2_odb' ('oid' CHARACTER(20) PRIMARY KET NOT NULL, 'type' INTEGER NOT NULL, 'size' INTEGER NOT NULL, 'data' BLOB)", params![])?;
+        }
+
+        conn.prepare_cached(ST_READ)?;
+        conn.prepare_cached(ST_READ_HEADER)?;
+        conn.prepare_cached(ST_WRITE)?;
+
+        Ok(Self { conn })
+    }
+}
+
+impl OdbBackend for SqliteBackend {
+    type Writepack = Infallible;
+    type ReadStream = Infallible;
+    type WriteStream = Infallible;
+
+    fn supported_operations(&self) -> SupportedOperations {
+        SupportedOperations::READ
+            | SupportedOperations::READ_HEADER
+            | SupportedOperations::WRITE
+            | SupportedOperations::EXISTS
+    }
+
+    fn read(
+        &mut self,
+        ctx: &OdbBackendContext,
+        oid: Oid,
+        object_type: &mut ObjectType,
+        data: &mut OdbBackendAllocation,
+    ) -> Result<(), Error> {
+        let row = self
+            .conn
+            .prepare_cached(ST_READ)
+            .map_err(map_sqlite_err)?
+            .query_one(params![oid.as_bytes()], |row| {
+                let object_type: raw::git_object_t = row.get(0)?;
+                let size: usize = row.get(1)?;
+                let data: Box<[u8]> = row.get(2)?;
+                Ok((ObjectType::from_raw(object_type).unwrap(), size, data))
+            })
+            .map_err(map_sqlite_err)?;
+        *object_type = row.0;
+        *data = ctx.try_alloc(row.1)?;
+        data.as_mut().copy_from_slice(&row.2);
+        Ok(())
+    }
+
+    fn read_header(
+        &mut self,
+        _ctx: &OdbBackendContext,
+        oid: Oid,
+        length: &mut usize,
+        object_type: &mut ObjectType,
+    ) -> Result<(), Error> {
+        let row = self
+            .conn
+            .prepare_cached(ST_READ_HEADER)
+            .map_err(map_sqlite_err)?
+            .query_one(params![oid.as_bytes()], |row| {
+                let object_type: raw::git_object_t = row.get(0)?;
+                let size: usize = row.get(1)?;
+                Ok((ObjectType::from_raw(object_type).unwrap(), size))
+            })
+            .map_err(map_sqlite_err)?;
+        *object_type = row.0;
+        *length = row.1;
+        Ok(())
+    }
+
+    fn write(
+        &mut self,
+        _ctx: &OdbBackendContext,
+        oid: Oid,
+        object_type: ObjectType,
+        data: &[u8],
+    ) -> Result<(), Error> {
+        self.conn
+            .prepare_cached(ST_WRITE)
+            .map_err(map_sqlite_err)?
+            .execute(params![
+                oid.as_bytes(),
+                object_type.raw(),
+                oid.as_bytes().len(),
+                data
+            ])
+            .map_err(map_sqlite_err)?;
+        Ok(())
+    }
+
+    fn exists(&mut self, _ctx: &OdbBackendContext, oid: Oid) -> Result<bool, Error> {
+        let row = self
+            .conn
+            .prepare_cached(ST_READ_HEADER)
+            .map_err(map_sqlite_err)?
+            .query_one(params![oid.as_bytes()], |_| Ok(()))
+            .optional()
+            .map_err(map_sqlite_err)?;
+        Ok(row.is_some())
+    }
+}
+
+fn map_sqlite_err(err: RusqliteError) -> Error {
+    match err {
+        RusqliteError::QueryReturnedNoRows => {
+            Error::new(ErrorCode::NotFound, ErrorClass::None, "not found")
+        }
+        _ => Error::new(ErrorCode::GenericError, ErrorClass::Object, err.to_string()),
+    }
+}
+
+fn main() {
+    todo!("Demonstrate how to use SqliteBackend")
+}

--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -173,7 +173,7 @@ pub struct git_odb_stream {
 }
 
 git_enum! {
-    pub enum git_odb_stream_t: c_int {
+    pub enum git_odb_stream_t: c_uint {
         GIT_STREAM_RDONLY = 2,
         GIT_STREAM_WRONLY = 4,
         GIT_STREAM_RW = 6,

--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -102,7 +102,7 @@ pub struct git_config_backend {
     pub snapshot:
         Option<extern "C" fn(*mut *mut git_config_backend, *mut git_config_backend) -> c_int>,
     pub lock: Option<extern "C" fn(*mut git_config_backend) -> c_int>,
-    pub unlock: Option<extern "C" fn(*mut git_config_backend) -> c_int>,
+    pub unlock: Option<extern "C" fn(*mut git_config_backend, c_int) -> c_int>,
     pub free: Option<extern "C" fn(*mut git_config_backend)>,
 }
 
@@ -3244,13 +3244,13 @@ extern "C" {
         repo: *const git_repository,
         force: c_int,
     ) -> c_int;
-    pub fn git_config_backend_backend_from_string(
+    pub fn git_config_backend_from_string(
         out: *mut *mut git_config_backend,
         cfg: *const c_char,
         len: size_t,
         opts: *mut git_config_backend_memory_options,
     ) -> c_int;
-    pub fn git_config_backend_backend_from_values(
+    pub fn git_config_backend_from_values(
         out: *mut *mut git_config_backend,
         values: *mut *const c_char,
         len: size_t,

--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -112,7 +112,7 @@ pub const GIT_CONFIG_BACKEND_VERSION: c_uint = 1;
 pub struct git_config_backend_memory_options {
     pub version: c_uint,
     pub backend_type: *const c_char,
-    pub origin_path: *const c_char
+    pub origin_path: *const c_char,
 }
 
 pub const GIT_CONFIG_BACKEND_MEMORY_OPTIONS_VERSION: c_uint = 1;
@@ -121,7 +121,15 @@ pub enum git_index {}
 pub enum git_index_conflict_iterator {}
 pub enum git_object {}
 pub enum git_reference {}
-pub enum git_reference_iterator {}
+
+#[repr(C)]
+pub struct git_reference_iterator {
+    pub db: *mut git_refdb,
+    pub next: Option<fn(*mut *mut git_reference, *mut git_reference_iterator) -> c_int>,
+    pub next_name: Option<fn(*mut *const c_char, *mut git_reference_iterator) -> c_int>,
+    pub free: Option<fn(*mut git_reference_iterator)>,
+}
+
 pub enum git_annotated_commit {}
 pub enum git_refdb {}
 pub enum git_refspec {}

--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -87,7 +87,28 @@ pub enum git_reflog_entry {}
 pub enum git_describe_result {}
 pub enum git_packbuilder {}
 pub enum git_odb {}
-pub enum git_odb_stream {}
+
+#[repr(C)]
+pub struct git_odb_stream {
+    pub backend: *mut git_odb_backend,
+    pub mode: c_uint,
+    pub hash_ctx: *mut c_void,
+    pub declared_size: git_object_size_t,
+    pub received_bytes: git_object_size_t,
+    pub read: Option<extern "C" fn(*mut git_odb_stream, *mut c_char, size_t) -> c_int>,
+    pub write: Option<extern "C" fn(*mut git_odb_stream, *const c_char, size_t) -> c_int>,
+    pub finalize_write: Option<extern "C" fn(*mut git_odb_stream, *const git_oid) -> c_int>,
+    pub free: Option<extern "C" fn(*mut git_odb_stream)>
+}
+
+git_enum! {
+    pub enum git_odb_stream_t: c_int {
+        GIT_STREAM_RDONLY = 2,
+        GIT_STREAM_WRONLY = 4,
+        GIT_STREAM_RW = 6,
+    }
+}
+
 pub enum git_odb_object {}
 pub enum git_worktree {}
 pub enum git_transaction {}

--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -2991,7 +2991,7 @@ extern "C" {
     pub fn git_commit_message_encoding(commit: *const git_commit) -> *const c_char;
     pub fn git_commit_message_raw(commit: *const git_commit) -> *const c_char;
     pub fn git_commit_nth_gen_ancestor(
-        commit: *mut *mut git_commit,
+        ancestor: *mut *mut git_commit,
         commit: *const git_commit,
         n: c_uint,
     ) -> c_int;

--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -125,9 +125,9 @@ pub enum git_reference {}
 #[repr(C)]
 pub struct git_reference_iterator {
     pub db: *mut git_refdb,
-    pub next: Option<fn(*mut *mut git_reference, *mut git_reference_iterator) -> c_int>,
-    pub next_name: Option<fn(*mut *const c_char, *mut git_reference_iterator) -> c_int>,
-    pub free: Option<fn(*mut git_reference_iterator)>,
+    pub next: Option<extern "C" fn(*mut *mut git_reference, *mut git_reference_iterator) -> c_int>,
+    pub next_name: Option<extern "C" fn(*mut *const c_char, *mut git_reference_iterator) -> c_int>,
+    pub free: Option<extern "C" fn(*mut git_reference_iterator)>,
 }
 
 pub enum git_annotated_commit {}

--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -173,7 +173,7 @@ pub struct git_odb_stream {
 }
 
 git_enum! {
-    pub enum git_odb_stream_t: c_uint {
+    pub enum git_odb_stream_t {
         GIT_STREAM_RDONLY = 2,
         GIT_STREAM_WRONLY = 4,
         GIT_STREAM_RW = 6,

--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -99,6 +99,8 @@ pub struct git_config_backend {
     pub del: Option<extern "C" fn(*mut git_config_backend, *const c_char) -> c_int>,
     pub del_multivar:
         Option<extern "C" fn(*mut git_config_backend, *const c_char, *const c_char) -> c_int>,
+    pub iterator:
+        Option<extern "C" fn(*mut *mut git_config_iterator, *mut git_config_backend) -> c_int>,
     pub snapshot:
         Option<extern "C" fn(*mut *mut git_config_backend, *mut git_config_backend) -> c_int>,
     pub lock: Option<extern "C" fn(*mut git_config_backend) -> c_int>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -690,6 +690,7 @@ mod util;
 
 pub mod build;
 pub mod cert;
+pub mod odb_backend;
 pub mod oid_array;
 pub mod opts;
 pub mod string_array;

--- a/src/odb.rs
+++ b/src/odb.rs
@@ -7,12 +7,12 @@ use std::ffi::CString;
 
 use libc::{c_char, c_int, c_uint, c_void, size_t};
 
+use crate::odb_backend::{CustomOdbBackend, OdbBackend};
 use crate::panic;
 use crate::util::Binding;
 use crate::{
     raw, Error, IndexerProgress, Mempack, Object, ObjectType, OdbLookupFlags, Oid, Progress,
 };
-use crate::odb_backend::{CustomOdbBackend, OdbBackend};
 
 /// A structure to represent a git object database
 pub struct Odb<'repo> {
@@ -275,10 +275,18 @@ impl<'repo> Odb<'repo> {
     /// Returns a handle to the backend.
     ///
     /// `backend` will be dropped when this Odb is dropped.
-    pub fn add_custom_backend<'odb, B: OdbBackend + 'odb>(&'odb self, backend: B, priority: i32) -> Result<CustomOdbBackend<'odb, B>, Error> {
+    pub fn add_custom_backend<'odb, B: OdbBackend + 'odb>(
+        &'odb self,
+        backend: B,
+        priority: i32,
+    ) -> Result<CustomOdbBackend<'odb, B>, Error> {
         let mut inner = CustomOdbBackend::new_inner(backend);
         unsafe {
-            try_call!(raw::git_odb_add_backend(self.raw, ptr::from_mut(inner.as_mut()).cast(), priority as c_int));
+            try_call!(raw::git_odb_add_backend(
+                self.raw,
+                ptr::from_mut(inner.as_mut()).cast(),
+                priority as c_int
+            ));
             Ok(CustomOdbBackend::new(inner))
         }
     }

--- a/src/odb_backend.rs
+++ b/src/odb_backend.rs
@@ -248,7 +248,7 @@ pub trait OdbBackend {
     /// "Freshens" an already existing object, updating its last-used time.
     ///
     /// Corresponds to the `freshen` function of [`git_odb_backend`].
-    /// Requires that [`SupportedOperations::REFRESH`] is present in the value returned from
+    /// Requires that [`SupportedOperations::FRESHEN`] is present in the value returned from
     /// [`supported_operations`] to expose it to libgit2.
     ///
     /// The default implementation of this method panics.

--- a/src/odb_backend.rs
+++ b/src/odb_backend.rs
@@ -1,0 +1,290 @@
+//! Custom backends for [`Odb`]s.
+use crate::util::Binding;
+use crate::{raw, Error, ErrorClass, ErrorCode, ObjectType, Oid};
+use libc::{c_int, size_t};
+use std::ffi::c_void;
+use std::marker::PhantomData;
+use std::mem::ManuallyDrop;
+use std::{ptr, slice};
+
+pub trait OdbBackend {
+    fn supported_operations(&self) -> SupportedOperations;
+
+    fn read(
+        &mut self,
+        ctx: &OdbBackendContext,
+        oid: Oid,
+        out: &mut OdbBackendAllocation,
+    ) -> Result<ObjectType, Error> {
+        (ctx, oid, out);
+        unimplemented!("OdbBackend::read")
+    }
+    // TODO: fn read_prefix(&mut self, ctx: &OdbBackendContext);
+    fn read_header(&mut self, ctx: &OdbBackendContext, oid: Oid) -> Result<OdbHeader, Error> {
+        (ctx, oid);
+        unimplemented!("OdbBackend::read")
+    }
+    // TODO: fn write()
+    // TODO: fn writestream()
+    // TODO: fn readstream()
+    fn exists(&mut self, ctx: &OdbBackendContext, oid: Oid) -> Result<bool, Error>;
+    // TODO: fn exists_prefix()
+    // TODO: fn refresh()
+    // TODO: fn foreach()
+    // TODO: fn writepack()
+    // TODO: fn writemidx()
+    // TODO: fn freshen()
+}
+
+bitflags::bitflags! {
+    pub struct SupportedOperations: u32 {
+        /// The backend supports the [`OdbBackend::read`] method.
+        const READ = 1;
+        /// The backend supports the [`OdbBackend::read_prefix`] method.
+        const READ_PREFIX = 1 << 1;
+        /// The backend supports the [`OdbBackend::read_header`] method.
+        const READ_HEADER = 1 << 2;
+        /// The backend supports the [`OdbBackend::write`] method.
+        const WRITE = 1 << 3;
+        /// The backend supports the [`OdbBackend::writestream`] method.
+        const WRITESTREAM = 1 << 4;
+        /// The backend supports the [`OdbBackend::readstream`] method.
+        const READSTREAM = 1 << 5;
+        /// The backend supports the [`OdbBackend::exists`] method.
+        const EXISTS = 1 << 6;
+        /// The backend supports the [`OdbBackend::exists_prefix`] method.
+        const EXISTS_PREFIX = 1 << 7;
+        /// The backend supports the [`OdbBackend::refresh`] method.
+        const REFRESH = 1 << 7;
+        /// The backend supports the [`OdbBackend::foreach`] method.
+        const FOREACH = 1 << 8;
+        /// The backend supports the [`OdbBackend::writepack`] method.
+        const WRITEPACK = 1 << 9;
+        /// The backend supports the [`OdbBackend::writemidx`] method.
+        const WRITEMIDX = 1 << 10;
+        /// The backend supports the [`OdbBackend::freshen`] method.
+        const FRESHEN = 1 << 11;
+    }
+}
+
+pub struct OdbHeader {
+    pub size: usize,
+    pub object_type: ObjectType,
+}
+
+pub struct OdbBackendAllocation {
+    backend_ptr: *mut raw::git_odb_backend,
+    raw: *mut c_void,
+    size: usize,
+}
+impl OdbBackendAllocation {
+    pub fn as_mut(&mut self) -> &mut [u8] {
+        unsafe { slice::from_raw_parts_mut(self.raw.cast(), self.size) }
+    }
+}
+impl Drop for OdbBackendAllocation {
+    fn drop(&mut self) {
+        unsafe {
+            raw::git_odb_backend_data_free(self.backend_ptr, self.raw);
+        }
+    }
+}
+
+pub struct OdbBackendRead {}
+
+pub struct OdbBackendContext {
+    backend_ptr: *mut raw::git_odb_backend,
+}
+impl OdbBackendContext {
+    /// Creates an instance of `OdbBackendAllocation` that points to `null`.
+    /// Its size will be 0.
+    pub fn null_alloc(&self) -> OdbBackendAllocation {
+        OdbBackendAllocation {
+            backend_ptr: self.backend_ptr,
+            raw: ptr::null_mut(),
+            size: 0,
+        }
+    }
+
+    /// Attempts to allocate a buffer of size `size`.
+    ///
+    /// # Return value
+    /// `Some(allocation)` if the allocation succeeded.
+    /// `None` otherwise. This usually indicates that there is not enough memory.
+    pub fn alloc(&self, size: usize) -> Option<OdbBackendAllocation> {
+        let data = unsafe { raw::git_odb_backend_data_alloc(self.backend_ptr, size as size_t) };
+        if data.is_null() {
+            return None;
+        }
+        Some(OdbBackendAllocation {
+            backend_ptr: self.backend_ptr,
+            raw: data,
+            size,
+        })
+    }
+
+    /// Attempts to allocate a buffer of size `size`, returning an error when that fails.
+    /// Essentially the same as [`alloc`], but returns a [`Result`].
+    ///
+    /// # Return value
+    /// `Ok(allocation)` if the allocation succeeded.
+    /// `Err(error)` otherwise. The error is always a `GenericError` of class `NoMemory`.
+    pub fn try_alloc(&self, size: usize) -> Result<OdbBackendAllocation, Error> {
+        self.alloc(size).ok_or_else(|| {
+            Error::new(
+                ErrorCode::GenericError,
+                ErrorClass::NoMemory,
+                "out of memory",
+            )
+        })
+    }
+}
+
+/// A handle to an [`OdbBackend`] that has been added to an [`Odb`](crate::Odb).
+pub struct CustomOdbBackend<'a, B: OdbBackend> {
+    // NOTE: Any pointer in this field must be both non-null and properly aligned.
+    raw: NonNull<Backend<B>>,
+    phantom: PhantomData<fn() -> &'a ()>,
+}
+
+impl<'a, B: OdbBackend> CustomOdbBackend<'a, B> {
+    pub(crate) fn new_inner(backend: B) -> Box<Backend<B>> {
+        let mut parent = raw::git_odb_backend {
+            version: raw::GIT_ODB_BACKEND_VERSION,
+            odb: ptr::null_mut(),
+            read: None,
+            read_prefix: None,
+            read_header: None,
+            write: None,
+            writestream: None,
+            readstream: None,
+            exists: None,
+            exists_prefix: None,
+            refresh: None,
+            foreach: None,
+            writepack: None,
+            writemidx: None,
+            freshen: None,
+            free: None,
+        };
+        Self::set_operations(backend.supported_operations(), &mut parent);
+
+        Box::new(Backend {
+            parent,
+            inner: backend,
+        })
+    }
+    pub(crate) fn new(backend: Box<Backend<B>>) -> Self {
+        // SAFETY: Box::into_raw guarantees that the pointer is properly aligned and non-null
+        let backend = Box::into_raw(backend);
+        let backend = unsafe { NonNull::new_unchecked(backend) };
+        Self {
+            raw: backend,
+            phantom: PhantomData,
+        }
+    }
+    fn set_operations(
+        supported_operations: SupportedOperations,
+        backend: &mut raw::git_odb_backend,
+    ) {
+        macro_rules! op_if {
+            ($name:ident if $flag:ident) => {
+                backend.$name = supported_operations
+                    .contains(SupportedOperations::$flag)
+                    .then_some(Backend::<B>::$name)
+            };
+        }
+        op_if!(read if READ);
+        op_if!(read_header if READ_HEADER);
+        op_if!(exists if EXISTS);
+
+        backend.free = Some(Backend::<B>::free);
+    }
+
+    pub(crate) fn as_git_odb_backend(&self) -> *mut raw::git_odb_backend {
+        self.raw.cast()
+    }
+}
+
+#[repr(C)]
+pub(crate) struct Backend<B> {
+    parent: raw::git_odb_backend,
+    inner: B,
+}
+impl<B: OdbBackend> Backend<B> {
+    extern "C" fn read(
+        data_ptr: *mut *mut c_void,
+        size_ptr: *mut size_t,
+        otype_ptr: *mut raw::git_object_t,
+        backend_ptr: *mut raw::git_odb_backend,
+        oid_ptr: *const raw::git_oid,
+    ) -> raw::git_error_code {
+        let backend = unsafe { backend_ptr.cast::<Self>().as_mut().unwrap() };
+        let data = unsafe { data_ptr.as_mut().unwrap() };
+        let size = unsafe { size_ptr.as_mut().unwrap() };
+        let object_type = unsafe { otype_ptr.as_mut().unwrap() };
+        let oid = unsafe { Oid::from_raw(oid_ptr) };
+
+        let context = OdbBackendContext { backend_ptr };
+
+        let mut allocation = ManuallyDrop::new(context.null_alloc());
+
+        let output = match backend.inner.read(&context, oid, &mut allocation) {
+            Err(e) => {
+                ManuallyDrop::into_inner(allocation);
+                return e.raw_code();
+            }
+            Ok(o) => o,
+        };
+
+        *size = allocation.size;
+        *data = allocation.raw;
+        *object_type = output.raw();
+
+        raw::GIT_OK
+    }
+    extern "C" fn read_header(
+        size_ptr: *mut size_t,
+        otype_ptr: *mut raw::git_object_t,
+        backend_ptr: *mut raw::git_odb_backend,
+        oid_ptr: *const raw::git_oid,
+    ) -> raw::git_error_code {
+        let size = unsafe { size_ptr.as_mut().unwrap() };
+        let otype = unsafe { otype_ptr.as_mut().unwrap() };
+        let backend = unsafe { backend_ptr.cast::<Backend<B>>().as_mut().unwrap() };
+        let oid = unsafe { Oid::from_raw(oid_ptr) };
+
+        let context = OdbBackendContext { backend_ptr };
+
+        let header = match backend.inner.read_header(&context, oid) {
+            Err(e) => unsafe { return e.raw_set_git_error() },
+            Ok(header) => header,
+        };
+        *size = header.size;
+        *otype = header.object_type.raw();
+        raw::GIT_OK
+    }
+
+    extern "C" fn free(backend: *mut raw::git_odb_backend) {
+        let inner = unsafe { Box::from_raw(backend.cast::<Self>()) };
+        drop(inner);
+    }
+
+    extern "C" fn exists(
+        backend_ptr: *mut raw::git_odb_backend,
+        oid_ptr: *const raw::git_oid,
+    ) -> c_int {
+        let backend = unsafe { backend_ptr.cast::<Backend<B>>().as_mut().unwrap() };
+        let oid = unsafe { Oid::from_raw(oid_ptr) };
+        let context = OdbBackendContext { backend_ptr };
+        let exists = match backend.inner.exists(&context, oid) {
+            Err(e) => return unsafe { e.raw_set_git_error() },
+            Ok(x) => x,
+        };
+        if exists {
+            1
+        } else {
+            0
+        }
+    }
+}

--- a/src/odb_backend.rs
+++ b/src/odb_backend.rs
@@ -11,10 +11,18 @@ use std::{ptr, slice};
 
 /// A custom implementation of an [`Odb`] backend.
 ///
-/// # Errors
+/// Most of the default implementations of this trait's methods panic when called as they are
+/// intended to be overridden.
 ///
-/// If the backend does not have enough memory, the error code should be
-/// [`ErrorCode::GenericError`] and the class should be [`ErrorClass::NoMemory`].
+/// # Error recommendations
+///
+/// Errors are generally left at the implementation's discretion; some recommendations are
+/// made regarding error codes and classes to ease implementation and usage of custom backends.
+///
+/// Read the individual methods' documentation for more specific recommendations.
+///
+/// If the backend does not have enough memory, the error SHOULD be code
+/// [`ErrorCode::GenericError`] and the class SHOULD be [`ErrorClass::NoMemory`].
 #[allow(unused_variables)]
 pub trait OdbBackend {
     /// Returns the supported operations of this backend.
@@ -162,6 +170,8 @@ pub trait OdbBackend {
     /// Corresponds to the `exists` function of [`git_odb_backend`].
     /// Requires that [`SupportedOperations::EXISTS`] is present in the value returned from
     /// [`supported_operations`] to expose it to libgit2.
+    ///
+    /// The default implementation of this method panics.
     ///
     /// # Implementation notes
     ///

--- a/src/odb_backend.rs
+++ b/src/odb_backend.rs
@@ -336,8 +336,9 @@ pub trait OdbBackend: Sized {
 bitflags! {
     /// Supported operations for a backend.
     pub struct SupportedOperations: u32 {
-        // NOTE: The names are taken from the trait method names, but the order is taken from the
-        //       fields of git_odb_backend.
+        // NOTE: The names are mostly taken from the trait method names, but the order of the flags
+        //       is taken from the fields of git_odb_backend.
+        //       Essentially, choose a name that is tasteful.
         /// The backend supports the [`OdbBackend::read`] method.
         const READ = 1;
         /// The backend supports the [`OdbBackend::read_prefix`] method.
@@ -358,7 +359,7 @@ bitflags! {
         const REFRESH = 1 << 7;
         /// The backend supports the [`OdbBackend::foreach`] method.
         const FOREACH = 1 << 8;
-        /// The backend supports the [`OdbBackend::write_pack`] method.
+        /// The backend supports the [`OdbBackend::open_writepack`] method.
         const WRITE_PACK = 1 << 9;
         /// The backend supports the [`OdbBackend::write_multipack_index`] method.
         const WRITE_MULTIPACK_INDEX = 1 << 10;

--- a/src/odb_backend.rs
+++ b/src/odb_backend.rs
@@ -277,7 +277,8 @@ impl OdbBackendContext {
     /// `Some(allocation)` if the allocation succeeded.
     /// `None` otherwise. This usually indicates that there is not enough memory.
     pub fn alloc(&self, size: usize) -> Option<OdbBackendAllocation> {
-        let data = unsafe { raw::git_odb_backend_data_alloc(self.backend_ptr, size as libc::size_t) };
+        let data =
+            unsafe { raw::git_odb_backend_data_alloc(self.backend_ptr, size as libc::size_t) };
         let data = NonNull::new(data)?;
         Some(OdbBackendAllocation {
             backend_ptr: self.backend_ptr,
@@ -514,14 +515,17 @@ impl<B: OdbBackend> Backend<B> {
         oid_ptr: *mut raw::git_oid,
         backend_ptr: *mut raw::git_odb_backend,
         oid_prefix_ptr: *const raw::git_oid,
-        oid_prefix_len: libc::size_t
+        oid_prefix_len: libc::size_t,
     ) -> libc::c_int {
         let backend = unsafe { backend_ptr.cast::<Self>().as_mut().unwrap() };
         let oid_prefix = unsafe { Oid::from_raw(oid_prefix_ptr) };
         let oid = unsafe { oid_ptr.cast::<Oid>().as_mut().unwrap() };
 
         let context = OdbBackendContext { backend_ptr };
-        *oid = match backend.inner.exists_prefix(&context, oid_prefix, oid_prefix_len) {
+        *oid = match backend
+            .inner
+            .exists_prefix(&context, oid_prefix, oid_prefix_len)
+        {
             Err(e) => return unsafe { e.raw_set_git_error() },
             Ok(x) => x,
         };

--- a/src/odb_backend.rs
+++ b/src/odb_backend.rs
@@ -1075,7 +1075,7 @@ impl<B: OdbBackend> Backend<B> {
         let stream = WriteStream::<B> {
             parent: raw::git_odb_stream {
                 backend: backend_ptr,
-                mode: raw::GIT_STREAM_WRONLY,
+                mode: raw::GIT_STREAM_WRONLY as _,
                 hash_ctx: ptr::null_mut(),
                 declared_size: 0,
                 received_bytes: 0,
@@ -1121,7 +1121,7 @@ impl<B: OdbBackend> Backend<B> {
         let stream = ReadStream::<B> {
             parent: raw::git_odb_stream {
                 backend: backend_ptr,
-                mode: raw::GIT_STREAM_RDONLY,
+                mode: raw::GIT_STREAM_RDONLY as _,
                 hash_ctx: ptr::null_mut(),
                 declared_size: 0,
                 received_bytes: 0,

--- a/src/odb_backend.rs
+++ b/src/odb_backend.rs
@@ -399,7 +399,7 @@ impl<B: OdbBackend> Backend<B> {
         otype_ptr: *mut raw::git_object_t,
         backend_ptr: *mut raw::git_odb_backend,
         oid_ptr: *const raw::git_oid,
-    ) -> raw::git_error_code {
+    ) -> c_int {
         let backend = unsafe { backend_ptr.cast::<Self>().as_mut().unwrap() };
         let data = unsafe { data_ptr.as_mut().unwrap() };
         let size = unsafe { size_ptr.as_mut().unwrap() };
@@ -434,7 +434,7 @@ impl<B: OdbBackend> Backend<B> {
         backend_ptr: *mut raw::git_odb_backend,
         oid_prefix_ptr: *const raw::git_oid,
         oid_prefix_len: size_t,
-    ) -> raw::git_error_code {
+    ) -> c_int {
         let backend = unsafe { backend_ptr.cast::<Self>().as_mut().unwrap() };
         let data = unsafe { data_ptr.as_mut().unwrap() };
         let size = unsafe { size_ptr.as_mut().unwrap() };
@@ -474,7 +474,7 @@ impl<B: OdbBackend> Backend<B> {
         otype_ptr: *mut raw::git_object_t,
         backend_ptr: *mut raw::git_odb_backend,
         oid_ptr: *const raw::git_oid,
-    ) -> raw::git_error_code {
+    ) -> c_int {
         let size = unsafe { size_ptr.as_mut().unwrap() };
         let otype = unsafe { otype_ptr.as_mut().unwrap() };
         let backend = unsafe { backend_ptr.cast::<Backend<B>>().as_mut().unwrap() };

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -16,6 +16,7 @@ fn main() {
         .header("git2/sys/repository.h")
         .header("git2/sys/cred.h")
         .header("git2/sys/email.h")
+        .header("git2/sys/config.h")
         .header("git2/cred_helpers.h")
         .type_name(|s, _, _| s.to_string());
     cfg.field_name(|_, f| match f {


### PR DESCRIPTION
This PR is largely an attempt at making a "safe" API for adding custom ODB backends.
Additions made for this purpose have been concentrated in `src/odb_backend.rs`, with minor modifications to `src/odb.rs` and `src/lib.rs` to make it accessible.

A disclaimer, however: custom ODB backends lack documentation in libgit2, so most of the code and documentation (of which there is plenty) is based upon what I think the code does; if someone else knows better, feel free to tell me and I'll fix it. 

I also haven't verified correctness nor safety, although I suspect the code does not violate all too many of Rust's memory rules.

The code has however been documented as thoroughly as I could be bothered to. It's not guaranteed to be correct, because libgit2 lacks documentation, but it should be largely correct as I cross-referenced with both libgit2 and libgit2sharp's source code and documentation to what extent I could.

# Usage

This is largely untested (as of writing), so I may have made mistakes here and there. 

1. Create a type that contains all the information you want from your backend (let's call it `YourBackend`).
2. Implement `git2::odb_backend::OdbBackend` trait for `YourBackend`. The only required method is `fn supported_operations(&self) -> SupportedOperations` - we'll come back to it.
3. Implement the methods you want your backend to support. All methods come with a great deal of implementation notes and recommendations.
4. In the `supported_operations` method, add a flag for each method your backend supports. The appropriate flags are described in each method's documentation.
5. To add `YourBackend` as a backend to an `odb: Odb`, use `odb.add_custom_backend(your_backend, priority)`.
6. If you want to access `YourBackend`, you can do so with the `CustomOdbBackend` handle that was returned in the previous call.

# TODO

There may also be some TODOs littered throughout the code.

- [x] Implement the `readstream` and `writestream` methods (203f81e)
- [x] Implement the `foreach` method (6a6b9ee)
- [ ] Add more implementation notes; the documentation is currently very lacking.
- [ ] Create an example backend using this system. Perhaps try to reimplement one of libgit2's builtin backends?
- [ ] Combine duplicated bindings (most notably `odb_backend::Indexer` to `indexer::Indexer` and `odb_backend::IndexerProgress` to `indexer::Progress`)
- [ ] Reconsider the naming of some of the types and methods before merging
