### PR TITLE
Fix unsoundness in git2::MergeFileResult::content() for empty content

### DIFF
--- a/src/merge.rs
+++ b/src/merge.rs
@@ -379,7 +379,18 @@ impl MergeFileResult {
 
     /// The contents of the merge.
     pub fn content(&self) -> &[u8] {
-        unsafe { std::slice::from_raw_parts(self.raw.ptr as *const u8, self.raw.len as usize) }
+        // If the pointer is null, slice::from_raw_parts() cannot be used
+        let ptr = self.raw.ptr as *const u8;
+        let len = self.raw.len as usize;
+        if ptr.is_null() {
+            assert_eq!(
+                0, len,
+                "git_merge_file_result has a null pointer for data of len {}",
+                len
+            );
+            return &[];
+        }
+        unsafe { std::slice::from_raw_parts(ptr, len) }
     }
 }
 
@@ -573,7 +584,7 @@ bar
         assert_eq!(Some("file.txt".as_bytes()), result.path_bytes());
         assert_eq!(33188, result.mode());
 
-        // This triggers unsoundness
+        // This triggered unsoundness
         let expected: &[u8] = &[];
         assert_eq!(expected, result.content());
     }

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -553,4 +553,28 @@ bar
 ",
         );
     }
+
+    #[test]
+    fn test_merge_no_content() {
+        // Trigger calls to git2::init(), otherwise the use of libgit2 stuff
+        // fails, e.g. the unwrapping below reports
+        // `called `Result::unwrap()` on an `Err` value: Error { code: -1, klass: 0, message: "no error" }`
+        crate::init();
+
+        // Create a merge result with empty content
+        let base = MergeFileInput::new();
+        let ours = MergeFileInput::new();
+        let theirs = MergeFileInput::new();
+        let result = crate::merge_file(&base, &ours, &theirs, None).unwrap();
+
+        // These are all okay
+        assert!(result.is_automergeable());
+        assert_eq!(Ok(Some("file.txt")), result.path());
+        assert_eq!(Some("file.txt".as_bytes()), result.path_bytes());
+        assert_eq!(33188, result.mode());
+
+        // This triggers unsoundness
+        let expected: &[u8] = &[];
+        assert_eq!(expected, result.content());
+    }
 }


### PR DESCRIPTION
Fixes #1281