### PR TITLE
[Clippy] Add clippy to CI, allow current violations at a module level

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,34 @@ jobs:
     - run: cargo run -p systest
     - run: cargo run -p systest --features unstable-sha256
 
+  clippy:
+    name: Clippy
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        build: [stable, beta, windows]
+        include:
+          - build: stable
+            os: ubuntu-latest
+            rust: stable
+          - build: beta
+            os: ubuntu-latest
+            rust: beta
+          - build: windows
+            os: windows-2022
+            rust: stable
+    steps:
+    - uses: actions/checkout@master
+      with:
+        submodules: true
+    - name: Install Rust (rustup)
+      run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
+      shell: bash
+    - name: Install Clippy (rustup)
+      run: rustup component add clippy
+    - run: cargo clippy --all-targets --all-features -- -Dwarnings
+
   rustfmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/examples/add.rs
+++ b/examples/add.rs
@@ -14,6 +14,7 @@
 
 #![deny(warnings)]
 #![allow(trivial_casts)]
+#![allow(clippy::needless_borrows_for_generic_args)]
 
 use clap::Parser;
 use git2::Repository;

--- a/examples/clone.rs
+++ b/examples/clone.rs
@@ -13,6 +13,8 @@
  */
 
 #![deny(warnings)]
+#![allow(clippy::explicit_auto_deref)]
+#![allow(clippy::manual_checked_ops)]
 
 use clap::Parser;
 use git2::build::{CheckoutBuilder, RepoBuilder};

--- a/examples/diff.rs
+++ b/examples/diff.rs
@@ -13,6 +13,9 @@
  */
 
 #![deny(warnings)]
+#![allow(clippy::explicit_auto_deref)]
+#![allow(clippy::needless_borrows_for_generic_args)]
+#![allow(clippy::redundant_closure)]
 
 use clap::Parser;
 use git2::{Blob, Diff, DiffOptions, Error, Object, ObjectType, Oid, Repository};

--- a/examples/init.rs
+++ b/examples/init.rs
@@ -13,6 +13,7 @@
  */
 
 #![deny(warnings)]
+#![allow(clippy::manual_strip)]
 
 use clap::Parser;
 use git2::ObjectFormat;

--- a/examples/log.rs
+++ b/examples/log.rs
@@ -13,6 +13,8 @@
  */
 
 #![deny(warnings)]
+#![allow(clippy::manual_strip)]
+#![allow(clippy::needless_borrowed_reference)]
 
 use clap::Parser;
 use git2::{Commit, DiffOptions, ObjectType, Repository, Signature, Time};

--- a/examples/pull.rs
+++ b/examples/pull.rs
@@ -12,6 +12,9 @@
  * <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
 
+#![allow(clippy::needless_borrow)]
+#![allow(clippy::needless_question_mark)]
+
 use clap::Parser;
 use git2::Repository;
 use std::io::{self, Write};

--- a/examples/rev-list.rs
+++ b/examples/rev-list.rs
@@ -14,6 +14,7 @@
  */
 
 #![deny(warnings)]
+#![allow(clippy::manual_strip)]
 
 use clap::Parser;
 use git2::{Error, Oid, Repository, Revwalk};

--- a/examples/tag.rs
+++ b/examples/tag.rs
@@ -13,6 +13,7 @@
  */
 
 #![deny(warnings)]
+#![allow(clippy::explicit_auto_deref)]
 
 use clap::Parser;
 use git2::{Commit, Error, Repository, Tag};

--- a/libgit2-sys/build.rs
+++ b/libgit2-sys/build.rs
@@ -1,3 +1,6 @@
+#![allow(clippy::needless_borrows_for_generic_args)]
+#![allow(clippy::unnecessary_map_or)]
+
 use std::env;
 use std::fs;
 use std::io;

--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -1,5 +1,6 @@
 #![doc(html_root_url = "https://docs.rs/libgit2-sys/0.18")]
 #![allow(non_camel_case_types, unused_extern_crates)]
+#![allow(clippy::legacy_numeric_constants)]
 
 // This is required to link libz when libssh2-sys is not included.
 extern crate libz_sys as libz;

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -1,6 +1,9 @@
 //! git_apply support
 //! see original: <https://github.com/libgit2/libgit2/blob/master/include/git2/apply.h>
 
+#![allow(clippy::missing_safety_doc)]
+#![allow(clippy::new_without_default)]
+
 use crate::{panic, raw, util::Binding, DiffDelta, DiffHunk};
 use libc::c_int;
 use std::{ffi::c_void, mem};
