### PR TITLE
Fix changelogs and html_root_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.21.0 - TBD
+## 0.21.0 - 2026-05-18
 [0.20.4...main](https://github.com/rust-lang/git2-rs/compare/git2-0.20.4...main)
 
 ### Added

--- a/git2-curl/CHANGELOG.md
+++ b/git2-curl/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.22.0 - 2026-05-18
+[0.21.0...0.22.0](https://github.com/rust-lang/git2-rs/compare/git2-curl-0.21.0...git2-curl-0.22.0)
+
+- Updated to [git2 0.21.0](../CHANGELOG.md#0210---2026-05-18)
+
 ## 0.21.0 - 2025-01-04
 [0.20.0...0.21.0](https://github.com/rust-lang/git2-rs/compare/git2-curl-0.20.0...git2-curl-0.21.0)
 

--- a/git2-curl/src/lib.rs
+++ b/git2-curl/src/lib.rs
@@ -15,7 +15,7 @@
 //! > **NOTE**: At this time this crate likely does not support a `git push`
 //! >           operation, only clones.
 
-#![doc(html_root_url = "https://docs.rs/git2-curl/0.21")]
+#![doc(html_root_url = "https://docs.rs/git2-curl/0.22")]
 #![deny(missing_docs)]
 #![warn(rust_2018_idioms)]
 #![cfg_attr(test, deny(warnings))]


### PR DESCRIPTION
There were a few steps missed during the 0.21 release for updating various items.