### PR TITLE
Fix header path for experimental.h in build.rs

### DIFF
--- a/libgit2-sys/build.rs
+++ b/libgit2-sys/build.rs
@@ -29,7 +29,7 @@ fn try_system_libgit2(
         {
             Ok(lib) => {
                 let sha256_constant_in_header = lib.include_paths.iter().any(|path| {
-                    let header = path.join("git2/experimental.h");
+                    let header = path.join("git2-experimental/experimental.h");
                     let contents = match std::fs::read_to_string(header) {
                         Ok(s) => s,
                         Err(_) => return false,


### PR DESCRIPTION
Should Close https://github.com/rust-lang/git2-rs/issues/1275

When libgit2-1.9.4 is built with `-DEXPERIMENTAL_SHA256=ON` it sets the header files in the following directory
```
$ ls /usr/include/git2-experimental
annotated_commit.h  clone.h               email.h         merge.h        patch.h       reset.h      sys/
apply.h             commit.h              errors.h        message.h      pathspec.h    revert.h     tag.h
attr.h              common.h              experimental.h  net.h          proxy.h       revparse.h   trace.h
blame.h             config.h              filter.h        notes.h        rebase.h      revwalk.h    transaction.h
blob.h              cred_helpers.h        global.h        object.h       refdb.h       signature.h  transport.h
branch.h            credential.h          graph.h         odb.h          reflog.h      stash.h      tree.h
buffer.h            credential_helpers.h  ignore.h        odb_backend.h  refs.h        status.h     types.h
cert.h              deprecated.h          index.h         oid.h          refspec.h     stdint.h     version.h
checkout.h          describe.h            indexer.h       oidarray.h     remote.h      strarray.h   worktree.h
cherrypick.h        diff.h                mailmap.h       pack.h         repository.h  submodule.h
```

relevant libgit2
https://github.com/libgit2/libgit2/blob/main/cmake/ExperimentalFeatures.cmake#L21-L23
https://github.com/libgit2/libgit2/blob/main/src/libgit2/CMakeLists.txt#L122