@@ -149,6 +152,7 @@ impl<'cb> ApplyOptions<'cb> {
 }
 
 #[cfg(test)]
+#[allow(clippy::needless_borrows_for_generic_args)]
 mod tests {
     use super::*;
     use std::{fs::File, io::Write, path::Path};

--- a/src/blame.rs
+++ b/src/blame.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::redundant_closure)]
+
 use crate::util::{self, Binding};
 use crate::{raw, signature, Error, Oid, Repository, Signature};
 use libc::c_char;
@@ -388,6 +390,9 @@ impl<'blame> FusedIterator for BlameIter<'blame> {}
 impl<'blame> ExactSizeIterator for BlameIter<'blame> {}
 
 #[cfg(test)]
+#[allow(clippy::bool_assert_comparison)]
+#[allow(clippy::needless_borrow)]
+#[allow(clippy::needless_borrows_for_generic_args)]
 mod tests {
     use std::fs::{self, File};
     use std::path::Path;

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::io_other_error)]
+
 use std::io;
 use std::marker;
 use std::mem;

--- a/src/branch.rs
+++ b/src/branch.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::missing_safety_doc)]
+
 use std::ffi::CString;
 use std::marker;
 use std::ptr;

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::explicit_auto_deref)]
+
 use std::ops::{Deref, DerefMut};
 use std::ptr;
 use std::slice;

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,5 +1,8 @@
 //! Builder-pattern objects for configuration various git operations.
 
+#![allow(clippy::manual_non_exhaustive)]
+#![allow(clippy::missing_safety_doc)]
+
 use libc::{c_char, c_int, c_uint, c_void, size_t};
 use std::ffi::{CStr, CString};
 use std::mem;
@@ -767,6 +770,8 @@ impl TreeUpdateBuilder {
 }
 
 #[cfg(test)]
+#[allow(clippy::needless_borrow)]
+#[allow(clippy::needless_borrows_for_generic_args)]
 mod tests {
     use super::{CheckoutBuilder, RepoBuilder, TreeUpdateBuilder};
     use crate::{CheckoutNotificationType, FileMode, Repository};

--- a/src/call.rs
+++ b/src/call.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::needless_lifetimes)]
 #![macro_use]
 
 use crate::Error;

--- a/src/cherrypick.rs
+++ b/src/cherrypick.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::new_without_default)]
+
 use std::mem;
 
 use crate::build::CheckoutBuilder;

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::redundant_closure)]
+
 use std::iter::FusedIterator;
 use std::marker;
 use std::mem;
@@ -413,6 +415,8 @@ impl<'repo> Drop for Commit<'repo> {
 }
 
 #[cfg(test)]
+#[allow(clippy::bool_assert_comparison)]
+#[allow(clippy::let_and_return)]
 mod tests {
     #[test]
     fn smoke() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::should_implement_trait)]
+
 use std::ffi::CString;
 use std::marker;
 use std::path::{Path, PathBuf};
@@ -639,6 +641,7 @@ impl<'cfg> Drop for ConfigEntry<'cfg> {
 }
 
 #[cfg(test)]
+#[allow(clippy::bool_assert_comparison)]
 mod tests {
     use std::fs::File;
     use tempfile::TempDir;

--- a/src/cred.rs
+++ b/src/cred.rs
@@ -1,3 +1,10 @@
+#![allow(clippy::manual_strip)]
+#![allow(clippy::match_result_ok)]
+#![allow(clippy::missing_safety_doc)]
+#![allow(clippy::needless_borrowed_reference)]
+#![allow(clippy::needless_borrows_for_generic_args)]
+#![allow(clippy::should_implement_trait)]
+
 #[cfg(feature = "cred")]
 use log::{debug, trace};
 use std::ffi::CString;
@@ -495,6 +502,8 @@ impl CredentialHelper {
 
 #[cfg(test)]
 #[cfg(feature = "cred")]
+#[allow(clippy::unused_io_amount)]
+#[allow(clippy::useless_conversion)]
 mod test {
     use std::env;
     use std::fs::File;

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,3 +1,7 @@
+#![allow(clippy::empty_docs)]
+#![allow(clippy::missing_safety_doc)]
+#![allow(clippy::new_without_default)]
+
 use libc::{c_char, c_int, c_void, size_t};
 use std::ffi::CString;
 use std::iter::FusedIterator;
@@ -1588,6 +1592,9 @@ impl DiffPatchidOptions {
 }
 
 #[cfg(test)]
+#[allow(clippy::assign_op_pattern)]
+#[allow(clippy::needless_borrows_for_generic_args)]
+#[allow(clippy::while_let_on_iterator)]
 mod tests {
     #[cfg(feature = "unstable-sha256")]
     use crate::Diff;

--- a/src/email.rs
+++ b/src/email.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::too_many_arguments)]
+
 use std::ffi::CString;
 use std::{mem, ptr};
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::should_implement_trait)]
+
 use libc::c_int;
 use std::env::JoinPathsError;
 use std::error;

