### PR TITLE
Improve function docs for `Repository::tag_foreach`

### DIFF
--- a/src/repo.rs
+++ b/src/repo.rs
@@ -2043,8 +2043,10 @@ impl Repository {
         }
     }
 
-    /// iterate over all tags calling `cb` on each.
-    /// the callback is provided the tag id and name
+    /// Iterate over all tags, calling the callback `cb` on each.
+    /// The arguments of `cb` are the tag id and name, in this order.
+    ///
+    /// Returning `false` from `cb` causes the iteration to break early.
     pub fn tag_foreach<T>(&self, cb: T) -> Result<(), Error>
     where
         T: FnMut(Oid, &[u8]) -> bool,


### PR DESCRIPTION
Previously the documentation did not make it clear the effect of the return value of `cb`. This PR clarifies that, alongside a minor rewording of existing docs.

Ref:

https://libgit2.org/docs/reference/main/tag/git_tag_foreach_cb.html

https://github.com/rust-lang/git2-rs/blob/1d9f4d4a9c934ef9236f5092de7c21201de4cf6f/src/tagforeach.rs#L18-L43