### PR TITLE
[Clippy] Address `clippy::unnecessary_cast` in production code

### DIFF
--- a/src/apply.rs
+++ b/src/apply.rs
@@ -102,7 +102,10 @@ impl<'cb> ApplyOptions<'cb> {
     }
 
     fn flag(&mut self, opt: raw::git_apply_flags_t, val: bool) -> &mut Self {
-        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
+        #[allow(
+            clippy::unnecessary_cast,
+            reason = "u32 unless compiling for msvc target env"
+        )]
         let opt = opt as u32;
         if val {
             self.raw.flags |= opt;

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -102,6 +102,7 @@ impl<'cb> ApplyOptions<'cb> {
     }
 
     fn flag(&mut self, opt: raw::git_apply_flags_t, val: bool) -> &mut Self {
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         let opt = opt as u32;
         if val {
             self.raw.flags |= opt;

--- a/src/blame.rs
+++ b/src/blame.rs
@@ -209,7 +209,7 @@ impl<'blame> BlameHunk<'blame> {
 
     /// Returns number of lines in this hunk.
     pub fn lines_in_hunk(&self) -> usize {
-        unsafe { (*self.raw).lines_in_hunk as usize }
+        unsafe { (*self.raw).lines_in_hunk }
     }
 
     /// Get the short "summary" of the git commit message for the hunk.

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -46,7 +46,7 @@ impl Deref for Buf {
         if self.raw.ptr.is_null() {
             return &[];
         }
-        unsafe { slice::from_raw_parts(self.raw.ptr as *const u8, self.raw.size as usize) }
+        unsafe { slice::from_raw_parts(self.raw.ptr as *const u8, self.raw.size) }
     }
 }
 
@@ -55,7 +55,7 @@ impl DerefMut for Buf {
         if self.raw.ptr.is_null() {
             return &mut [];
         }
-        unsafe { slice::from_raw_parts_mut(self.raw.ptr as *mut u8, self.raw.size as usize) }
+        unsafe { slice::from_raw_parts_mut(self.raw.ptr as *mut u8, self.raw.size) }
     }
 }
 

--- a/src/build.rs
+++ b/src/build.rs
@@ -336,6 +336,7 @@ impl<'cb> CheckoutBuilder<'cb> {
             ancestor_label: None,
             our_label: None,
             their_label: None,
+            #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
             checkout_opts: raw::GIT_CHECKOUT_SAFE as u32,
             progress: None,
             notify: None,
@@ -345,6 +346,7 @@ impl<'cb> CheckoutBuilder<'cb> {
 
     /// Indicate that this checkout should perform a dry run by checking for
     /// conflicts but not make any actual changes.
+    #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
     pub fn dry_run(&mut self) -> &mut CheckoutBuilder<'cb> {
         self.checkout_opts &= !((1 << 4) - 1);
         self.checkout_opts |= raw::GIT_CHECKOUT_NONE as u32;
@@ -353,6 +355,7 @@ impl<'cb> CheckoutBuilder<'cb> {
 
     /// Take any action necessary to get the working directory to match the
     /// target including potentially discarding modified files.
+    #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
     pub fn force(&mut self) -> &mut CheckoutBuilder<'cb> {
         self.checkout_opts &= !((1 << 4) - 1);
         self.checkout_opts |= raw::GIT_CHECKOUT_FORCE as u32;
@@ -363,6 +366,7 @@ impl<'cb> CheckoutBuilder<'cb> {
     /// files to be created but not overwriting existing files or changes.
     ///
     /// This is the default.
+    #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
     pub fn safe(&mut self) -> &mut CheckoutBuilder<'cb> {
         self.checkout_opts &= !((1 << 4) - 1);
         self.checkout_opts |= raw::GIT_CHECKOUT_SAFE as u32;
@@ -370,6 +374,7 @@ impl<'cb> CheckoutBuilder<'cb> {
     }
 
     fn flag(&mut self, bit: raw::git_checkout_strategy_t, on: bool) -> &mut CheckoutBuilder<'cb> {
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         if on {
             self.checkout_opts |= bit as u32;
         } else {
@@ -649,7 +654,7 @@ extern "C" fn progress_cb(
         } else {
             Some(util::bytes2path(CStr::from_ptr(path).to_bytes()))
         };
-        callback(path, completed as usize, total as usize)
+        callback(path, completed, total)
     });
 }
 
@@ -692,6 +697,7 @@ extern "C" fn notify_cb(
             Some(DiffFile::from_raw(workdir))
         };
 
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         let why = CheckoutNotificationType::from_bits_truncate(why as u32);
         let keep_going = callback(why, path, baseline, target, workdir);
         if keep_going {

--- a/src/build.rs
+++ b/src/build.rs
@@ -336,7 +336,10 @@ impl<'cb> CheckoutBuilder<'cb> {
             ancestor_label: None,
             our_label: None,
             their_label: None,
-            #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
+            #[allow(
+                clippy::unnecessary_cast,
+                reason = "u32 unless compiling for msvc target env"
+            )]
             checkout_opts: raw::GIT_CHECKOUT_SAFE as u32,
             progress: None,
             notify: None,
@@ -346,7 +349,10 @@ impl<'cb> CheckoutBuilder<'cb> {
 
     /// Indicate that this checkout should perform a dry run by checking for
     /// conflicts but not make any actual changes.
-    #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
+    #[allow(
+        clippy::unnecessary_cast,
+        reason = "u32 unless compiling for msvc target env"
+    )]
     pub fn dry_run(&mut self) -> &mut CheckoutBuilder<'cb> {
         self.checkout_opts &= !((1 << 4) - 1);
         self.checkout_opts |= raw::GIT_CHECKOUT_NONE as u32;
@@ -355,7 +361,10 @@ impl<'cb> CheckoutBuilder<'cb> {
 
     /// Take any action necessary to get the working directory to match the
     /// target including potentially discarding modified files.
-    #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
+    #[allow(
+        clippy::unnecessary_cast,
+        reason = "u32 unless compiling for msvc target env"
+    )]
     pub fn force(&mut self) -> &mut CheckoutBuilder<'cb> {
         self.checkout_opts &= !((1 << 4) - 1);
         self.checkout_opts |= raw::GIT_CHECKOUT_FORCE as u32;
@@ -366,7 +375,10 @@ impl<'cb> CheckoutBuilder<'cb> {
     /// files to be created but not overwriting existing files or changes.
     ///
     /// This is the default.
-    #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
+    #[allow(
+        clippy::unnecessary_cast,
+        reason = "u32 unless compiling for msvc target env"
+    )]
     pub fn safe(&mut self) -> &mut CheckoutBuilder<'cb> {
         self.checkout_opts &= !((1 << 4) - 1);
         self.checkout_opts |= raw::GIT_CHECKOUT_SAFE as u32;
@@ -374,7 +386,10 @@ impl<'cb> CheckoutBuilder<'cb> {
     }
 
     fn flag(&mut self, bit: raw::git_checkout_strategy_t, on: bool) -> &mut CheckoutBuilder<'cb> {
-        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
+        #[allow(
+            clippy::unnecessary_cast,
+            reason = "u32 unless compiling for msvc target env"
+        )]
         if on {
             self.checkout_opts |= bit as u32;
         } else {
@@ -697,7 +712,10 @@ extern "C" fn notify_cb(
             Some(DiffFile::from_raw(workdir))
         };
 
-        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
+        #[allow(
+            clippy::unnecessary_cast,
+            reason = "u32 unless compiling for msvc target env"
+        )]
         let why = CheckoutNotificationType::from_bits_truncate(why as u32);
         let keep_going = callback(why, path, baseline, target, workdir);
         if keep_going {

--- a/src/cert.rs
+++ b/src/cert.rs
@@ -105,7 +105,10 @@ impl<'a> CertHostkey<'a> {
     /// Returns the md5 hash of the hostkey, if available.
     pub fn hash_md5(&self) -> Option<&[u8; 16]> {
         let kind = unsafe { (*self.raw).kind };
-        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
+        #[allow(
+            clippy::unnecessary_cast,
+            reason = "u32 unless compiling for msvc target env"
+        )]
         if kind as u32 & raw::GIT_CERT_SSH_MD5 as u32 == 0 {
             None
         } else {
@@ -116,7 +119,10 @@ impl<'a> CertHostkey<'a> {
     /// Returns the SHA-1 hash of the hostkey, if available.
     pub fn hash_sha1(&self) -> Option<&[u8; 20]> {
         let kind = unsafe { (*self.raw).kind };
-        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
+        #[allow(
+            clippy::unnecessary_cast,
+            reason = "u32 unless compiling for msvc target env"
+        )]
         if kind as u32 & raw::GIT_CERT_SSH_SHA1 as u32 == 0 {
             None
         } else {
@@ -127,7 +133,10 @@ impl<'a> CertHostkey<'a> {
     /// Returns the SHA-256 hash of the hostkey, if available.
     pub fn hash_sha256(&self) -> Option<&[u8; 32]> {
         let kind = unsafe { (*self.raw).kind };
-        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
+        #[allow(
+            clippy::unnecessary_cast,
+            reason = "u32 unless compiling for msvc target env"
+        )]
         if kind as u32 & raw::GIT_CERT_SSH_SHA256 as u32 == 0 {
             None
         } else {
@@ -142,10 +151,7 @@ impl<'a> CertHostkey<'a> {
             return None;
         }
         Some(unsafe {
-            slice::from_raw_parts(
-                (*self.raw).hostkey as *const u8,
-                (*self.raw).hostkey_len,
-            )
+            slice::from_raw_parts((*self.raw).hostkey as *const u8, (*self.raw).hostkey_len)
         })
     }
 

--- a/src/cert.rs
+++ b/src/cert.rs
@@ -105,6 +105,7 @@ impl<'a> CertHostkey<'a> {
     /// Returns the md5 hash of the hostkey, if available.
     pub fn hash_md5(&self) -> Option<&[u8; 16]> {
         let kind = unsafe { (*self.raw).kind };
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         if kind as u32 & raw::GIT_CERT_SSH_MD5 as u32 == 0 {
             None
         } else {
@@ -115,6 +116,7 @@ impl<'a> CertHostkey<'a> {
     /// Returns the SHA-1 hash of the hostkey, if available.
     pub fn hash_sha1(&self) -> Option<&[u8; 20]> {
         let kind = unsafe { (*self.raw).kind };
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         if kind as u32 & raw::GIT_CERT_SSH_SHA1 as u32 == 0 {
             None
         } else {
@@ -125,6 +127,7 @@ impl<'a> CertHostkey<'a> {
     /// Returns the SHA-256 hash of the hostkey, if available.
     pub fn hash_sha256(&self) -> Option<&[u8; 32]> {
         let kind = unsafe { (*self.raw).kind };
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         if kind as u32 & raw::GIT_CERT_SSH_SHA256 as u32 == 0 {
             None
         } else {
@@ -141,7 +144,7 @@ impl<'a> CertHostkey<'a> {
         Some(unsafe {
             slice::from_raw_parts(
                 (*self.raw).hostkey as *const u8,
-                (*self.raw).hostkey_len as usize,
+                (*self.raw).hostkey_len,
             )
         })
     }
@@ -170,7 +173,7 @@ impl<'a> CertHostkey<'a> {
 impl<'a> CertX509<'a> {
     /// Return the X.509 certificate data as a byte slice
     pub fn data(&self) -> &[u8] {
-        unsafe { slice::from_raw_parts((*self.raw).data as *const u8, (*self.raw).len as usize) }
+        unsafe { slice::from_raw_parts((*self.raw).data as *const u8, (*self.raw).len) }
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -562,7 +562,9 @@ impl<'cfg> ConfigEntry<'cfg> {
     /// Depth of includes where this variable was found
     pub fn include_depth(&self) -> u32 {
         #[allow(clippy::unnecessary_cast, reason = "c_uint is not always u32")]
-        unsafe { (*self.raw).include_depth as u32 }
+        unsafe {
+            (*self.raw).include_depth as u32
+        }
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -561,6 +561,7 @@ impl<'cfg> ConfigEntry<'cfg> {
 
     /// Depth of includes where this variable was found
     pub fn include_depth(&self) -> u32 {
+        #[allow(clippy::unnecessary_cast, reason = "c_uint is not always u32")]
         unsafe { (*self.raw).include_depth as u32 }
     }
 }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -625,26 +625,46 @@ impl<'a> DiffFile<'a> {
 
     /// Returns `true` if file(s) are treated as binary data.
     pub fn is_binary(&self) -> bool {
-        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
-        unsafe { (*self.raw).flags & raw::GIT_DIFF_FLAG_BINARY as u32 != 0 }
+        #[allow(
+            clippy::unnecessary_cast,
+            reason = "u32 unless compiling for msvc target env"
+        )]
+        unsafe {
+            (*self.raw).flags & raw::GIT_DIFF_FLAG_BINARY as u32 != 0
+        }
     }
 
     /// Returns `true` if file(s) are treated as text data.
     pub fn is_not_binary(&self) -> bool {
-        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
-        unsafe { (*self.raw).flags & raw::GIT_DIFF_FLAG_NOT_BINARY as u32 != 0 }
+        #[allow(
+            clippy::unnecessary_cast,
+            reason = "u32 unless compiling for msvc target env"
+        )]
+        unsafe {
+            (*self.raw).flags & raw::GIT_DIFF_FLAG_NOT_BINARY as u32 != 0
+        }
     }
 
     /// Returns `true` if `id` value is known correct.
     pub fn is_valid_id(&self) -> bool {
-        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
-        unsafe { (*self.raw).flags & raw::GIT_DIFF_FLAG_VALID_ID as u32 != 0 }
+        #[allow(
+            clippy::unnecessary_cast,
+            reason = "u32 unless compiling for msvc target env"
+        )]
+        unsafe {
+            (*self.raw).flags & raw::GIT_DIFF_FLAG_VALID_ID as u32 != 0
+        }
     }
 
     /// Returns `true` if file exists at this side of the delta.
     pub fn exists(&self) -> bool {
-        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
-        unsafe { (*self.raw).flags & raw::GIT_DIFF_FLAG_EXISTS as u32 != 0 }
+        #[allow(
+            clippy::unnecessary_cast,
+            reason = "u32 unless compiling for msvc target env"
+        )]
+        unsafe {
+            (*self.raw).flags & raw::GIT_DIFF_FLAG_EXISTS as u32 != 0
+        }
     }
 
     /// Returns file mode.
@@ -713,7 +733,10 @@ impl DiffOptions {
     }
 
     fn flag(&mut self, opt: raw::git_diff_option_t, val: bool) -> &mut DiffOptions {
-        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
+        #[allow(
+            clippy::unnecessary_cast,
+            reason = "u32 unless compiling for msvc target env"
+        )]
         let opt = opt as u32;
         if val {
             self.raw.flags |= opt;
@@ -1082,12 +1105,7 @@ impl<'a> DiffLine<'a> {
 
     /// Content of this line as bytes.
     pub fn content(&self) -> &'a [u8] {
-        unsafe {
-            slice::from_raw_parts(
-                (*self.raw).content as *const u8,
-                (*self.raw).content_len,
-            )
-        }
+        unsafe { slice::from_raw_parts((*self.raw).content as *const u8, (*self.raw).content_len) }
     }
 
     /// origin of this `DiffLine`.

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -620,26 +620,30 @@ impl<'a> DiffFile<'a> {
 
     /// Returns the size of this entry, in bytes
     pub fn size(&self) -> u64 {
-        unsafe { (*self.raw).size as u64 }
+        unsafe { (*self.raw).size }
     }
 
     /// Returns `true` if file(s) are treated as binary data.
     pub fn is_binary(&self) -> bool {
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         unsafe { (*self.raw).flags & raw::GIT_DIFF_FLAG_BINARY as u32 != 0 }
     }
 
     /// Returns `true` if file(s) are treated as text data.
     pub fn is_not_binary(&self) -> bool {
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         unsafe { (*self.raw).flags & raw::GIT_DIFF_FLAG_NOT_BINARY as u32 != 0 }
     }
 
     /// Returns `true` if `id` value is known correct.
     pub fn is_valid_id(&self) -> bool {
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         unsafe { (*self.raw).flags & raw::GIT_DIFF_FLAG_VALID_ID as u32 != 0 }
     }
 
     /// Returns `true` if file exists at this side of the delta.
     pub fn exists(&self) -> bool {
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         unsafe { (*self.raw).flags & raw::GIT_DIFF_FLAG_EXISTS as u32 != 0 }
     }
 
@@ -709,6 +713,7 @@ impl DiffOptions {
     }
 
     fn flag(&mut self, opt: raw::git_diff_option_t, val: bool) -> &mut DiffOptions {
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         let opt = opt as u32;
         if val {
             self.raw.flags |= opt;
@@ -1072,7 +1077,7 @@ impl<'a> DiffLine<'a> {
 
     /// Offset in the original file to the content
     pub fn content_offset(&self) -> i64 {
-        unsafe { (*self.raw).content_offset as i64 }
+        unsafe { (*self.raw).content_offset }
     }
 
     /// Content of this line as bytes.
@@ -1080,7 +1085,7 @@ impl<'a> DiffLine<'a> {
         unsafe {
             slice::from_raw_parts(
                 (*self.raw).content as *const u8,
-                (*self.raw).content_len as usize,
+                (*self.raw).content_len,
             )
         }
     }
@@ -1174,7 +1179,7 @@ impl<'a> DiffHunk<'a> {
         unsafe {
             slice::from_raw_parts(
                 (*self.raw).header.as_ptr() as *const u8,
-                (*self.raw).header_len as usize,
+                (*self.raw).header_len,
             )
         }
     }
@@ -1317,12 +1322,12 @@ impl<'a> DiffBinaryFile<'a> {
             );
             return &[];
         }
-        unsafe { slice::from_raw_parts(ptr as *const u8, datalen as usize) }
+        unsafe { slice::from_raw_parts(ptr as *const u8, datalen) }
     }
 
     /// The length of the binary data after inflation
     pub fn inflated_len(&self) -> usize {
-        unsafe { (*self.raw).inflatedlen as usize }
+        unsafe { (*self.raw).inflatedlen }
     }
 }
 

--- a/src/email.rs
+++ b/src/email.rs
@@ -23,7 +23,10 @@ impl Default for EmailCreateOptions {
         // Defaults options created in corresponding to `GIT_EMAIL_CREATE_OPTIONS_INIT`
         let default_options = raw::git_email_create_options {
             version: raw::GIT_EMAIL_CREATE_OPTIONS_VERSION,
-            #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
+            #[allow(
+                clippy::unnecessary_cast,
+                reason = "u32 unless compiling for msvc target env"
+            )]
             flags: raw::GIT_EMAIL_CREATE_DEFAULT as u32,
             diff_opts: unsafe { mem::zeroed() },
             diff_find_opts: unsafe { mem::zeroed() },
@@ -52,7 +55,10 @@ impl EmailCreateOptions {
     }
 
     fn flag(&mut self, opt: raw::git_email_create_flags_t, val: bool) -> &mut Self {
-        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
+        #[allow(
+            clippy::unnecessary_cast,
+            reason = "u32 unless compiling for msvc target env"
+        )]
         let opt = opt as u32;
         if val {
             self.raw.flags |= opt;

--- a/src/email.rs
+++ b/src/email.rs
@@ -23,6 +23,7 @@ impl Default for EmailCreateOptions {
         // Defaults options created in corresponding to `GIT_EMAIL_CREATE_OPTIONS_INIT`
         let default_options = raw::git_email_create_options {
             version: raw::GIT_EMAIL_CREATE_OPTIONS_VERSION,
+            #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
             flags: raw::GIT_EMAIL_CREATE_DEFAULT as u32,
             diff_opts: unsafe { mem::zeroed() },
             diff_find_opts: unsafe { mem::zeroed() },
@@ -51,6 +52,7 @@ impl EmailCreateOptions {
     }
 
     fn flag(&mut self, opt: raw::git_email_create_flags_t, val: bool) -> &mut Self {
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         let opt = opt as u32;
         if val {
             self.raw.flags |= opt;

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -207,8 +207,7 @@ impl<'a> Indexer<'a> {
     where
         F: FnMut(Progress<'_>) -> bool + 'a,
     {
-        let progress_payload =
-            unsafe { &mut *self.progress_payload_ptr };
+        let progress_payload = unsafe { &mut *self.progress_payload_ptr };
         progress_payload.cb = Some(Box::new(cb) as Box<IndexerProgress<'a>>);
 
         self

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -58,7 +58,7 @@ impl<'a> Progress<'a> {
     }
     /// Size of the packfile received up to now
     pub fn received_bytes(&self) -> usize {
-        unsafe { (*self.raw()).received_bytes as usize }
+        unsafe { (*self.raw()).received_bytes }
     }
 
     /// Convert this to an owned version of `Progress`.
@@ -208,7 +208,7 @@ impl<'a> Indexer<'a> {
         F: FnMut(Progress<'_>) -> bool + 'a,
     {
         let progress_payload =
-            unsafe { &mut *(self.progress_payload_ptr as *mut OdbPackwriterCb<'_>) };
+            unsafe { &mut *self.progress_payload_ptr };
         progress_payload.cb = Some(Box::new(cb) as Box<IndexerProgress<'a>>);
 
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -443,22 +443,26 @@ bitflags! {
         ///
         /// This sorting is arbitrary, implementation-specific, and subject to
         /// change at any time. This is the default sorting for new walkers.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const NONE = raw::GIT_SORT_NONE as u32;
 
         /// Sort the repository contents in topological order (children before
         /// parents).
         ///
         /// This sorting mode can be combined with time sorting.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const TOPOLOGICAL = raw::GIT_SORT_TOPOLOGICAL as u32;
 
         /// Sort the repository contents by commit time.
         ///
         /// This sorting mode can be combined with topological sorting.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const TIME = raw::GIT_SORT_TIME as u32;
 
         /// Iterate through the repository contents in reverse order.
         ///
         /// This sorting mode can be combined with any others.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const REVERSE = raw::GIT_SORT_REVERSE as u32;
     }
 }
@@ -475,18 +479,25 @@ bitflags! {
     #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
     pub struct CredentialType: u32 {
         #[allow(missing_docs)]
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const USER_PASS_PLAINTEXT = raw::GIT_CREDTYPE_USERPASS_PLAINTEXT as u32;
         #[allow(missing_docs)]
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const SSH_KEY = raw::GIT_CREDTYPE_SSH_KEY as u32;
         #[allow(missing_docs)]
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const SSH_MEMORY = raw::GIT_CREDTYPE_SSH_MEMORY as u32;
         #[allow(missing_docs)]
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const SSH_CUSTOM = raw::GIT_CREDTYPE_SSH_CUSTOM as u32;
         #[allow(missing_docs)]
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const DEFAULT = raw::GIT_CREDTYPE_DEFAULT as u32;
         #[allow(missing_docs)]
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const SSH_INTERACTIVE = raw::GIT_CREDTYPE_SSH_INTERACTIVE as u32;
         #[allow(missing_docs)]
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const USERNAME = raw::GIT_CREDTYPE_USERNAME as u32;
     }
 }
@@ -548,13 +559,17 @@ bitflags! {
     #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
     pub struct IndexAddOption: u32 {
         /// Adds files that are not ignored to the index
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const DEFAULT = raw::GIT_INDEX_ADD_DEFAULT as u32;
         /// Allows adding otherwise ignored files to the index
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const FORCE = raw::GIT_INDEX_ADD_FORCE as u32;
         #[allow(missing_docs)]
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const DISABLE_PATHSPEC_MATCH =
                 raw::GIT_INDEX_ADD_DISABLE_PATHSPEC_MATCH as u32;
         #[allow(missing_docs)]
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const CHECK_PATHSPEC = raw::GIT_INDEX_ADD_CHECK_PATHSPEC as u32;
     }
 }
@@ -580,14 +595,19 @@ bitflags! {
     #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
     pub struct RepositoryOpenFlags: u32 {
         /// Only open the specified path; don't walk upward searching.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const NO_SEARCH = raw::GIT_REPOSITORY_OPEN_NO_SEARCH as u32;
         /// Search across filesystem boundaries.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const CROSS_FS = raw::GIT_REPOSITORY_OPEN_CROSS_FS as u32;
         /// Force opening as bare repository, and defer loading its config.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const BARE = raw::GIT_REPOSITORY_OPEN_BARE as u32;
         /// Don't try appending `/.git` to the specified repository path.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const NO_DOTGIT = raw::GIT_REPOSITORY_OPEN_NO_DOTGIT as u32;
         /// Respect environment variables like `$GIT_DIR`.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const FROM_ENV = raw::GIT_REPOSITORY_OPEN_FROM_ENV as u32;
     }
 }
@@ -605,10 +625,13 @@ bitflags! {
     #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
     pub struct RevparseMode: u32 {
         /// The spec targeted a single object
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const SINGLE = raw::GIT_REVPARSE_SINGLE as u32;
         /// The spec targeted a range of commits
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const RANGE = raw::GIT_REVPARSE_RANGE as u32;
         /// The spec used the `...` operator, which invokes special semantics.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const MERGE_BASE = raw::GIT_REVPARSE_MERGE_BASE as u32;
     }
 }
@@ -624,20 +647,25 @@ bitflags! {
     #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
     pub struct MergeAnalysis: u32 {
         /// No merge is possible.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const ANALYSIS_NONE = raw::GIT_MERGE_ANALYSIS_NONE as u32;
         /// A "normal" merge; both HEAD and the given merge input have diverged
         /// from their common ancestor. The divergent commits must be merged.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const ANALYSIS_NORMAL = raw::GIT_MERGE_ANALYSIS_NORMAL as u32;
         /// All given merge inputs are reachable from HEAD, meaning the
         /// repository is up-to-date and no merge needs to be performed.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const ANALYSIS_UP_TO_DATE = raw::GIT_MERGE_ANALYSIS_UP_TO_DATE as u32;
         /// The given merge input is a fast-forward from HEAD and no merge
         /// needs to be performed.  Instead, the client can check out the
         /// given merge input.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const ANALYSIS_FASTFORWARD = raw::GIT_MERGE_ANALYSIS_FASTFORWARD as u32;
         /// The HEAD of the current repository is "unborn" and does not point to
         /// a valid commit.  No merge can be performed, but the caller may wish
         /// to simply set HEAD to the target commit(s).
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const ANALYSIS_UNBORN = raw::GIT_MERGE_ANALYSIS_UNBORN as u32;
     }
 }
@@ -656,12 +684,15 @@ bitflags! {
     pub struct MergePreference: u32 {
         /// No configuration was found that suggests a preferred behavior for
         /// merge.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const NONE = raw::GIT_MERGE_PREFERENCE_NONE as u32;
         /// There is a `merge.ff=false` configuration setting, suggesting that
         /// the user does not want to allow a fast-forward merge.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const NO_FAST_FORWARD = raw::GIT_MERGE_PREFERENCE_NO_FASTFORWARD as u32;
         /// There is a `merge.ff=only` configuration setting, suggesting that
         /// the user only wants fast-forward merges.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const FASTFORWARD_ONLY = raw::GIT_MERGE_PREFERENCE_FASTFORWARD_ONLY as u32;
     }
 }
@@ -680,6 +711,7 @@ bitflags! {
         /// a batch of lookup operations for objects that may legitimately not
         /// exist. When using this flag, you may wish to manually call
         /// `git_odb_refresh` before processing a batch of objects.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const NO_REFRESH = raw::GIT_ODB_LOOKUP_NO_REFRESH as u32;
     }
 }
@@ -689,8 +721,10 @@ bitflags! {
     #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
     pub struct RemoteUpdateFlags: u32 {
        /// Write the fetch results to FETCH_HEAD.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
        const UPDATE_FETCHHEAD = raw::GIT_REMOTE_UPDATE_FETCHHEAD as u32;
        /// Report unchanged tips in the update_tips callback.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
        const REPORT_UNCHANGED = raw::GIT_REMOTE_UPDATE_REPORT_UNCHANGED as u32;
     }
 }
@@ -1048,35 +1082,49 @@ bitflags! {
     #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
     pub struct Status: u32 {
         #[allow(missing_docs)]
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const CURRENT = raw::GIT_STATUS_CURRENT as u32;
 
         #[allow(missing_docs)]
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const INDEX_NEW = raw::GIT_STATUS_INDEX_NEW as u32;
         #[allow(missing_docs)]
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const INDEX_MODIFIED = raw::GIT_STATUS_INDEX_MODIFIED as u32;
         #[allow(missing_docs)]
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const INDEX_DELETED = raw::GIT_STATUS_INDEX_DELETED as u32;
         #[allow(missing_docs)]
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const INDEX_RENAMED = raw::GIT_STATUS_INDEX_RENAMED as u32;
         #[allow(missing_docs)]
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const INDEX_TYPECHANGE = raw::GIT_STATUS_INDEX_TYPECHANGE as u32;
 
         #[allow(missing_docs)]
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const WT_NEW = raw::GIT_STATUS_WT_NEW as u32;
         #[allow(missing_docs)]
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const WT_MODIFIED = raw::GIT_STATUS_WT_MODIFIED as u32;
         #[allow(missing_docs)]
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const WT_DELETED = raw::GIT_STATUS_WT_DELETED as u32;
         #[allow(missing_docs)]
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const WT_TYPECHANGE = raw::GIT_STATUS_WT_TYPECHANGE as u32;
         #[allow(missing_docs)]
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const WT_RENAMED = raw::GIT_STATUS_WT_RENAMED as u32;
         #[allow(missing_docs)]
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const WT_UNREADABLE = raw::GIT_STATUS_WT_UNREADABLE as u32;
 
         #[allow(missing_docs)]
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const IGNORED = raw::GIT_STATUS_IGNORED as u32;
         #[allow(missing_docs)]
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const CONFLICTED = raw::GIT_STATUS_CONFLICTED as u32;
     }
 }
@@ -1101,11 +1149,14 @@ bitflags! {
     #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
     pub struct RepositoryInitMode: u32 {
         /// Use permissions configured by umask - the default
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const SHARED_UMASK = raw::GIT_REPOSITORY_INIT_SHARED_UMASK as u32;
         /// Use `--shared=group` behavior, chmod'ing the new repo to be
         /// group writable and \"g+sx\" for sticky group assignment
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const SHARED_GROUP = raw::GIT_REPOSITORY_INIT_SHARED_GROUP as u32;
         /// Use `--shared=all` behavior, adding world readability.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const SHARED_ALL = raw::GIT_REPOSITORY_INIT_SHARED_ALL as u32;
     }
 }
@@ -1165,12 +1216,19 @@ pub enum FileMode {
 impl From<FileMode> for i32 {
     fn from(mode: FileMode) -> i32 {
         match mode {
+            #[allow(clippy::unnecessary_cast, reason = "only i32 when compiling for msvc target env")]
             FileMode::Unreadable => raw::GIT_FILEMODE_UNREADABLE as i32,
+            #[allow(clippy::unnecessary_cast, reason = "only i32 when compiling for msvc target env")]
             FileMode::Tree => raw::GIT_FILEMODE_TREE as i32,
+            #[allow(clippy::unnecessary_cast, reason = "only i32 when compiling for msvc target env")]
             FileMode::Blob => raw::GIT_FILEMODE_BLOB as i32,
+            #[allow(clippy::unnecessary_cast, reason = "only i32 when compiling for msvc target env")]
             FileMode::BlobGroupWritable => raw::GIT_FILEMODE_BLOB_GROUP_WRITABLE as i32,
+            #[allow(clippy::unnecessary_cast, reason = "only i32 when compiling for msvc target env")]
             FileMode::BlobExecutable => raw::GIT_FILEMODE_BLOB_EXECUTABLE as i32,
+            #[allow(clippy::unnecessary_cast, reason = "only i32 when compiling for msvc target env")]
             FileMode::Link => raw::GIT_FILEMODE_LINK as i32,
+            #[allow(clippy::unnecessary_cast, reason = "only i32 when compiling for msvc target env")]
             FileMode::Commit => raw::GIT_FILEMODE_COMMIT as i32,
         }
     }
@@ -1179,12 +1237,19 @@ impl From<FileMode> for i32 {
 impl From<FileMode> for u32 {
     fn from(mode: FileMode) -> u32 {
         match mode {
+            #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
             FileMode::Unreadable => raw::GIT_FILEMODE_UNREADABLE as u32,
+            #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
             FileMode::Tree => raw::GIT_FILEMODE_TREE as u32,
+            #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
             FileMode::Blob => raw::GIT_FILEMODE_BLOB as u32,
+            #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
             FileMode::BlobGroupWritable => raw::GIT_FILEMODE_BLOB_GROUP_WRITABLE as u32,
+            #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
             FileMode::BlobExecutable => raw::GIT_FILEMODE_BLOB_EXECUTABLE as u32,
+            #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
             FileMode::Link => raw::GIT_FILEMODE_LINK as u32,
+            #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
             FileMode::Commit => raw::GIT_FILEMODE_COMMIT as u32,
         }
     }
@@ -1234,34 +1299,48 @@ bitflags! {
     #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
     pub struct SubmoduleStatus: u32 {
         #[allow(missing_docs)]
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const IN_HEAD = raw::GIT_SUBMODULE_STATUS_IN_HEAD as u32;
         #[allow(missing_docs)]
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const IN_INDEX = raw::GIT_SUBMODULE_STATUS_IN_INDEX as u32;
         #[allow(missing_docs)]
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const IN_CONFIG = raw::GIT_SUBMODULE_STATUS_IN_CONFIG as u32;
         #[allow(missing_docs)]
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const IN_WD = raw::GIT_SUBMODULE_STATUS_IN_WD as u32;
         #[allow(missing_docs)]
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const INDEX_ADDED = raw::GIT_SUBMODULE_STATUS_INDEX_ADDED as u32;
         #[allow(missing_docs)]
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const INDEX_DELETED = raw::GIT_SUBMODULE_STATUS_INDEX_DELETED as u32;
         #[allow(missing_docs)]
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const INDEX_MODIFIED = raw::GIT_SUBMODULE_STATUS_INDEX_MODIFIED as u32;
         #[allow(missing_docs)]
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const WD_UNINITIALIZED =
                 raw::GIT_SUBMODULE_STATUS_WD_UNINITIALIZED as u32;
         #[allow(missing_docs)]
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const WD_ADDED = raw::GIT_SUBMODULE_STATUS_WD_ADDED as u32;
         #[allow(missing_docs)]
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const WD_DELETED = raw::GIT_SUBMODULE_STATUS_WD_DELETED as u32;
         #[allow(missing_docs)]
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const WD_MODIFIED = raw::GIT_SUBMODULE_STATUS_WD_MODIFIED as u32;
         #[allow(missing_docs)]
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const WD_INDEX_MODIFIED =
                 raw::GIT_SUBMODULE_STATUS_WD_INDEX_MODIFIED as u32;
         #[allow(missing_docs)]
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const WD_WD_MODIFIED = raw::GIT_SUBMODULE_STATUS_WD_WD_MODIFIED as u32;
         #[allow(missing_docs)]
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const WD_UNTRACKED = raw::GIT_SUBMODULE_STATUS_WD_UNTRACKED as u32;
     }
 }
@@ -1331,27 +1410,34 @@ bitflags! {
     #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
     pub struct PathspecFlags: u32 {
         /// Use the default pathspec matching configuration.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const DEFAULT = raw::GIT_PATHSPEC_DEFAULT as u32;
         /// Force matching to ignore case, otherwise matching will use native
         /// case sensitivity of the platform filesystem.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const IGNORE_CASE = raw::GIT_PATHSPEC_IGNORE_CASE as u32;
         /// Force case sensitive matches, otherwise match will use the native
         /// case sensitivity of the platform filesystem.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const USE_CASE = raw::GIT_PATHSPEC_USE_CASE as u32;
         /// Disable glob patterns and just use simple string comparison for
         /// matching.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const NO_GLOB = raw::GIT_PATHSPEC_NO_GLOB as u32;
         /// Means that match functions return the error code `NotFound` if no
         /// matches are found. By default no matches is a success.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const NO_MATCH_ERROR = raw::GIT_PATHSPEC_NO_MATCH_ERROR as u32;
         /// Means that the list returned should track which patterns matched
         /// which files so that at the end of the match we can identify patterns
         /// that did not match any files.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const FIND_FAILURES = raw::GIT_PATHSPEC_FIND_FAILURES as u32;
         /// Means that the list returned does not need to keep the actual
         /// matching filenames. Use this to just test if there were any matches
         /// at all or in combination with `PATHSPEC_FAILURES` to validate a
         /// pathspec.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const FAILURES_ONLY = raw::GIT_PATHSPEC_FAILURES_ONLY as u32;
     }
 }
@@ -1377,14 +1463,19 @@ bitflags! {
     #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
     pub struct CheckoutNotificationType: u32 {
         /// Notification about a conflict.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const CONFLICT = raw::GIT_CHECKOUT_NOTIFY_CONFLICT as u32;
         /// Notification about a dirty file.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const DIRTY = raw::GIT_CHECKOUT_NOTIFY_DIRTY as u32;
         /// Notification about an updated file.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const UPDATED = raw::GIT_CHECKOUT_NOTIFY_UPDATED as u32;
         /// Notification about an untracked file.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const UNTRACKED = raw::GIT_CHECKOUT_NOTIFY_UNTRACKED as u32;
         /// Notification about an ignored file.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const IGNORED = raw::GIT_CHECKOUT_NOTIFY_IGNORED as u32;
     }
 }
@@ -1492,9 +1583,11 @@ bitflags! {
     #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
     pub struct StashApplyFlags: u32 {
         /// Default options if no additional customization is desired.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const DEFAULT = raw::GIT_STASH_APPLY_DEFAULT as u32;
         /// Try to reinstate not only the working tree's changes,
         /// but also the index's changes.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const REINSTATE_INDEX = raw::GIT_STASH_APPLY_REINSTATE_INDEX as u32;
     }
 }
@@ -1518,17 +1611,22 @@ bitflags! {
     #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
     pub struct StashFlags: u32 {
         /// Default options if no additional customization is desired.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const DEFAULT = raw::GIT_STASH_DEFAULT as u32;
         /// All changes already added to the index are left intact in
         /// the working directory
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const KEEP_INDEX = raw::GIT_STASH_KEEP_INDEX as u32;
         /// All untracked files are also stashed and then cleaned up
         /// from the working directory
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const INCLUDE_UNTRACKED = raw::GIT_STASH_INCLUDE_UNTRACKED as u32;
         /// All ignored files are also stashed and then cleaned up from
         /// the working directory
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const INCLUDE_IGNORED = raw::GIT_STASH_INCLUDE_IGNORED as u32;
         /// All changes in the index and working directory are left intact
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const KEEP_ALL = raw::GIT_STASH_KEEP_ALL as u32;
     }
 }
@@ -1551,13 +1649,13 @@ bitflags! {
     #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
     pub struct AttrCheckFlags: u32 {
         /// Check the working directory, then the index.
-        const FILE_THEN_INDEX = raw::GIT_ATTR_CHECK_FILE_THEN_INDEX as u32;
+        const FILE_THEN_INDEX = raw::GIT_ATTR_CHECK_FILE_THEN_INDEX;
         /// Check the index, then the working directory.
-        const INDEX_THEN_FILE = raw::GIT_ATTR_CHECK_INDEX_THEN_FILE as u32;
+        const INDEX_THEN_FILE = raw::GIT_ATTR_CHECK_INDEX_THEN_FILE;
         /// Check the index only.
-        const INDEX_ONLY = raw::GIT_ATTR_CHECK_INDEX_ONLY as u32;
+        const INDEX_ONLY = raw::GIT_ATTR_CHECK_INDEX_ONLY;
         /// Do not use the system gitattributes file.
-        const NO_SYSTEM = raw::GIT_ATTR_CHECK_NO_SYSTEM as u32;
+        const NO_SYSTEM = raw::GIT_ATTR_CHECK_NO_SYSTEM;
     }
 }
 
@@ -1572,12 +1670,16 @@ bitflags! {
     #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
     pub struct DiffFlags: u32 {
         /// File(s) treated as binary data.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const BINARY = raw::GIT_DIFF_FLAG_BINARY as u32;
         /// File(s) treated as text data.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const NOT_BINARY = raw::GIT_DIFF_FLAG_NOT_BINARY as u32;
         /// `id` value is known correct.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const VALID_ID = raw::GIT_DIFF_FLAG_VALID_ID as u32;
         /// File exists at this side of the delta.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const EXISTS = raw::GIT_DIFF_FLAG_EXISTS as u32;
     }
 }
@@ -1594,20 +1696,24 @@ bitflags! {
     #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
     pub struct ReferenceFormat: u32 {
         /// No particular normalization.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const NORMAL = raw::GIT_REFERENCE_FORMAT_NORMAL as u32;
         /// Control whether one-level refname are accepted (i.e., refnames that
         /// do not contain multiple `/`-separated components). Those are
         /// expected to be written only using uppercase letters and underscore
         /// (e.g. `HEAD`, `FETCH_HEAD`).
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const ALLOW_ONELEVEL = raw::GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL as u32;
         /// Interpret the provided name as a reference pattern for a refspec (as
         /// used with remote repositories). If this option is enabled, the name
         /// is allowed to contain a single `*` in place of a full pathname
         /// components (e.g., `foo/*/bar` but not `foo/bar*`).
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const REFSPEC_PATTERN = raw::GIT_REFERENCE_FORMAT_REFSPEC_PATTERN as u32;
         /// Interpret the name as part of a refspec in shorthand form so the
         /// `ALLOW_ONELEVEL` naming rules aren't enforced and `main` becomes a
         /// valid name.
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         const REFSPEC_SHORTHAND = raw::GIT_REFERENCE_FORMAT_REFSPEC_SHORTHAND as u32;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1216,19 +1216,40 @@ pub enum FileMode {
 impl From<FileMode> for i32 {
     fn from(mode: FileMode) -> i32 {
         match mode {
-            #[allow(clippy::unnecessary_cast, reason = "only i32 when compiling for msvc target env")]
+            #[allow(
+                clippy::unnecessary_cast,
+                reason = "only i32 when compiling for msvc target env"
+            )]
             FileMode::Unreadable => raw::GIT_FILEMODE_UNREADABLE as i32,
-            #[allow(clippy::unnecessary_cast, reason = "only i32 when compiling for msvc target env")]
+            #[allow(
+                clippy::unnecessary_cast,
+                reason = "only i32 when compiling for msvc target env"
+            )]
             FileMode::Tree => raw::GIT_FILEMODE_TREE as i32,
-            #[allow(clippy::unnecessary_cast, reason = "only i32 when compiling for msvc target env")]
+            #[allow(
+                clippy::unnecessary_cast,
+                reason = "only i32 when compiling for msvc target env"
+            )]
             FileMode::Blob => raw::GIT_FILEMODE_BLOB as i32,
-            #[allow(clippy::unnecessary_cast, reason = "only i32 when compiling for msvc target env")]
+            #[allow(
+                clippy::unnecessary_cast,
+                reason = "only i32 when compiling for msvc target env"
+            )]
             FileMode::BlobGroupWritable => raw::GIT_FILEMODE_BLOB_GROUP_WRITABLE as i32,
-            #[allow(clippy::unnecessary_cast, reason = "only i32 when compiling for msvc target env")]
+            #[allow(
+                clippy::unnecessary_cast,
+                reason = "only i32 when compiling for msvc target env"
+            )]
             FileMode::BlobExecutable => raw::GIT_FILEMODE_BLOB_EXECUTABLE as i32,
-            #[allow(clippy::unnecessary_cast, reason = "only i32 when compiling for msvc target env")]
+            #[allow(
+                clippy::unnecessary_cast,
+                reason = "only i32 when compiling for msvc target env"
+            )]
             FileMode::Link => raw::GIT_FILEMODE_LINK as i32,
-            #[allow(clippy::unnecessary_cast, reason = "only i32 when compiling for msvc target env")]
+            #[allow(
+                clippy::unnecessary_cast,
+                reason = "only i32 when compiling for msvc target env"
+            )]
             FileMode::Commit => raw::GIT_FILEMODE_COMMIT as i32,
         }
     }
@@ -1237,19 +1258,40 @@ impl From<FileMode> for i32 {
 impl From<FileMode> for u32 {
     fn from(mode: FileMode) -> u32 {
         match mode {
-            #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
+            #[allow(
+                clippy::unnecessary_cast,
+                reason = "u32 unless compiling for msvc target env"
+            )]
             FileMode::Unreadable => raw::GIT_FILEMODE_UNREADABLE as u32,
-            #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
+            #[allow(
+                clippy::unnecessary_cast,
+                reason = "u32 unless compiling for msvc target env"
+            )]
             FileMode::Tree => raw::GIT_FILEMODE_TREE as u32,
-            #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
+            #[allow(
+                clippy::unnecessary_cast,
+                reason = "u32 unless compiling for msvc target env"
+            )]
             FileMode::Blob => raw::GIT_FILEMODE_BLOB as u32,
-            #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
+            #[allow(
+                clippy::unnecessary_cast,
+                reason = "u32 unless compiling for msvc target env"
+            )]
             FileMode::BlobGroupWritable => raw::GIT_FILEMODE_BLOB_GROUP_WRITABLE as u32,
-            #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
+            #[allow(
+                clippy::unnecessary_cast,
+                reason = "u32 unless compiling for msvc target env"
+            )]
             FileMode::BlobExecutable => raw::GIT_FILEMODE_BLOB_EXECUTABLE as u32,
-            #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
+            #[allow(
+                clippy::unnecessary_cast,
+                reason = "u32 unless compiling for msvc target env"
+            )]
             FileMode::Link => raw::GIT_FILEMODE_LINK as u32,
-            #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
+            #[allow(
+                clippy::unnecessary_cast,
+                reason = "u32 unless compiling for msvc target env"
+            )]
             FileMode::Commit => raw::GIT_FILEMODE_COMMIT as u32,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,6 @@
 #![deny(missing_docs)]
 #![warn(rust_2018_idioms)]
 #![cfg_attr(test, deny(warnings))]
-#![allow(clippy::unnecessary_cast)]
 
 use bitflags::bitflags;
 use libgit2_sys as raw;

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -81,20 +81,29 @@ impl MergeOptions {
 
     /// Detect file renames
     pub fn find_renames(&mut self, find: bool) -> &mut MergeOptions {
-        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
+        #[allow(
+            clippy::unnecessary_cast,
+            reason = "u32 unless compiling for msvc target env"
+        )]
         self.flag(raw::GIT_MERGE_FIND_RENAMES as u32, find)
     }
 
     /// If a conflict occurs, exit immediately instead of attempting to continue
     /// resolving conflicts
     pub fn fail_on_conflict(&mut self, fail: bool) -> &mut MergeOptions {
-        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
+        #[allow(
+            clippy::unnecessary_cast,
+            reason = "u32 unless compiling for msvc target env"
+        )]
         self.flag(raw::GIT_MERGE_FAIL_ON_CONFLICT as u32, fail)
     }
 
     /// Do not write the REUC extension on the generated index
     pub fn skip_reuc(&mut self, skip: bool) -> &mut MergeOptions {
-        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
+        #[allow(
+            clippy::unnecessary_cast,
+            reason = "u32 unless compiling for msvc target env"
+        )]
         self.flag(raw::GIT_MERGE_SKIP_REUC as u32, skip)
     }
 
@@ -102,7 +111,10 @@ impl MergeOptions {
     /// recursive merge base (by merging the multiple merge bases), instead
     /// simply use the first base.
     pub fn no_recursive(&mut self, disable: bool) -> &mut MergeOptions {
-        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
+        #[allow(
+            clippy::unnecessary_cast,
+            reason = "u32 unless compiling for msvc target env"
+        )]
         self.flag(raw::GIT_MERGE_NO_RECURSIVE as u32, disable)
     }
 
@@ -147,49 +159,73 @@ impl MergeOptions {
 
     /// Create standard conflicted merge files
     pub fn standard_style(&mut self, standard: bool) -> &mut MergeOptions {
-        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
+        #[allow(
+            clippy::unnecessary_cast,
+            reason = "u32 unless compiling for msvc target env"
+        )]
         self.file_flag(raw::GIT_MERGE_FILE_STYLE_MERGE as u32, standard)
     }
 
     /// Create diff3-style file
     pub fn diff3_style(&mut self, diff3: bool) -> &mut MergeOptions {
-        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
+        #[allow(
+            clippy::unnecessary_cast,
+            reason = "u32 unless compiling for msvc target env"
+        )]
         self.file_flag(raw::GIT_MERGE_FILE_STYLE_DIFF3 as u32, diff3)
     }
 
     /// Condense non-alphanumeric regions for simplified diff file
     pub fn simplify_alnum(&mut self, simplify: bool) -> &mut MergeOptions {
-        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
+        #[allow(
+            clippy::unnecessary_cast,
+            reason = "u32 unless compiling for msvc target env"
+        )]
         self.file_flag(raw::GIT_MERGE_FILE_SIMPLIFY_ALNUM as u32, simplify)
     }
 
     /// Ignore all whitespace
     pub fn ignore_whitespace(&mut self, ignore: bool) -> &mut MergeOptions {
-        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
+        #[allow(
+            clippy::unnecessary_cast,
+            reason = "u32 unless compiling for msvc target env"
+        )]
         self.file_flag(raw::GIT_MERGE_FILE_IGNORE_WHITESPACE as u32, ignore)
     }
 
     /// Ignore changes in amount of whitespace
     pub fn ignore_whitespace_change(&mut self, ignore: bool) -> &mut MergeOptions {
-        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
+        #[allow(
+            clippy::unnecessary_cast,
+            reason = "u32 unless compiling for msvc target env"
+        )]
         self.file_flag(raw::GIT_MERGE_FILE_IGNORE_WHITESPACE_CHANGE as u32, ignore)
     }
 
     /// Ignore whitespace at end of line
     pub fn ignore_whitespace_eol(&mut self, ignore: bool) -> &mut MergeOptions {
-        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
+        #[allow(
+            clippy::unnecessary_cast,
+            reason = "u32 unless compiling for msvc target env"
+        )]
         self.file_flag(raw::GIT_MERGE_FILE_IGNORE_WHITESPACE_EOL as u32, ignore)
     }
 
     /// Use the "patience diff" algorithm
     pub fn patience(&mut self, patience: bool) -> &mut MergeOptions {
-        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
+        #[allow(
+            clippy::unnecessary_cast,
+            reason = "u32 unless compiling for msvc target env"
+        )]
         self.file_flag(raw::GIT_MERGE_FILE_DIFF_PATIENCE as u32, patience)
     }
 
     /// Take extra time to find minimal diff
     pub fn minimal(&mut self, minimal: bool) -> &mut MergeOptions {
-        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
+        #[allow(
+            clippy::unnecessary_cast,
+            reason = "u32 unless compiling for msvc target env"
+        )]
         self.file_flag(raw::GIT_MERGE_FILE_DIFF_MINIMAL as u32, minimal)
     }
 