--- a/src/index.rs
+++ b/src/index.rs
@@ -882,6 +882,8 @@ impl Binding for IndexEntry {
 }
 
 #[cfg(test)]
+#[allow(clippy::needless_borrow)]
+#[allow(clippy::needless_borrows_for_generic_args)]
 mod tests {
     use std::fs::{self, File};
     use std::path::Path;

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::io_other_error)]
+
 use std::ffi::CStr;
 use std::path::Path;
 use std::{io, marker, mem, ptr};
@@ -242,6 +244,7 @@ impl Drop for Indexer<'_> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unused_io_amount)]
 mod tests {
     use crate::{Buf, Indexer};
     use std::io::prelude::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,9 @@
 #![deny(missing_docs)]
 #![warn(rust_2018_idioms)]
 #![cfg_attr(test, deny(warnings))]
+#![allow(clippy::needless_lifetimes)]
+#![allow(clippy::should_implement_trait)]
+#![allow(clippy::unnecessary_cast)]
 
 use bitflags::bitflags;
 use libgit2_sys as raw;

--- a/src/mailmap.rs
+++ b/src/mailmap.rs
@@ -93,6 +93,7 @@ impl Mailmap {
 }
 
 #[cfg(test)]
+#[allow(clippy::needless_borrow)]
 mod tests {
     use super::*;
 

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -1,3 +1,6 @@
+#![allow(clippy::missing_safety_doc)]
+#![allow(clippy::redundant_closure)]
+
 use libc::{c_char, c_uint, c_ushort, size_t};
 use std::ffi::CString;
 use std::marker;

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,3 +1,7 @@
+#![allow(clippy::len_without_is_empty)]
+#![allow(clippy::needless_borrow)]
+#![allow(clippy::redundant_closure)]
+
 use core::ops::Range;
 use std::ffi::CStr;
 use std::ffi::CString;
@@ -237,6 +241,7 @@ fn to_bytes_tuple(trailers: &MessageTrailers, index: usize) -> (&[u8], &[u8]) {
 }
 
 #[cfg(test)]
+#[allow(clippy::char_lit_as_u8)]
 mod tests {
 
     #[test]

--- a/src/odb.rs
+++ b/src/odb.rs
@@ -1,3 +1,8 @@
+#![allow(clippy::io_other_error)]
+#![allow(clippy::len_without_is_empty)]
+#![allow(clippy::single_match)]
+#![allow(clippy::should_implement_trait)]
+
 use std::io;
 use std::marker;
 use std::ptr;
@@ -579,6 +584,8 @@ pub(crate) extern "C" fn write_pack_progress_cb(
 }
 
 #[cfg(test)]
+#[allow(clippy::bool_assert_comparison)]
+#[allow(clippy::unused_io_amount)]
 mod tests {
     use crate::{Buf, ObjectType, Oid, Repository};
     use std::io::prelude::*;

--- a/src/oid_array.rs
+++ b/src/oid_array.rs
@@ -1,5 +1,7 @@
 //! Bindings to libgit2's raw `git_oidarray` type
 
+#![allow(clippy::extra_unused_lifetimes)]
+
 use std::ops::Deref;
 
 use crate::oid::Oid;

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -1,5 +1,7 @@
 //! Bindings to libgit2's git_libgit2_opts function.
 
+#![allow(clippy::missing_safety_doc)]
+
 use std::ffi::CString;
 use std::ptr;
 

--- a/src/packbuilder.rs
+++ b/src/packbuilder.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::redundant_closure)]
+
 use libc::{c_int, c_uint, c_void, size_t};
 use std::marker;
 use std::path::Path;
@@ -296,6 +298,7 @@ extern "C" fn progress_c(
 }
 
 #[cfg(test)]
+#[allow(clippy::bool_assert_comparison)]
 mod tests {
     use crate::Buf;
 

--- a/src/pathspec.rs
+++ b/src/pathspec.rs
@@ -337,6 +337,7 @@ impl<'list> FusedIterator for PathspecFailedEntries<'list> {}
 impl<'list> ExactSizeIterator for PathspecFailedEntries<'list> {}
 
 #[cfg(test)]
+#[allow(clippy::needless_borrows_for_generic_args)]
 mod tests {
     use super::Pathspec;
     use crate::PathspecFlags;

--- a/src/rebase.rs
+++ b/src/rebase.rs
@@ -1,3 +1,7 @@
+#![allow(clippy::len_without_is_empty)]
+#![allow(clippy::needless_option_take)]
+#![allow(clippy::redundant_closure)]
+
 use std::ffi::CString;
 use std::{marker, mem, ptr, str};
 

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::redundant_closure)]
+
 use std::cmp::Ordering;
 use std::ffi::CString;
 use std::marker;
@@ -517,6 +519,7 @@ impl<'repo, 'references> Iterator for ReferenceNames<'repo, 'references> {
 }
 
 #[cfg(test)]
+#[allow(clippy::octal_escapes)]
 mod tests {
     use crate::{ObjectType, Reference, ReferenceType};
 

--- a/src/reflog.rs
+++ b/src/reflog.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::redundant_closure)]
+
 use libc::size_t;
 use std::iter::FusedIterator;
 use std::marker;

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -1,3 +1,8 @@
+#![allow(clippy::derivable_impls)]
+#![allow(clippy::empty_line_after_doc_comments)]
+#![allow(clippy::redundant_closure)]
+#![allow(clippy::unwrap_or_default)]
+
 use raw::git_strarray;
 use std::iter::FusedIterator;
 use std::marker;
@@ -825,6 +830,8 @@ impl RemoteRedirect {
 }
 
 #[cfg(test)]
+#[allow(clippy::needless_borrow)]
+#[allow(clippy::octal_escapes)]
 mod tests {
     use crate::{AutotagOption, PushOptions, RemoteUpdateFlags};
     use crate::{Direction, FetchOptions, ObjectFormat, Remote, RemoteCallbacks, Repository};

--- a/src/remote_callbacks.rs
+++ b/src/remote_callbacks.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::doc_overindented_list_items)]
+
 use libc::{c_char, c_int, c_uint, c_void, size_t};
 use std::ffi::CStr;
 use std::mem;

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1,3 +1,11 @@
+#![allow(clippy::explicit_auto_deref)]
+#![allow(clippy::missing_safety_doc)]
+#![allow(clippy::needless_borrow)]
+#![allow(clippy::new_without_default)]
+#![allow(clippy::redundant_closure)]
+#![allow(clippy::too_many_arguments)]
+#![allow(clippy::zero_ptr)]
+
 use libc::{c_char, c_int, c_uint, c_void, size_t};
 use std::env;
 use std::ffi::{CStr, CString, OsStr};
