### PR TITLE
feat: add `raw::git_repository_oid_type` and friends

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -2304,6 +2304,8 @@ extern "C" {
     pub fn git_repository_index(out: *mut *mut git_index, repo: *mut git_repository) -> c_int;
     pub fn git_repository_set_index(repo: *mut git_repository, index: *mut git_index) -> c_int;
 
+    pub fn git_repository_oid_type(repo: *mut git_repository) -> git_oid_t;
+
     pub fn git_repository_message(buf: *mut git_buf, repo: *mut git_repository) -> c_int;
 
     pub fn git_repository_message_remove(repo: *mut git_repository) -> c_int;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,7 @@ pub use crate::message::{
 pub use crate::note::{Note, Notes};
 pub use crate::object::Object;
 pub use crate::odb::{Odb, OdbObject, OdbPackwriter, OdbReader, OdbWriter};
+pub use crate::oid::ObjectFormat;
 pub use crate::oid::Oid;
 pub use crate::packbuilder::{PackBuilder, PackBuilderStage};
 pub use crate::patch::Patch;

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -8,6 +8,30 @@ use crate::{raw, Error, IntoCString, ObjectType};
 
 use crate::util::{c_cmp_to_ordering, Binding};
 
+/// Object ID format (hash algorithm).
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum ObjectFormat {
+    /// SHA1 object format (20-byte object IDs)
+    Sha1,
+}
+
+impl Binding for ObjectFormat {
+    type Raw = raw::git_oid_t;
+
+    unsafe fn from_raw(raw: raw::git_oid_t) -> Self {
+        match raw {
+            raw::GIT_OID_SHA1 => ObjectFormat::Sha1,
+            _ => panic!("Unknown git oid type"),
+        }
+    }
+
+    fn raw(&self) -> Self::Raw {
+        match self {
+            ObjectFormat::Sha1 => raw::GIT_OID_SHA1,
+        }
+    }
+}
+
 /// Unique identity of any object (commit, tree, blob, tag).
 #[derive(Copy, Clone)]
 #[repr(C)]


### PR DESCRIPTION
This is not behind any experimental flag.
Should be fine exposing directly

(Spun off from rust-lang/git2-rs#1202)