@@ -294,7 +330,10 @@ impl MergeFileOptions {
     }
 
     fn flag(&mut self, opt: raw::git_merge_file_flag_t, val: bool) -> &mut MergeFileOptions {
-        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
+        #[allow(
+            clippy::unnecessary_cast,
+            reason = "u32 unless compiling for msvc target env"
+        )]
         if val {
             self.raw.flags |= opt as u32;
         } else {

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -81,17 +81,20 @@ impl MergeOptions {
 
     /// Detect file renames
     pub fn find_renames(&mut self, find: bool) -> &mut MergeOptions {
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         self.flag(raw::GIT_MERGE_FIND_RENAMES as u32, find)
     }
 
     /// If a conflict occurs, exit immediately instead of attempting to continue
     /// resolving conflicts
     pub fn fail_on_conflict(&mut self, fail: bool) -> &mut MergeOptions {
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         self.flag(raw::GIT_MERGE_FAIL_ON_CONFLICT as u32, fail)
     }
 
     /// Do not write the REUC extension on the generated index
     pub fn skip_reuc(&mut self, skip: bool) -> &mut MergeOptions {
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         self.flag(raw::GIT_MERGE_SKIP_REUC as u32, skip)
     }
 
@@ -99,6 +102,7 @@ impl MergeOptions {
     /// recursive merge base (by merging the multiple merge bases), instead
     /// simply use the first base.
     pub fn no_recursive(&mut self, disable: bool) -> &mut MergeOptions {
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         self.flag(raw::GIT_MERGE_NO_RECURSIVE as u32, disable)
     }
 
@@ -143,41 +147,49 @@ impl MergeOptions {
 
     /// Create standard conflicted merge files
     pub fn standard_style(&mut self, standard: bool) -> &mut MergeOptions {
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         self.file_flag(raw::GIT_MERGE_FILE_STYLE_MERGE as u32, standard)
     }
 
     /// Create diff3-style file
     pub fn diff3_style(&mut self, diff3: bool) -> &mut MergeOptions {
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         self.file_flag(raw::GIT_MERGE_FILE_STYLE_DIFF3 as u32, diff3)
     }
 
     /// Condense non-alphanumeric regions for simplified diff file
     pub fn simplify_alnum(&mut self, simplify: bool) -> &mut MergeOptions {
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         self.file_flag(raw::GIT_MERGE_FILE_SIMPLIFY_ALNUM as u32, simplify)
     }
 
     /// Ignore all whitespace
     pub fn ignore_whitespace(&mut self, ignore: bool) -> &mut MergeOptions {
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         self.file_flag(raw::GIT_MERGE_FILE_IGNORE_WHITESPACE as u32, ignore)
     }
 
     /// Ignore changes in amount of whitespace
     pub fn ignore_whitespace_change(&mut self, ignore: bool) -> &mut MergeOptions {
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         self.file_flag(raw::GIT_MERGE_FILE_IGNORE_WHITESPACE_CHANGE as u32, ignore)
     }
 
     /// Ignore whitespace at end of line
     pub fn ignore_whitespace_eol(&mut self, ignore: bool) -> &mut MergeOptions {
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         self.file_flag(raw::GIT_MERGE_FILE_IGNORE_WHITESPACE_EOL as u32, ignore)
     }
 
     /// Use the "patience diff" algorithm
     pub fn patience(&mut self, patience: bool) -> &mut MergeOptions {
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         self.file_flag(raw::GIT_MERGE_FILE_DIFF_PATIENCE as u32, patience)
     }
 
     /// Take extra time to find minimal diff
     pub fn minimal(&mut self, minimal: bool) -> &mut MergeOptions {
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         self.file_flag(raw::GIT_MERGE_FILE_DIFF_MINIMAL as u32, minimal)
     }
 
@@ -282,6 +294,7 @@ impl MergeFileOptions {
     }
 
     fn flag(&mut self, opt: raw::git_merge_file_flag_t, val: bool) -> &mut MergeFileOptions {
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         if val {
             self.raw.flags |= opt as u32;
         } else {
@@ -378,6 +391,7 @@ impl MergeFileResult {
     }
 
     /// The mode that the resultant merge file should use.
+    #[allow(clippy::unnecessary_cast, reason = "c_uint is not always u32")]
     pub fn mode(&self) -> u32 {
         self.raw.mode as u32
     }
@@ -386,7 +400,7 @@ impl MergeFileResult {
     pub fn content(&self) -> &[u8] {
         // If the pointer is null, slice::from_raw_parts() cannot be used
         let ptr = self.raw.ptr as *const u8;
-        let len = self.raw.len as usize;
+        let len = self.raw.len;
         if ptr.is_null() {
             assert_eq!(
                 0, len,

--- a/src/odb.rs
+++ b/src/odb.rs
@@ -494,7 +494,7 @@ impl<'repo> OdbPackwriter<'repo> {
         F: FnMut(Progress<'_>) -> bool + 'repo,
     {
         let progress_payload =
-            unsafe { &mut *(self.progress_payload_ptr as *mut OdbPackwriterCb<'_>) };
+            unsafe { &mut *self.progress_payload_ptr };
 
         progress_payload.cb = Some(Box::new(cb) as Box<IndexerProgress<'repo>>);
         self

--- a/src/odb.rs
+++ b/src/odb.rs
@@ -493,8 +493,7 @@ impl<'repo> OdbPackwriter<'repo> {
     where
         F: FnMut(Progress<'_>) -> bool + 'repo,
     {
-        let progress_payload =
-            unsafe { &mut *self.progress_payload_ptr };
+        let progress_payload = unsafe { &mut *self.progress_payload_ptr };
 
         progress_payload.cb = Some(Box::new(cb) as Box<IndexerProgress<'repo>>);
         self

--- a/src/oid_array.rs
+++ b/src/oid_array.rs
@@ -24,7 +24,7 @@ impl Deref for OidArray {
         unsafe {
             debug_assert_eq!(mem::size_of::<Oid>(), mem::size_of_val(&*self.raw.ids));
 
-            slice::from_raw_parts(self.raw.ids as *const Oid, self.raw.count as usize)
+            slice::from_raw_parts(self.raw.ids as *const Oid, self.raw.count)
         }
     }
 }

--- a/src/packbuilder.rs
+++ b/src/packbuilder.rs
@@ -259,7 +259,7 @@ impl Binding for PackBuilderStage {
 extern "C" fn foreach_c(buf: *const c_void, size: size_t, data: *mut c_void) -> c_int {
     let r;
     unsafe {
-        let buf = slice::from_raw_parts(buf as *const u8, size as usize);
+        let buf = slice::from_raw_parts(buf as *const u8, size);
 
         r = panic::wrap(|| {
             let data = data as *mut &mut ForEachCb<'_>;

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -421,7 +421,7 @@ impl<'repo> Remote<'repo> {
             return Ok(&[]);
         }
         unsafe {
-            let slice = slice::from_raw_parts(base as *const _, size as usize);
+            let slice = slice::from_raw_parts(base as *const _, size);
             Ok(mem::transmute::<
                 &[*const raw::git_remote_head],
                 &[RemoteHead<'_>],

--- a/src/remote_callbacks.rs
+++ b/src/remote_callbacks.rs
@@ -327,6 +327,7 @@ extern "C" fn credentials_cb(
             None => None,
         };
 
+        #[allow(clippy::unnecessary_cast, reason = "c_uint is not always u32")]
         let cred_type = CredentialType::from_bits_truncate(allowed_types as u32);
 
         callback(url, username_from_url, cred_type).map_err(|e| e.raw_set_git_error())
@@ -475,7 +476,7 @@ extern "C" fn push_transfer_progress_cb(
             None => return 0,
         };
 
-        callback(progress as usize, total as usize, bytes as usize);
+        callback(progress as usize, total as usize, bytes);
 
         0
     })

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -3488,7 +3488,10 @@ impl RepositoryInitOptions {
     /// and initializing a directory from the user-configured templates path.
     pub fn new() -> RepositoryInitOptions {
         RepositoryInitOptions {
-            #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
+            #[allow(
+                clippy::unnecessary_cast,
+                reason = "u32 unless compiling for msvc target env"
+            )]
             flags: raw::GIT_REPOSITORY_INIT_MKDIR as u32
                 | raw::GIT_REPOSITORY_INIT_MKPATH as u32
                 | raw::GIT_REPOSITORY_INIT_EXTERNAL_TEMPLATE as u32,
@@ -3564,7 +3567,10 @@ impl RepositoryInitOptions {
         flag: raw::git_repository_init_flag_t,
         on: bool,
     ) -> &mut RepositoryInitOptions {
-        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
+        #[allow(
+            clippy::unnecessary_cast,
+            reason = "u32 unless compiling for msvc target env"
+        )]
         if on {
             self.flags |= flag as u32;
         } else {

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -388,6 +388,7 @@ impl Repository {
         let to;
         let from;
         let mode;
+        #[allow(clippy::unnecessary_cast, reason = "c_uint is not always u32")]
         unsafe {
             try_call!(raw::git_revparse(&mut raw, self.raw, spec));
             to = Binding::from_raw_opt(raw.to);
@@ -1907,6 +1908,7 @@ impl Repository {
         unsafe {
             try_call!(raw::git_submodule_status(&mut ret, self.raw, name, ignore));
         }
+        #[allow(clippy::unnecessary_cast, reason = "c_uint is not always u32")]
         Ok(SubmoduleStatus::from_bits_truncate(ret as u32))
     }
 
@@ -3486,6 +3488,7 @@ impl RepositoryInitOptions {
     /// and initializing a directory from the user-configured templates path.
     pub fn new() -> RepositoryInitOptions {
         RepositoryInitOptions {
+            #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
             flags: raw::GIT_REPOSITORY_INIT_MKDIR as u32
                 | raw::GIT_REPOSITORY_INIT_MKPATH as u32
                 | raw::GIT_REPOSITORY_INIT_EXTERNAL_TEMPLATE as u32,
@@ -3561,6 +3564,7 @@ impl RepositoryInitOptions {
         flag: raw::git_repository_init_flag_t,
         on: bool,
     ) -> &mut RepositoryInitOptions {
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         if on {
             self.flags |= flag as u32;
         } else {

--- a/src/stash.rs
+++ b/src/stash.rs
@@ -110,7 +110,10 @@ impl<'cb> StashApplyOptions<'cb> {
     }
 
     /// Set stash application flag to GIT_STASH_APPLY_REINSTATE_INDEX
-    #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
+    #[allow(
+        clippy::unnecessary_cast,
+        reason = "u32 unless compiling for msvc target env"
+    )]
     pub fn reinstantiate_index(&mut self) -> &mut StashApplyOptions<'cb> {
         self.raw_opts.flags = raw::GIT_STASH_APPLY_REINSTATE_INDEX as u32;
         self

--- a/src/stash.rs
+++ b/src/stash.rs
@@ -110,6 +110,7 @@ impl<'cb> StashApplyOptions<'cb> {
     }
 
     /// Set stash application flag to GIT_STASH_APPLY_REINSTATE_INDEX
+    #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
     pub fn reinstantiate_index(&mut self) -> &mut StashApplyOptions<'cb> {
         self.raw_opts.flags = raw::GIT_STASH_APPLY_REINSTATE_INDEX as u32;
         self

--- a/src/status.rs
+++ b/src/status.rs
@@ -335,6 +335,7 @@ impl<'statuses> StatusEntry<'statuses> {
 
     /// Access the status flags for this file
     pub fn status(&self) -> Status {
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         Status::from_bits_truncate(unsafe { (*self.raw).status as u32 })
     }
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -335,7 +335,10 @@ impl<'statuses> StatusEntry<'statuses> {
 
     /// Access the status flags for this file
     pub fn status(&self) -> Status {
-        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
+        #[allow(
+            clippy::unnecessary_cast,
+            reason = "u32 unless compiling for msvc target env"
+        )]
         Status::from_bits_truncate(unsafe { (*self.raw).status as u32 })
     }
 

--- a/src/string_array.rs
+++ b/src/string_array.rs
@@ -40,7 +40,7 @@ impl StringArray {
 
     /// Returns None if `i` is out of bounds.
     pub fn get_bytes(&self, i: usize) -> Option<&[u8]> {
-        if i < self.raw.count as usize {
+        if i < self.raw.count {
             unsafe {
                 let ptr = *self.raw.strings.add(i) as *const _;
                 Some(crate::opt_bytes(self, ptr).unwrap())
@@ -72,7 +72,7 @@ impl StringArray {
 
     /// Returns the number of strings in this array.
     pub fn len(&self) -> usize {
-        self.raw.count as usize
+        self.raw.count
     }
 
     /// Return `true` if this array is empty.

--- a/src/time.rs
+++ b/src/time.rs
@@ -31,10 +31,11 @@ impl Time {
 
     /// Return the time, in seconds, from epoch
     pub fn seconds(&self) -> i64 {
-        self.raw.time as i64
+        self.raw.time
     }
 
     /// Return the timezone offset, in minutes
+    #[allow(clippy::unnecessary_cast, reason = "c_int is not always i32")]
     pub fn offset_minutes(&self) -> i32 {
         self.raw.offset as i32
     }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -319,7 +319,7 @@ extern "C" fn stream_read(
 ) -> c_int {
     let ret = panic::wrap(|| unsafe {
         let transport = &mut *(stream as *mut RawSmartSubtransportStream);
-        let buf = slice::from_raw_parts_mut(buffer as *mut u8, buf_size as usize);
+        let buf = slice::from_raw_parts_mut(buffer as *mut u8, buf_size);
         match transport.obj.read(buf) {
             Ok(n) => {
                 *bytes_read = n as size_t;
@@ -347,7 +347,7 @@ extern "C" fn stream_write(
 ) -> c_int {
     let ret = panic::wrap(|| unsafe {
         let transport = &mut *(stream as *mut RawSmartSubtransportStream);
-        let buf = slice::from_raw_parts(buffer as *const u8, len as usize);
+        let buf = slice::from_raw_parts(buffer as *const u8, len);
         transport.obj.write_all(buf)
     });
     match ret {

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -241,7 +241,10 @@ impl WorktreePruneOptions {
     }
 
     fn flag(&mut self, flag: raw::git_worktree_prune_t, on: bool) -> &mut WorktreePruneOptions {
-        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
+        #[allow(
+            clippy::unnecessary_cast,
+            reason = "u32 unless compiling for msvc target env"
+        )]
         if on {
             self.raw.flags |= flag as u32;
         } else {

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -241,6 +241,7 @@ impl WorktreePruneOptions {
     }
 
     fn flag(&mut self, flag: raw::git_worktree_prune_t, on: bool) -> &mut WorktreePruneOptions {
+        #[allow(clippy::unnecessary_cast, reason = "u32 unless compiling for msvc target env")]
         if on {
             self.raw.flags |= flag as u32;
         } else {


### PR DESCRIPTION
In a lot of places, the lint is triggered when casting a constant from the libgit2 bindings that is created (in libgit2-sys) via `git_enum!`. That macro will use i32 when `#[cfg(target_env = "msvc")]`, and u32 otherwise, meaning that a number of the casts that clippy flags as "unnecessary" are indeed necessary. In those cases, use `#[allow]` with a reason.

Similarly, clippy also lints against casting of `c_int` and `c_uint` to `i32` and `u32` - while those are usually the same types, the libc documentation makes it clear that they are not always the same. In those cases too, use `#[allow]` with a reason.

The only libc-provided type with a consistent rust type is that `size_t` is always the same as `usize` - fix the places that clippy identified where that conversion is unneeded. Other fixes include casts when the underlying type is explicitly set in the libgit2 bindings to be a specific rust type, or when converting mutable pointers to the same type they already are.