@@ -3654,6 +3662,9 @@ impl RepositoryInitOptions {
 }
 
 #[cfg(test)]
+#[allow(clippy::assertions_on_constants)]
+#[allow(clippy::bool_assert_comparison)]
+#[allow(clippy::needless_borrows_for_generic_args)]
 mod tests {
     use crate::build::CheckoutBuilder;
     use crate::AttrCheckFlags;

--- a/src/revert.rs
+++ b/src/revert.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::new_without_default)]
+
 use std::mem;
 
 use crate::build::CheckoutBuilder;

--- a/src/stash.rs
+++ b/src/stash.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::missing_safety_doc)]
+
 use crate::build::CheckoutBuilder;
 use crate::util::{self, Binding};
 use crate::{panic, raw, IntoCString, Oid, Signature, StashApplyProgress, StashFlags};
@@ -210,6 +212,7 @@ extern "C" fn stash_apply_progress_cb(
 }
 
 #[cfg(test)]
+#[allow(clippy::needless_borrow)]
 mod tests {
     use crate::stash::{StashApplyOptions, StashSaveOptions};
     use crate::test::repo_init;

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::missing_safety_doc)]
+
 use libc::{c_char, c_uint, size_t};
 use std::ffi::CString;
 use std::iter::FusedIterator;
@@ -364,6 +366,7 @@ impl<'statuses> Binding for StatusEntry<'statuses> {
 }
 
 #[cfg(test)]
