### PR TITLE
Fix skip_reuc flag in MergeOptions to use GIT_MERGE_SKIP_REUC

### DIFF
--- a/src/merge.rs
+++ b/src/merge.rs
@@ -95,7 +95,7 @@ impl MergeOptions {
 
     /// Do not write the REUC extension on the generated index
     pub fn skip_reuc(&mut self, skip: bool) -> &mut MergeOptions {
-        self.flag(raw::GIT_MERGE_FAIL_ON_CONFLICT as u32, skip)
+        self.flag(raw::GIT_MERGE_SKIP_REUC as u32, skip)
     }
 
     /// If the commits being merged have multiple merge bases, do not build a


### PR DESCRIPTION
The `skip_reuc` sets the wrong flag (FAIL_ON_CONFLICT instead of SKIP_REUC), making merges abort immediately on any conflict rather than skipping the REUC as intended