+#[allow(clippy::needless_borrows_for_generic_args)]
 mod tests {
     use super::StatusOptions;
     use std::fs::File;

--- a/src/string_array.rs
+++ b/src/string_array.rs
@@ -1,5 +1,7 @@
 //! Bindings to libgit2's raw `git_strarray` type
 
+#![allow(clippy::redundant_closure)]
+
 use std::iter::FusedIterator;
 use std::ops::Range;
 use std::str;

--- a/src/submodule.rs
+++ b/src/submodule.rs
@@ -1,3 +1,7 @@
+#![allow(clippy::empty_line_after_doc_comments)]
+#![allow(clippy::let_and_return)]
+#![allow(clippy::redundant_closure)]
+
 use std::marker;
 use std::mem;
 use std::os::raw::c_int;
@@ -329,6 +333,8 @@ impl<'cb> Default for SubmoduleUpdateOptions<'cb> {
 }
 
 #[cfg(test)]
+#[allow(clippy::needless_borrows_for_generic_args)]
+#[allow(clippy::unnecessary_to_owned)]
 mod tests {
     use std::fs;
     use std::path::Path;

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -1,3 +1,6 @@
+#![allow(clippy::from_over_into)]
+#![allow(clippy::redundant_closure)]
+
 use std::ffi::CString;
 use std::marker;
 use std::mem;
@@ -153,6 +156,8 @@ impl<'repo> Drop for Tag<'repo> {
 }
 
 #[cfg(test)]
+#[allow(clippy::bool_assert_comparison)]
+#[allow(clippy::octal_escapes)]
 mod tests {
     use crate::Tag;
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::needless_borrows_for_generic_args)]
+
 use std::fs::File;
 use std::io;
 use std::path::{Path, PathBuf};

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,5 +1,8 @@
 //! Interfaces for adding custom transports to libgit2
 
+#![allow(clippy::missing_safety_doc)]
+#![allow(clippy::missing_transmute_annotations)]
+
 use libc::{c_char, c_int, c_uint, c_void, size_t};
 use std::ffi::{CStr, CString};
 use std::io;
@@ -369,6 +372,7 @@ extern "C" fn stream_free(stream: *mut raw::git_smart_subtransport_stream) {
 }
 
 #[cfg(test)]
+#[allow(clippy::needless_borrow)]
 mod tests {
     use super::*;
     use crate::{ErrorClass, ErrorCode};

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,3 +1,6 @@
+#![allow(clippy::from_over_into)]
+#![allow(clippy::manual_unwrap_or)]
+
 use libc::{c_char, c_int, c_void};
 use std::cmp::Ordering;
 use std::ffi::{CStr, CString};
@@ -401,6 +404,9 @@ impl<'tree> FusedIterator for TreeIter<'tree> {}
 impl<'tree> ExactSizeIterator for TreeIter<'tree> {}
 
 #[cfg(test)]
+#[allow(clippy::needless_borrows_for_generic_args)]
+#[allow(clippy::redundant_field_names)]
+#[allow(clippy::single_match)]
 mod tests {
     use super::{TreeWalkMode, TreeWalkResult};
     use crate::{Object, ObjectType, Repository, Tree, TreeEntry};

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,8 @@
+#![allow(clippy::missing_safety_doc)]
+#![allow(clippy::needless_lifetimes)]
+#![allow(clippy::needless_range_loop)]
+#![allow(clippy::needless_return)]
+
 use libc::{c_char, c_int, size_t};
 use std::cmp::Ordering;
 use std::ffi::{CString, OsStr, OsString};

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -1,3 +1,6 @@
+#![allow(clippy::new_without_default)]
+#![allow(clippy::redundant_closure)]
+
 use crate::buf::Buf;
 use crate::reference::Reference;
 use crate::repo::Repository;

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -1,4 +1,8 @@
 //! Tests for some end-to-end logic about certain operations
+
+#![allow(clippy::needless_borrow)]
+#![allow(unused_variables)]
+
 use git2::{
     Error, ReferenceType, Repository, RepositoryInitOptions, StashFlags, Status, StatusOptions,
 };

--- a/tests/global_state.rs
+++ b/tests/global_state.rs
@@ -1,6 +1,8 @@
 //! Test for some global state set up by libgit2's `git_libgit2_init` function
 //! that need to be synchronized within a single process.
 
+#![allow(clippy::needless_borrows_for_generic_args)]
+
 use git2::opts;
 use git2::{ConfigLevel, IntoCString};
 


### PR DESCRIPTION
Add clippy to CI so that future changes do not increase the number of violations. The existing violations are allowlisted on a module level (i.e. at the top of files with inner attributes, or above the start of nested inline test modules with outer attributes).

CI runs clippy on both Window and Linux because some lints may fire on one but not the other; see, e.g. #1238.

Existing violations will be addressed in subsequent pull requests.