### PR TITLE
[Clippy] Fix clippy issues in test code

### DIFF
--- a/src/apply.rs
+++ b/src/apply.rs
@@ -161,7 +161,6 @@ impl<'cb> Default for ApplyOptions<'cb> {
 }
 
 #[cfg(test)]
-#[allow(clippy::needless_borrows_for_generic_args)]
 mod tests {
     use super::*;
     use std::{fs::File, io::Write, path::Path};
@@ -193,11 +192,11 @@ mod tests {
         let file_path = Path::new("foo.txt");
         let (td, repo) = crate::test::repo_init();
         // create new file
-        t!(t!(File::create(&td.path().join(file_path))).write_all(b"bar"));
+        t!(t!(File::create(td.path().join(file_path))).write_all(b"bar"));
         // stage the new file
         t!(t!(repo.index()).add_path(file_path));
         // now change workdir version
-        t!(t!(File::create(&td.path().join(file_path))).write_all(b"foo\nbar"));
+        t!(t!(File::create(td.path().join(file_path))).write_all(b"foo\nbar"));
 
         let diff = t!(repo.diff_index_to_workdir(None, None));
         assert_eq!(diff.deltas().len(), 1);

--- a/src/blame.rs
+++ b/src/blame.rs
@@ -404,7 +404,6 @@ impl<'blame> FusedIterator for BlameIter<'blame> {}
 impl<'blame> ExactSizeIterator for BlameIter<'blame> {}
 
 #[cfg(test)]
-#[allow(clippy::bool_assert_comparison)]
 #[allow(clippy::needless_borrow)]
 #[allow(clippy::needless_borrows_for_generic_args)]
 mod tests {
@@ -539,7 +538,7 @@ mod tests {
             assert_eq!(1, hunk.final_start_line());
             assert_eq!(0, hunk.orig_start_line());
             assert_eq!(Some(Path::new("README.md")), hunk.path());
-            assert_eq!(false, hunk.is_boundary());
+            assert!(!hunk.is_boundary());
             assert_eq!(1, hunk.lines_in_hunk());
             assert_eq!(Ok(None), hunk.summary());
             assert_eq!(None, hunk.summary_bytes());

--- a/src/blame.rs
+++ b/src/blame.rs
@@ -404,7 +404,6 @@ impl<'blame> FusedIterator for BlameIter<'blame> {}
 impl<'blame> ExactSizeIterator for BlameIter<'blame> {}
 
 #[cfg(test)]
-#[allow(clippy::needless_borrow)]
 #[allow(clippy::needless_borrows_for_generic_args)]
 mod tests {
     use std::fs::{self, File};
@@ -490,7 +489,7 @@ mod tests {
             fs::write(&path.join("README.md"), "Testing").unwrap();
 
             let mut index = repo.index().unwrap();
-            index.add_path(&Path::new("README.md")).unwrap();
+            index.add_path(Path::new("README.md")).unwrap();
             index.write().unwrap();
 
             let id = index.write_tree().unwrap();
@@ -500,7 +499,7 @@ mod tests {
                 .unwrap();
         }
 
-        let blame = repo.blame_file(&Path::new("README.md"), None).unwrap();
+        let blame = repo.blame_file(Path::new("README.md"), None).unwrap();
         // This hunk is safe to use
         let hunk = blame.get_index(0).unwrap();
 
@@ -575,7 +574,7 @@ mod tests {
             fs::write(&path.join("README.md"), "Testing").unwrap();
 
             let mut index = repo.index().unwrap();
-            index.add_path(&Path::new("README.md")).unwrap();
+            index.add_path(Path::new("README.md")).unwrap();
             index.write().unwrap();
 
             let id = index.write_tree().unwrap();
@@ -585,7 +584,7 @@ mod tests {
                 .unwrap();
         }
 
-        let blame = repo.blame_file(&Path::new("README.md"), None).unwrap();
+        let blame = repo.blame_file(Path::new("README.md"), None).unwrap();
         // Cannot use unwrap_err() because Blame does not implement Debug
         let result = match blame.blame_buffer(b"") {
             Ok(_) => panic!("Expected an error"),

--- a/src/blame.rs
+++ b/src/blame.rs
@@ -404,7 +404,6 @@ impl<'blame> FusedIterator for BlameIter<'blame> {}
 impl<'blame> ExactSizeIterator for BlameIter<'blame> {}
 
 #[cfg(test)]
-#[allow(clippy::needless_borrows_for_generic_args)]
 mod tests {
     use std::fs::{self, File};
     use std::path::Path;
@@ -415,8 +414,8 @@ mod tests {
         let mut index = repo.index().unwrap();
 
         let root = repo.workdir().unwrap();
-        fs::create_dir(&root.join("foo")).unwrap();
-        File::create(&root.join("foo/bar")).unwrap();
+        fs::create_dir(root.join("foo")).unwrap();
+        File::create(root.join("foo/bar")).unwrap();
         index.add_path(Path::new("foo/bar")).unwrap();
 
         let committer_sig = crate::Signature::now("FizzBuzz", "bar@example.com")
@@ -486,7 +485,7 @@ mod tests {
             config.set_str("user.name", "name").unwrap();
             config.set_str("user.email", "email").unwrap();
 
-            fs::write(&path.join("README.md"), "Testing").unwrap();
+            fs::write(path.join("README.md"), "Testing").unwrap();
 
             let mut index = repo.index().unwrap();
             index.add_path(Path::new("README.md")).unwrap();
@@ -571,7 +570,7 @@ mod tests {
             config.set_str("user.name", "name").unwrap();
             config.set_str("user.email", "email").unwrap();
 
-            fs::write(&path.join("README.md"), "Testing").unwrap();
+            fs::write(path.join("README.md"), "Testing").unwrap();
 
             let mut index = repo.index().unwrap();
             index.add_path(Path::new("README.md")).unwrap();

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -76,11 +76,10 @@ impl Drop for Buf {
 }
 
 #[test]
-#[allow(clippy::explicit_auto_deref)]
 fn empty_buf() {
     let mut buf = Buf::new();
-    let x: &[u8] = &*buf;
+    let x: &[u8] = &buf;
     assert_eq!(x.len(), 0);
-    let x: &mut [u8] = &mut *buf;
+    let x: &mut [u8] = &mut buf;
     assert_eq!(x.len(), 0);
 }

--- a/src/build.rs
+++ b/src/build.rs
@@ -771,7 +771,6 @@ impl TreeUpdateBuilder {
 }
 
 #[cfg(test)]
-#[allow(clippy::needless_borrows_for_generic_args)]
 mod tests {
     use super::{CheckoutBuilder, RepoBuilder, TreeUpdateBuilder};
     use crate::{CheckoutNotificationType, FileMode, Repository};
@@ -788,7 +787,7 @@ mod tests {
     #[test]
     fn smoke2() {
         let td = TempDir::new().unwrap();
-        Repository::init_bare(&td.path().join("bare")).unwrap();
+        Repository::init_bare(td.path().join("bare")).unwrap();
         let url = if cfg!(unix) {
             format!("file://{}/bare", td.path().display())
         } else {
@@ -830,7 +829,7 @@ mod tests {
         {
             let mut opts = crate::RepositoryInitOptions::new();
             opts.initial_head("main");
-            let repo = Repository::init_opts(&td.path(), &opts).unwrap();
+            let repo = Repository::init_opts(td.path(), &opts).unwrap();
 
             let mut config = repo.config().unwrap();
             config.set_str("user.name", "name").unwrap();
@@ -849,7 +848,7 @@ mod tests {
                 .unwrap();
         }
 
-        let repo = Repository::open_bare(&td.path().join(".git")).unwrap();
+        let repo = Repository::open_bare(td.path().join(".git")).unwrap();
         let tree = repo
             .revparse_single("main")
             .unwrap()

--- a/src/build.rs
+++ b/src/build.rs
@@ -771,7 +771,6 @@ impl TreeUpdateBuilder {
 }
 
 #[cfg(test)]
-#[allow(clippy::needless_borrow)]
 #[allow(clippy::needless_borrows_for_generic_args)]
 mod tests {
     use super::{CheckoutBuilder, RepoBuilder, TreeUpdateBuilder};
@@ -841,7 +840,7 @@ mod tests {
             let p = Path::new(td.path()).join("file");
             println!("using path {:?}", p);
             fs::File::create(&p).unwrap();
-            index.add_path(&Path::new("file")).unwrap();
+            index.add_path(Path::new("file")).unwrap();
             let id = index.write_tree().unwrap();
 
             let tree = repo.find_tree(id).unwrap();
@@ -852,7 +851,7 @@ mod tests {
 
         let repo = Repository::open_bare(&td.path().join(".git")).unwrap();
         let tree = repo
-            .revparse_single(&"main")
+            .revparse_single("main")
             .unwrap()
             .peel_to_tree()
             .unwrap();
@@ -860,7 +859,7 @@ mod tests {
         index.read_tree(&tree).unwrap();
 
         let mut checkout_opts = CheckoutBuilder::new();
-        checkout_opts.target_dir(&cd.path());
+        checkout_opts.target_dir(cd.path());
         checkout_opts.notify_on(CheckoutNotificationType::all());
         checkout_opts.notify(|_notif, _path, baseline, target, workdir| {
             assert!(baseline.is_none());

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -413,7 +413,6 @@ impl<'repo> Drop for Commit<'repo> {
 }
 
 #[cfg(test)]
-#[allow(clippy::bool_assert_comparison)]
 #[allow(clippy::let_and_return)]
 mod tests {
     #[test]

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -413,7 +413,6 @@ impl<'repo> Drop for Commit<'repo> {
 }
 
 #[cfg(test)]
-#[allow(clippy::let_and_return)]
 mod tests {
     #[test]
     fn smoke() {
@@ -492,8 +491,7 @@ mod tests {
         let tree_header_bytes = commit.header_field_bytes("tree").unwrap();
         let tree_oid = {
             let str = tree_header_bytes.as_str().unwrap();
-            let oid = crate::Oid::from_str_ext(str, repo.object_format()).unwrap();
-            oid
+            crate::Oid::from_str_ext(str, repo.object_format()).unwrap()
         };
         assert_eq!(tree_oid, commit.tree_id());
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -640,7 +640,6 @@ impl<'cfg> Drop for ConfigEntry<'cfg> {
 }
 
 #[cfg(test)]
-#[allow(clippy::bool_assert_comparison)]
 mod tests {
     use std::fs::File;
     use tempfile::TempDir;
@@ -671,7 +670,7 @@ mod tests {
         drop(cfg);
 
         let cfg = Config::open(&path).unwrap().snapshot().unwrap();
-        assert_eq!(cfg.get_bool("foo.k1").unwrap(), true);
+        assert!(cfg.get_bool("foo.k1").unwrap());
         assert_eq!(cfg.get_i32("foo.k2").unwrap(), 1);
         assert_eq!(cfg.get_i64("foo.k3").unwrap(), 2);
         assert_eq!(cfg.get_str("foo.k4").unwrap(), "bar");
@@ -738,17 +737,17 @@ mod tests {
 
     #[test]
     fn parse() {
-        assert_eq!(Config::parse_bool("").unwrap(), false);
-        assert_eq!(Config::parse_bool("false").unwrap(), false);
-        assert_eq!(Config::parse_bool("no").unwrap(), false);
-        assert_eq!(Config::parse_bool("off").unwrap(), false);
-        assert_eq!(Config::parse_bool("0").unwrap(), false);
+        assert!(!Config::parse_bool("").unwrap());
+        assert!(!Config::parse_bool("false").unwrap());
+        assert!(!Config::parse_bool("no").unwrap());
+        assert!(!Config::parse_bool("off").unwrap());
+        assert!(!Config::parse_bool("0").unwrap());
 
-        assert_eq!(Config::parse_bool("true").unwrap(), true);
-        assert_eq!(Config::parse_bool("yes").unwrap(), true);
-        assert_eq!(Config::parse_bool("on").unwrap(), true);
-        assert_eq!(Config::parse_bool("1").unwrap(), true);
-        assert_eq!(Config::parse_bool("42").unwrap(), true);
+        assert!(Config::parse_bool("true").unwrap());
+        assert!(Config::parse_bool("yes").unwrap());
+        assert!(Config::parse_bool("on").unwrap());
+        assert!(Config::parse_bool("1").unwrap());
+        assert!(Config::parse_bool("42").unwrap());
 
         assert!(Config::parse_bool(" ").is_err());
         assert!(Config::parse_bool("some-string").is_err());

--- a/src/cred.rs
+++ b/src/cred.rs
@@ -501,7 +501,6 @@ impl CredentialHelper {
 
 #[cfg(test)]
 #[cfg(feature = "cred")]
-#[allow(clippy::useless_conversion)]
 mod test {
     use std::env;
     use std::fs::File;
@@ -613,8 +612,7 @@ echo username=$1
         chmod(&path);
 
         let paths = env::var("PATH").unwrap();
-        let paths =
-            env::split_paths(&paths).chain(path.parent().map(|p| p.to_path_buf()).into_iter());
+        let paths = env::split_paths(&paths).chain(path.parent().map(|p| p.to_path_buf()));
         env::set_var("PATH", env::join_paths(paths).unwrap());
 
         let cfg = test_cfg! {

--- a/src/cred.rs
+++ b/src/cred.rs
@@ -501,7 +501,6 @@ impl CredentialHelper {
 
 #[cfg(test)]
 #[cfg(feature = "cred")]
-#[allow(clippy::unused_io_amount)]
 #[allow(clippy::useless_conversion)]
 mod test {
     use std::env;
@@ -570,7 +569,7 @@ mod test {
 
         let td = TempDir::new().unwrap();
         let path = td.path().join("script");
-        File::create(&path)
+        let written_bytes = File::create(&path)
             .unwrap()
             .write(
                 br"\
@@ -579,6 +578,7 @@ echo username=c
 ",
             )
             .unwrap();
+        assert_eq!(28, written_bytes);
         chmod(&path);
         let cfg = test_cfg! {
             "credential.https://example.com.helper" =>
@@ -600,7 +600,7 @@ echo username=c
         } // shell scripts don't work on Windows
         let td = TempDir::new().unwrap();
         let path = td.path().join("git-credential-some-script");
-        File::create(&path)
+        let written_bytes = File::create(&path)
             .unwrap()
             .write(
                 br"\
@@ -609,6 +609,7 @@ echo username=$1
 ",
             )
             .unwrap();
+        assert_eq!(29, written_bytes);
         chmod(&path);
 
         let paths = env::var("PATH").unwrap();
@@ -646,7 +647,7 @@ echo username=$1
         } // shell scripts don't work on Windows
         let td = TempDir::new().unwrap();
         let path = td.path().join("script");
-        File::create(&path)
+        let written_bytes = File::create(&path)
             .unwrap()
             .write(
                 br"\
@@ -656,6 +657,7 @@ echo password=$2
 ",
             )
             .unwrap();
+        assert_eq!(46, written_bytes);
         chmod(&path);
         let cfg = test_cfg! {
             "credential.helper" => &format!("{} a b", path.display())

--- a/src/cred.rs
+++ b/src/cred.rs
@@ -501,7 +501,6 @@ impl CredentialHelper {
 
 #[cfg(test)]
 #[cfg(feature = "cred")]
-#[allow(clippy::needless_borrows_for_generic_args)]
 #[allow(clippy::unused_io_amount)]
 #[allow(clippy::useless_conversion)]
 mod test {
@@ -615,7 +614,7 @@ echo username=$1
         let paths = env::var("PATH").unwrap();
         let paths =
             env::split_paths(&paths).chain(path.parent().map(|p| p.to_path_buf()).into_iter());
-        env::set_var("PATH", &env::join_paths(paths).unwrap());
+        env::set_var("PATH", env::join_paths(paths).unwrap());
 
         let cfg = test_cfg! {
             "credential.https://example.com.helper" => "some-script \"value/with\\slashes\"",

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1604,7 +1604,6 @@ impl Default for DiffPatchidOptions {
 }
 
 #[cfg(test)]
-#[allow(clippy::while_let_on_iterator)]
 mod tests {
     #[cfg(feature = "unstable-sha256")]
     use crate::Diff;
@@ -1856,7 +1855,7 @@ mod tests {
             "Invalid version line: {:?}",
             version_line
         );
-        while let Some(line) = remaining_lines.next() {
+        for line in remaining_lines {
             assert_eq!(line.trim(), "")
         }
     }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1604,7 +1604,6 @@ impl Default for DiffPatchidOptions {
 }
 
 #[cfg(test)]
-#[allow(clippy::needless_borrows_for_generic_args)]
 #[allow(clippy::while_let_on_iterator)]
 mod tests {
     #[cfg(feature = "unstable-sha256")]
@@ -1649,7 +1648,7 @@ mod tests {
     fn foreach_file_only() {
         let path = Path::new("foo");
         let (td, repo) = crate::test::repo_init();
-        t!(t!(File::create(&td.path().join(path))).write_all(b"bar"));
+        t!(t!(File::create(td.path().join(path))).write_all(b"bar"));
         let mut opts = DiffOptions::new();
         opts.include_untracked(true);
         let diff = t!(repo.diff_tree_to_workdir(None, Some(&mut opts)));
@@ -1673,7 +1672,7 @@ mod tests {
     fn foreach_file_and_hunk() {
         let path = Path::new("foo");
         let (td, repo) = crate::test::repo_init();
-        t!(t!(File::create(&td.path().join(path))).write_all(b"bar"));
+        t!(t!(File::create(td.path().join(path))).write_all(b"bar"));
         let mut index = t!(repo.index());
         t!(index.add_path(path));
         let mut opts = DiffOptions::new();
@@ -1701,8 +1700,8 @@ mod tests {
         let foo_path = Path::new("foo");
         let bin_path = Path::new("bin");
         let (td, repo) = crate::test::repo_init();
-        t!(t!(File::create(&td.path().join(foo_path))).write_all(b"bar\n"));
-        t!(t!(File::create(&td.path().join(bin_path))).write_all(&fib));
+        t!(t!(File::create(td.path().join(foo_path))).write_all(b"bar\n"));
+        t!(t!(File::create(td.path().join(bin_path))).write_all(&fib));
         let mut index = t!(repo.index());
         t!(index.add_path(foo_path));
         t!(index.add_path(bin_path));
@@ -1866,7 +1865,7 @@ mod tests {
     fn foreach_diff_line_origin_value() {
         let foo_path = Path::new("foo");
         let (td, repo) = crate::test::repo_init();
-        t!(t!(File::create(&td.path().join(foo_path))).write_all(b"bar\n"));
+        t!(t!(File::create(td.path().join(foo_path))).write_all(b"bar\n"));
         let mut index = t!(repo.index());
         t!(index.add_path(foo_path));
         let mut opts = DiffOptions::new();
@@ -1892,7 +1891,7 @@ mod tests {
         let bar_path = Path::new("foo");
 
         let (td, repo) = crate::test::repo_init();
-        t!(t!(File::create(&td.path().join(foo_path))).write_all(b"bar\n"));
+        t!(t!(File::create(td.path().join(foo_path))).write_all(b"bar\n"));
 
         let mut index = t!(repo.index());
         t!(index.add_path(foo_path));
@@ -2036,14 +2035,14 @@ Binary files /dev/null and b/binary.pdf differ
 
         // Commit a file with enough content for rename detection to latch onto.
         let body = "alpha\nbravo\ncharlie\ndelta\necho\nfoxtrot\n";
-        t!(t!(File::create(&root.join("orig.txt"))).write_all(body.as_bytes()));
+        t!(t!(File::create(root.join("orig.txt"))).write_all(body.as_bytes()));
         let mut index = t!(repo.index());
         t!(index.add_path(Path::new("orig.txt")));
         let tree1 = t!(repo.find_tree(t!(index.write_tree())));
 
         // Pure rename: identical content at a new path scores 100.
-        t!(std::fs::remove_file(&root.join("orig.txt")));
-        t!(t!(File::create(&root.join("renamed.txt"))).write_all(body.as_bytes()));
+        t!(std::fs::remove_file(root.join("orig.txt")));
+        t!(t!(File::create(root.join("renamed.txt"))).write_all(body.as_bytes()));
         t!(index.remove_path(Path::new("orig.txt")));
         t!(index.add_path(Path::new("renamed.txt")));
         let tree2 = t!(repo.find_tree(t!(index.write_tree())));
@@ -2060,7 +2059,7 @@ Binary files /dev/null and b/binary.pdf differ
         // Rename + edit: a changed line drops the score below 100 while keeping
         // it above the default 50 rename threshold.
         let edited = "ALPHA is different now\nbravo\ncharlie\ndelta\necho\nfoxtrot\n";
-        t!(t!(File::create(&root.join("renamed.txt"))).write_all(edited.as_bytes()));
+        t!(t!(File::create(root.join("renamed.txt"))).write_all(edited.as_bytes()));
         t!(index.add_path(Path::new("renamed.txt")));
         let tree3 = t!(repo.find_tree(t!(index.write_tree())));
         {

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1604,7 +1604,6 @@ impl Default for DiffPatchidOptions {
 }
 
 #[cfg(test)]
-#[allow(clippy::assign_op_pattern)]
 #[allow(clippy::needless_borrows_for_generic_args)]
 #[allow(clippy::while_let_on_iterator)]
 mod tests {
@@ -1636,7 +1635,7 @@ mod tests {
         let mut count = 0;
         t!(diff.foreach(
             &mut |_file, _progress| {
-                count = count + 1;
+                count += 1;
                 true
             },
             None,
@@ -1658,7 +1657,7 @@ mod tests {
         let mut result = None;
         t!(diff.foreach(
             &mut |file, _progress| {
-                count = count + 1;
+                count += 1;
                 result = file.new_file().path().map(ToOwned::to_owned);
                 true
             },

--- a/src/index.rs
+++ b/src/index.rs
@@ -882,7 +882,6 @@ impl Binding for IndexEntry {
 }
 
 #[cfg(test)]
-#[allow(clippy::needless_borrows_for_generic_args)]
 mod tests {
     use std::fs::{self, File};
     use std::path::Path;
@@ -926,8 +925,8 @@ mod tests {
         let mut index = repo.index().unwrap();
 
         let root = repo.path().parent().unwrap();
-        fs::create_dir(&root.join("foo")).unwrap();
-        File::create(&root.join("foo/bar")).unwrap();
+        fs::create_dir(root.join("foo")).unwrap();
+        File::create(root.join("foo/bar")).unwrap();
         let mut called = false;
         index
             .add_all(
@@ -966,8 +965,8 @@ mod tests {
         let mut index = repo.index().unwrap();
 
         let root = repo.path().parent().unwrap();
-        fs::create_dir(&root.join("foo")).unwrap();
-        File::create(&root.join("foo/bar")).unwrap();
+        fs::create_dir(root.join("foo")).unwrap();
+        File::create(root.join("foo/bar")).unwrap();
         index.add_path(Path::new("foo/bar")).unwrap();
         index.write().unwrap();
         assert_eq!(index.iter().count(), 1);

--- a/src/index.rs
+++ b/src/index.rs
@@ -882,7 +882,6 @@ impl Binding for IndexEntry {
 }
 
 #[cfg(test)]
-#[allow(clippy::needless_borrow)]
 #[allow(clippy::needless_borrows_for_generic_args)]
 mod tests {
     use std::fs::{self, File};
@@ -896,7 +895,7 @@ mod tests {
     #[test]
     fn smoke() {
         let mut index = Index::new().unwrap();
-        assert!(index.add_path(&Path::new(".")).is_err());
+        assert!(index.add_path(Path::new(".")).is_err());
         index.clear().unwrap();
         assert_eq!(index.len(), 0);
         assert!(index.get(0).is_none());
@@ -986,7 +985,7 @@ mod tests {
         repo.reset(&obj, ResetType::Hard, None).unwrap();
 
         let td2 = TempDir::new().unwrap();
-        let url = crate::test::path2url(&root);
+        let url = crate::test::path2url(root);
         let repo = Repository::clone(&url, td2.path()).unwrap();
         let obj = repo.find_object(commit, None).unwrap();
         repo.reset(&obj, ResetType::Hard, None).unwrap();

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -242,7 +242,6 @@ impl Drop for Indexer<'_> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unused_io_amount)]
 mod tests {
     use crate::{Buf, Indexer};
     use std::io::prelude::*;
@@ -274,7 +273,9 @@ mod tests {
             progress_called = true;
             true
         });
-        indexer.write(&buf).unwrap();
+        let expected_len = buf.len();
+        let written_bytes = indexer.write(&buf).unwrap();
+        assert_eq!(expected_len, written_bytes);
         indexer.commit().unwrap();
 
         // Assert that target repo picks it up as valid
@@ -312,7 +313,9 @@ mod tests {
             progress_called = true;
             true
         });
-        indexer.write(&buf).unwrap();
+        let expected_len = buf.len();
+        let written_bytes = indexer.write(&buf).unwrap();
+        assert_eq!(expected_len, written_bytes);
         indexer.commit().unwrap();
 
         // Assert that target repo picks it up as valid

--- a/src/mailmap.rs
+++ b/src/mailmap.rs
@@ -93,7 +93,6 @@ impl Mailmap {
 }
 
 #[cfg(test)]
-#[allow(clippy::needless_borrow)]
 mod tests {
     use super::*;
 
@@ -125,7 +124,7 @@ mod tests {
     #[test]
     fn from_buffer() {
         let buf = "<prøper@emæil> <email>";
-        let mm = t!(Mailmap::from_buffer(&buf));
+        let mm = t!(Mailmap::from_buffer(buf));
 
         let sig = t!(Signature::now("name", "email"));
         let mailmapped_sig = t!(mm.resolve_signature(&sig));

--- a/src/message.rs
+++ b/src/message.rs
@@ -249,7 +249,6 @@ fn to_bytes_tuple(trailers: &MessageTrailers, index: usize) -> (&[u8], &[u8]) {
 }
 
 #[cfg(test)]
-#[allow(clippy::char_lit_as_u8)]
 mod tests {
 
     #[test]
@@ -273,7 +272,7 @@ mod tests {
             "1\n"
         );
         assert_eq!(
-            message_prettify("1\n; comment\n; more", Some(';' as u8)).unwrap(),
+            message_prettify("1\n; comment\n; more", Some(b';')).unwrap(),
             "1\n"
         );
     }

--- a/src/odb.rs
+++ b/src/odb.rs
@@ -583,7 +583,6 @@ pub(crate) extern "C" fn write_pack_progress_cb(
 }
 
 #[cfg(test)]
-#[allow(clippy::bool_assert_comparison)]
 #[allow(clippy::unused_io_amount)]
 mod tests {
     use crate::{Buf, ObjectType, Oid, Repository};
@@ -705,7 +704,7 @@ mod tests {
             packwriter.write(&buf).unwrap();
             packwriter.commit().unwrap();
         }
-        assert_eq!(progress_called, true);
+        assert!(progress_called);
     }
 
     #[test]

--- a/src/odb.rs
+++ b/src/odb.rs
@@ -583,7 +583,6 @@ pub(crate) extern "C" fn write_pack_progress_cb(
 }
 
 #[cfg(test)]
-#[allow(clippy::unused_io_amount)]
 mod tests {
     use crate::{Buf, ObjectType, Oid, Repository};
     use std::io::prelude::*;
@@ -678,7 +677,9 @@ mod tests {
         t!(builder.write_buf(&mut buf));
         let db = repo_target.odb().unwrap();
         let mut packwriter = db.packwriter().unwrap();
-        packwriter.write(&buf).unwrap();
+        let expected_len = buf.len();
+        let written_bytes = packwriter.write(&buf).unwrap();
+        assert_eq!(expected_len, written_bytes);
         packwriter.commit().unwrap();
         let commit_target = repo_target.find_commit(commit_source_id).unwrap();
         assert_eq!(commit_target.id(), commit_source_id);
@@ -701,7 +702,9 @@ mod tests {
                 progress_called = true;
                 true
             });
-            packwriter.write(&buf).unwrap();
+            let expected_len = buf.len();
+            let written_bytes = packwriter.write(&buf).unwrap();
+            assert_eq!(expected_len, written_bytes);
             packwriter.commit().unwrap();
         }
         assert!(progress_called);
@@ -742,7 +745,9 @@ mod tests {
         // Write the buf into a packfile in the repo. This brings back the
         // missing objects, and we verify everything is good again.
         let mut packwriter = odb.packwriter().unwrap();
-        packwriter.write(&buf).unwrap();
+        let expected_len = buf.len();
+        let written_bytes = packwriter.write(&buf).unwrap();
+        assert_eq!(expected_len, written_bytes);
         packwriter.commit().unwrap();
         t!(repo.reset(commit1.as_object(), ResetType::Hard, None));
         assert!(foo_file.exists());

--- a/src/packbuilder.rs
+++ b/src/packbuilder.rs
@@ -296,7 +296,6 @@ extern "C" fn progress_c(
 }
 
 #[cfg(test)]
-#[allow(clippy::bool_assert_comparison)]
 mod tests {
     use crate::Buf;
 
@@ -597,7 +596,7 @@ mod tests {
             t!(builder.insert_commit(commit));
             t!(builder.write_buf(&mut Buf::new()));
         }
-        assert_eq!(progress_called, true);
+        assert!(progress_called);
     }
 
     #[test]
@@ -615,7 +614,7 @@ mod tests {
             t!(builder.insert_commit(commit));
             t!(builder.write_buf(&mut Buf::new()));
         }
-        assert_eq!(progress_called, false);
+        assert!(!progress_called);
     }
 
     #[test]
@@ -632,7 +631,7 @@ mod tests {
             t!(builder.insert_commit(commit));
             t!(builder.write(repo.path(), 0));
         }
-        assert_eq!(progress_called, true);
+        assert!(progress_called);
     }
 
     #[test]

--- a/src/pathspec.rs
+++ b/src/pathspec.rs
@@ -337,7 +337,6 @@ impl<'list> FusedIterator for PathspecFailedEntries<'list> {}
 impl<'list> ExactSizeIterator for PathspecFailedEntries<'list> {}
 
 #[cfg(test)]
-#[allow(clippy::needless_borrows_for_generic_args)]
 mod tests {
     use super::Pathspec;
     use crate::PathspecFlags;
@@ -358,7 +357,7 @@ mod tests {
         assert_eq!(list.diff_entries().len(), 0);
         assert_eq!(list.failed_entries().len(), 0);
 
-        File::create(&td.path().join("a")).unwrap();
+        File::create(td.path().join("a")).unwrap();
 
         let list = ps
             .match_workdir(&repo, crate::PathspecFlags::FIND_FAILURES)

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -517,7 +517,6 @@ impl<'repo, 'references> Iterator for ReferenceNames<'repo, 'references> {
 }
 
 #[cfg(test)]
-#[allow(clippy::octal_escapes)]
 mod tests {
     use crate::{ObjectType, Reference, ReferenceType};
 
@@ -531,7 +530,7 @@ mod tests {
         assert!(!Reference::is_valid_name("_FOO_BAR"));
 
         // Previously would panic, see #1218
-        assert!(!Reference::is_valid_name("ab\012"));
+        assert!(!Reference::is_valid_name("ab\x0012"));
     }
 
     #[test]

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -820,7 +820,6 @@ impl RemoteRedirect {
 }
 
 #[cfg(test)]
-#[allow(clippy::octal_escapes)]
 mod tests {
     use crate::{AutotagOption, PushOptions, RemoteUpdateFlags};
     use crate::{Direction, FetchOptions, ObjectFormat, Remote, RemoteCallbacks, Repository};
@@ -980,7 +979,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn is_valid_name_for_invalid_remote() {
-        Remote::is_valid_name("ab\012");
+        Remote::is_valid_name("ab\x0012");
     }
 
     #[test]

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -820,7 +820,6 @@ impl RemoteRedirect {
 }
 
 #[cfg(test)]
-#[allow(clippy::needless_borrow)]
 #[allow(clippy::octal_escapes)]
 mod tests {
     use crate::{AutotagOption, PushOptions, RemoteUpdateFlags};
@@ -988,7 +987,7 @@ mod tests {
     fn transfer_cb() {
         let (td, _repo) = crate::test::repo_init();
         let td2 = TempDir::new().unwrap();
-        let url = crate::test::path2url(&td.path());
+        let url = crate::test::path2url(td.path());
 
         let repo = Repository::init(td2.path()).unwrap();
         let progress_hit = Cell::new(false);
@@ -1024,7 +1023,7 @@ mod tests {
     fn connect_list() {
         let (td, _repo) = crate::test::repo_init();
         let td2 = TempDir::new().unwrap();
-        let url = crate::test::path2url(&td.path());
+        let url = crate::test::path2url(td.path());
 
         let repo = Repository::init(td2.path()).unwrap();
         let mut callbacks = RemoteCallbacks::new();
@@ -1056,7 +1055,7 @@ mod tests {
         let (_td, repo) = crate::test::repo_init();
         let td2 = TempDir::new().unwrap();
         let td3 = TempDir::new().unwrap();
-        let url = crate::test::path2url(&td2.path());
+        let url = crate::test::path2url(td2.path());
 
         let mut opts = crate::RepositoryInitOptions::new();
         opts.bare(true);
@@ -1095,7 +1094,7 @@ mod tests {
         remote_repo.branch("stale", &commit, true).unwrap();
 
         let td2 = TempDir::new().unwrap();
-        let url = crate::test::path2url(&td.path());
+        let url = crate::test::path2url(td.path());
         let repo = Repository::clone(&url, &td2).unwrap();
 
         fn assert_branch_count(repo: &Repository, count: usize) {

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -3671,7 +3671,6 @@ impl Default for RepositoryInitOptions {
 }
 
 #[cfg(test)]
-#[allow(clippy::needless_borrow)]
 #[allow(clippy::needless_borrows_for_generic_args)]
 mod tests {
     use crate::build::CheckoutBuilder;
@@ -3765,7 +3764,7 @@ mod tests {
         assert!(!repo.is_shallow());
         assert!(repo.is_empty().unwrap());
         assert_eq!(
-            crate::test::realpath(&repo.path()).unwrap(),
+            crate::test::realpath(repo.path()).unwrap(),
             crate::test::realpath(&td.path().join(".git/")).unwrap()
         );
         assert_eq!(repo.state(), crate::RepositoryState::Clean);
@@ -3790,7 +3789,7 @@ mod tests {
         assert!(!repo.is_bare());
         assert!(repo.is_empty().unwrap());
         assert_eq!(
-            crate::test::realpath(&repo.path()).unwrap(),
+            crate::test::realpath(repo.path()).unwrap(),
             crate::test::realpath(&td.path().join(".git/")).unwrap()
         );
         assert_eq!(repo.state(), crate::RepositoryState::Clean);
@@ -3813,7 +3812,7 @@ mod tests {
         let repo = Repository::open(path).unwrap();
         assert!(repo.is_bare());
         assert_eq!(
-            crate::test::realpath(&repo.path()).unwrap(),
+            crate::test::realpath(repo.path()).unwrap(),
             crate::test::realpath(&td.path().join("")).unwrap()
         );
     }
@@ -3833,7 +3832,7 @@ mod tests {
         let repo = Repository::open(path).unwrap();
         assert!(repo.is_bare());
         assert_eq!(
-            crate::test::realpath(&repo.path()).unwrap(),
+            crate::test::realpath(repo.path()).unwrap(),
             crate::test::realpath(&td.path().join("")).unwrap()
         );
     }
@@ -3908,7 +3907,7 @@ mod tests {
         Repository::init_bare(td.path()).unwrap();
         let repo = Repository::discover(&subdir).unwrap();
         assert_eq!(
-            crate::test::realpath(&repo.path()).unwrap(),
+            crate::test::realpath(repo.path()).unwrap(),
             crate::test::realpath(&td.path().join("")).unwrap()
         );
     }
@@ -3956,7 +3955,7 @@ mod tests {
         .unwrap();
         assert!(!repo.is_bare());
         assert_eq!(
-            crate::test::realpath(&repo.path()).unwrap(),
+            crate::test::realpath(repo.path()).unwrap(),
             crate::test::realpath(&td.path().join(".git")).unwrap()
         );
 
@@ -3965,7 +3964,7 @@ mod tests {
                 .unwrap();
         assert!(repo.is_bare());
         assert_eq!(
-            crate::test::realpath(&repo.path()).unwrap(),
+            crate::test::realpath(repo.path()).unwrap(),
             crate::test::realpath(&td.path().join(".git")).unwrap()
         );
 
@@ -4338,7 +4337,7 @@ mod tests {
         let base_commit = {
             t!(fs::write(repo.workdir().unwrap().join(&file_path), "base"));
             let mut index = t!(repo.index());
-            t!(index.add_path(&file_path));
+            t!(index.add_path(file_path));
             let tree_id = t!(index.write_tree());
             let tree = t!(repo.find_tree(tree_id));
 
@@ -4356,7 +4355,7 @@ mod tests {
         let foo_commit = {
             t!(fs::write(repo.workdir().unwrap().join(&file_path), "foo"));
             let mut index = t!(repo.index());
-            t!(index.add_path(&file_path));
+            t!(index.add_path(file_path));
             let tree_id = t!(index.write_tree());
             let tree = t!(repo.find_tree(tree_id));
 
@@ -4374,7 +4373,7 @@ mod tests {
         let bar_commit = {
             t!(fs::write(repo.workdir().unwrap().join(&file_path), "bar"));
             let mut index = t!(repo.index());
-            t!(index.add_path(&file_path));
+            t!(index.add_path(file_path));
             let tree_id = t!(index.write_tree());
             let tree = t!(repo.find_tree(tree_id));
 
@@ -4727,7 +4726,7 @@ Author Name <author.proper@email> name <email>
 Committer Name <committer.proper@email> <committer@email>"#,
             ));
             let mut index = t!(repo.index());
-            t!(index.add_path(&mailmap_file));
+            t!(index.add_path(mailmap_file));
             let id_mailmap = t!(index.write_tree());
             let tree_mailmap = t!(repo.find_tree(id_mailmap));
 

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -3671,7 +3671,6 @@ impl Default for RepositoryInitOptions {
 }
 
 #[cfg(test)]
-#[allow(clippy::assertions_on_constants)]
 #[allow(clippy::bool_assert_comparison)]
 #[allow(clippy::needless_borrow)]
 #[allow(clippy::needless_borrows_for_generic_args)]
@@ -4299,7 +4298,7 @@ mod tests {
             } else if mg == &oid3 {
                 found_oid3 = true;
             } else {
-                assert!(false);
+                panic!("Merge base was neither oid2 nor oid3: {:?}", mg);
             }
         }
         assert!(found_oid2);
@@ -4317,7 +4316,7 @@ mod tests {
             } else if mg == &oid3 {
                 found_oid3 = true;
             } else {
-                assert!(false);
+                panic!("Merge base was neither oid2 nor oid3: {:?}", mg);
             }
         }
         assert!(found_oid2);

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -3671,7 +3671,6 @@ impl Default for RepositoryInitOptions {
 }
 
 #[cfg(test)]
-#[allow(clippy::bool_assert_comparison)]
 #[allow(clippy::needless_borrow)]
 #[allow(clippy::needless_borrows_for_generic_args)]
 mod tests {
@@ -4031,16 +4030,16 @@ mod tests {
     fn smoke_reference_has_log_ensure_log() {
         let (_td, repo) = crate::test::repo_init();
 
-        assert_eq!(repo.reference_has_log("HEAD").unwrap(), true);
-        assert_eq!(repo.reference_has_log("refs/heads/main").unwrap(), true);
-        assert_eq!(repo.reference_has_log("NOT_HEAD").unwrap(), false);
+        assert!(repo.reference_has_log("HEAD").unwrap());
+        assert!(repo.reference_has_log("refs/heads/main").unwrap());
+        assert!(!repo.reference_has_log("NOT_HEAD").unwrap());
         let main_oid = repo.revparse_single("main").unwrap().id();
         assert!(repo
             .reference("NOT_HEAD", main_oid, false, "creating a new branch")
             .is_ok());
-        assert_eq!(repo.reference_has_log("NOT_HEAD").unwrap(), false);
+        assert!(!repo.reference_has_log("NOT_HEAD").unwrap());
         assert!(repo.reference_ensure_log("NOT_HEAD").is_ok());
-        assert_eq!(repo.reference_has_log("NOT_HEAD").unwrap(), true);
+        assert!(repo.reference_has_log("NOT_HEAD").unwrap());
     }
 
     #[test]

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -3671,7 +3671,6 @@ impl Default for RepositoryInitOptions {
 }
 
 #[cfg(test)]
-#[allow(clippy::needless_borrows_for_generic_args)]
 mod tests {
     use crate::build::CheckoutBuilder;
     use crate::AttrCheckFlags;
@@ -3896,7 +3895,7 @@ mod tests {
     #[test]
     fn makes_dirs() {
         let td = TempDir::new().unwrap();
-        Repository::init(&td.path().join("a/b/c/d")).unwrap();
+        Repository::init(td.path().join("a/b/c/d")).unwrap();
     }
 
     #[test]
@@ -3935,7 +3934,7 @@ mod tests {
         let testdir = ceilingdir.join("testdi");
         fs::create_dir(&testdir).unwrap();
         Repository::init_bare(td.path()).unwrap();
-        let path = Repository::discover_path(&testdir, &[ceilingdir.as_os_str()]);
+        let path = Repository::discover_path(&testdir, [ceilingdir.as_os_str()]);
 
         assert!(path.is_err());
     }
@@ -3978,7 +3977,7 @@ mod tests {
         assert_eq!(err.code(), crate::ErrorCode::NotFound);
 
         assert!(
-            Repository::open_ext(&subdir, crate::RepositoryOpenFlags::empty(), &[&subdir]).is_ok()
+            Repository::open_ext(&subdir, crate::RepositoryOpenFlags::empty(), [&subdir]).is_ok()
         );
     }
 
@@ -4335,7 +4334,7 @@ mod tests {
         let author = t!(Signature::now("committer", "committer@email"));
 
         let base_commit = {
-            t!(fs::write(repo.workdir().unwrap().join(&file_path), "base"));
+            t!(fs::write(repo.workdir().unwrap().join(file_path), "base"));
             let mut index = t!(repo.index());
             t!(index.add_path(file_path));
             let tree_id = t!(index.write_tree());
@@ -4353,7 +4352,7 @@ mod tests {
         };
 
         let foo_commit = {
-            t!(fs::write(repo.workdir().unwrap().join(&file_path), "foo"));
+            t!(fs::write(repo.workdir().unwrap().join(file_path), "foo"));
             let mut index = t!(repo.index());
             t!(index.add_path(file_path));
             let tree_id = t!(index.write_tree());
@@ -4371,7 +4370,7 @@ mod tests {
         };
 
         let bar_commit = {
-            t!(fs::write(repo.workdir().unwrap().join(&file_path), "bar"));
+            t!(fs::write(repo.workdir().unwrap().join(file_path), "bar"));
             let mut index = t!(repo.index());
             t!(index.add_path(file_path));
             let tree_id = t!(index.write_tree());
@@ -4718,7 +4717,7 @@ bar
             // - Include entries for both author and committer to prove we call
             //   the right raw functions.
             let mailmap_file = Path::new(".mailmap");
-            let p = Path::new(repo.workdir().unwrap()).join(&mailmap_file);
+            let p = Path::new(repo.workdir().unwrap()).join(mailmap_file);
             t!(fs::write(
                 p,
                 r#"
@@ -4998,7 +4997,7 @@ Committer Name <committer.proper@email> <committer@email>"#,
     fn attr_invalid_utf8() {
         let (td, repo) = crate::test::repo_init();
         t!(fs::write(
-            &td.path().join(".gitattributes"),
+            td.path().join(".gitattributes"),
             b"README.md foo=valid bar=inva\xFFlid"
         ));
 

--- a/src/stash.rs
+++ b/src/stash.rs
@@ -212,7 +212,6 @@ extern "C" fn stash_apply_progress_cb(
 }
 
 #[cfg(test)]
-#[allow(clippy::needless_borrow)]
 mod tests {
     use crate::stash::{StashApplyOptions, StashSaveOptions};
     use crate::test::repo_init;
@@ -233,12 +232,12 @@ mod tests {
         fs::write(&p, "data".as_bytes()).unwrap();
 
         let rel_p = Path::new("file_b.txt");
-        assert!(repo.status_file(&rel_p).unwrap() == Status::WT_NEW);
+        assert!(repo.status_file(rel_p).unwrap() == Status::WT_NEW);
 
         repo.stash_save(&signature, "msg1", Some(StashFlags::INCLUDE_UNTRACKED))
             .unwrap();
 
-        assert!(repo.status_file(&rel_p).is_err());
+        assert!(repo.status_file(rel_p).is_err());
 
         let mut count = 0;
         repo.stash_foreach(|index, name, _oid| {

--- a/src/status.rs
+++ b/src/status.rs
@@ -366,7 +366,6 @@ impl<'statuses> Binding for StatusEntry<'statuses> {
 }
 
 #[cfg(test)]
-#[allow(clippy::needless_borrows_for_generic_args)]
 mod tests {
     use super::StatusOptions;
     use std::fs::File;
@@ -377,7 +376,7 @@ mod tests {
     fn smoke() {
         let (td, repo) = crate::test::repo_init();
         assert_eq!(repo.statuses(None).unwrap().len(), 0);
-        File::create(&td.path().join("foo")).unwrap();
+        File::create(td.path().join("foo")).unwrap();
         let statuses = repo.statuses(None).unwrap();
         assert_eq!(statuses.iter().count(), 1);
         let status = statuses.iter().next().unwrap();
@@ -393,8 +392,8 @@ mod tests {
     #[test]
     fn filter() {
         let (td, repo) = crate::test::repo_init();
-        t!(File::create(&td.path().join("foo")));
-        t!(File::create(&td.path().join("bar")));
+        t!(File::create(td.path().join("foo")));
+        t!(File::create(td.path().join("bar")));
         let mut opts = StatusOptions::new();
         opts.include_untracked(true).pathspec("foo");
 

--- a/src/submodule.rs
+++ b/src/submodule.rs
@@ -328,7 +328,6 @@ impl<'cb> Default for SubmoduleUpdateOptions<'cb> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unnecessary_to_owned)]
 mod tests {
     use std::fs;
     use std::path::Path;
@@ -376,10 +375,10 @@ mod tests {
 
         let url = Url::from_file_path(repo1.workdir().unwrap()).unwrap();
         let mut s = repo2
-            .submodule(&url.to_string(), Path::new("bar"), true)
+            .submodule(url.as_ref(), Path::new("bar"), true)
             .unwrap();
         t!(fs::remove_dir_all(td.path().join("bar")));
-        t!(Repository::clone(&url.to_string(), td.path().join("bar")));
+        t!(Repository::clone(url.as_ref(), td.path().join("bar")));
         t!(s.add_to_index(false));
         t!(s.add_finalize());
     }
@@ -393,10 +392,10 @@ mod tests {
 
         let url = Url::from_file_path(repo1.workdir().unwrap()).unwrap();
         let mut s = repo2
-            .submodule(&url.to_string(), Path::new("bar"), true)
+            .submodule(url.as_ref(), Path::new("bar"), true)
             .unwrap();
         t!(fs::remove_dir_all(td.path().join("bar")));
-        t!(Repository::clone(&url.to_string(), td.path().join("bar")));
+        t!(Repository::clone(url.as_ref(), td.path().join("bar")));
         t!(s.add_to_index(false));
         t!(s.add_finalize());
         // -----------------------------------
@@ -423,10 +422,10 @@ mod tests {
         let url1 = Url::from_file_path(repo1.workdir().unwrap()).unwrap();
         let url2 = Url::from_file_path(repo2.workdir().unwrap()).unwrap();
         let mut s1 = parent
-            .submodule(&url1.to_string(), Path::new("bar"), true)
+            .submodule(url1.as_ref(), Path::new("bar"), true)
             .unwrap();
         let mut s2 = parent
-            .submodule(&url2.to_string(), Path::new("bar2"), true)
+            .submodule(url2.as_ref(), Path::new("bar2"), true)
             .unwrap();
         // -----------------------------------
 
@@ -444,7 +443,7 @@ mod tests {
         let url_child = Url::from_file_path(child.workdir().unwrap()).unwrap();
         let url_parent = Url::from_file_path(parent.workdir().unwrap()).unwrap();
         let mut sub = parent
-            .submodule(&url_child.to_string(), Path::new("bar"), true)
+            .submodule(url_child.as_ref(), Path::new("bar"), true)
             .unwrap();
 
         // -----------------------------------
@@ -457,7 +456,7 @@ mod tests {
 
         // Clone the parent to init its submodules
         let td = TempDir::new().unwrap();
-        let new_parent = Repository::clone(&url_parent.to_string(), &td).unwrap();
+        let new_parent = Repository::clone(url_parent.as_ref(), &td).unwrap();
 
         let mut submodules = new_parent.submodules().unwrap();
         let child = submodules.first_mut().unwrap();

--- a/src/submodule.rs
+++ b/src/submodule.rs
@@ -328,7 +328,6 @@ impl<'cb> Default for SubmoduleUpdateOptions<'cb> {
 }
 
 #[cfg(test)]
-#[allow(clippy::needless_borrows_for_generic_args)]
 #[allow(clippy::unnecessary_to_owned)]
 mod tests {
     use std::fs;
@@ -375,7 +374,7 @@ mod tests {
         let (_td, repo1) = crate::test::repo_init();
         let (td, repo2) = crate::test::repo_init();
 
-        let url = Url::from_file_path(&repo1.workdir().unwrap()).unwrap();
+        let url = Url::from_file_path(repo1.workdir().unwrap()).unwrap();
         let mut s = repo2
             .submodule(&url.to_string(), Path::new("bar"), true)
             .unwrap();
@@ -392,7 +391,7 @@ mod tests {
         let (_td, repo1) = crate::test::repo_init();
         let (td, repo2) = crate::test::repo_init();
 
-        let url = Url::from_file_path(&repo1.workdir().unwrap()).unwrap();
+        let url = Url::from_file_path(repo1.workdir().unwrap()).unwrap();
         let mut s = repo2
             .submodule(&url.to_string(), Path::new("bar"), true)
             .unwrap();
@@ -421,8 +420,8 @@ mod tests {
         let (_td, repo2) = crate::test::repo_init();
         let (_td, parent) = crate::test::repo_init();
 
-        let url1 = Url::from_file_path(&repo1.workdir().unwrap()).unwrap();
-        let url2 = Url::from_file_path(&repo2.workdir().unwrap()).unwrap();
+        let url1 = Url::from_file_path(repo1.workdir().unwrap()).unwrap();
+        let url2 = Url::from_file_path(repo2.workdir().unwrap()).unwrap();
         let mut s1 = parent
             .submodule(&url1.to_string(), Path::new("bar"), true)
             .unwrap();
@@ -442,8 +441,8 @@ mod tests {
         let (_td, child) = crate::test::repo_init();
         let (_td, parent) = crate::test::repo_init();
 
-        let url_child = Url::from_file_path(&child.workdir().unwrap()).unwrap();
-        let url_parent = Url::from_file_path(&parent.workdir().unwrap()).unwrap();
+        let url_child = Url::from_file_path(child.workdir().unwrap()).unwrap();
+        let url_parent = Url::from_file_path(parent.workdir().unwrap()).unwrap();
         let mut sub = parent
             .submodule(&url_child.to_string(), Path::new("bar"), true)
             .unwrap();

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -156,7 +156,6 @@ impl<'repo> Drop for Tag<'repo> {
 }
 
 #[cfg(test)]
-#[allow(clippy::octal_escapes)]
 mod tests {
     use crate::Tag;
 
@@ -176,7 +175,7 @@ mod tests {
         assert!(!Tag::is_valid_name("as\\cd"));
 
         // Previously would panic, see #1290
-        assert!(!Tag::is_valid_name("ab\012"));
+        assert!(!Tag::is_valid_name("ab\x0012"));
     }
 
     #[test]

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -156,7 +156,6 @@ impl<'repo> Drop for Tag<'repo> {
 }
 
 #[cfg(test)]
-#[allow(clippy::bool_assert_comparison)]
 #[allow(clippy::octal_escapes)]
 mod tests {
     use crate::Tag;
@@ -164,20 +163,20 @@ mod tests {
     // Reference -- https://git-scm.com/docs/git-check-ref-format
     #[test]
     fn name_is_valid() {
-        assert_eq!(Tag::is_valid_name("blah_blah"), true);
-        assert_eq!(Tag::is_valid_name("v1.2.3"), true);
-        assert_eq!(Tag::is_valid_name("my/tag"), true);
-        assert_eq!(Tag::is_valid_name("@"), true);
+        assert!(Tag::is_valid_name("blah_blah"));
+        assert!(Tag::is_valid_name("v1.2.3"));
+        assert!(Tag::is_valid_name("my/tag"));
+        assert!(Tag::is_valid_name("@"));
 
-        assert_eq!(Tag::is_valid_name("-foo"), false);
-        assert_eq!(Tag::is_valid_name("foo:bar"), false);
-        assert_eq!(Tag::is_valid_name("foo^bar"), false);
-        assert_eq!(Tag::is_valid_name("foo."), false);
-        assert_eq!(Tag::is_valid_name("@{"), false);
-        assert_eq!(Tag::is_valid_name("as\\cd"), false);
+        assert!(!Tag::is_valid_name("-foo"));
+        assert!(!Tag::is_valid_name("foo:bar"));
+        assert!(!Tag::is_valid_name("foo^bar"));
+        assert!(!Tag::is_valid_name("foo."));
+        assert!(!Tag::is_valid_name("@{"));
+        assert!(!Tag::is_valid_name("as\\cd"));
 
         // Previously would panic, see #1290
-        assert_eq!(Tag::is_valid_name("ab\012"), false);
+        assert!(!Tag::is_valid_name("ab\012"));
     }
 
     #[test]

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::needless_borrows_for_generic_args)]
-
 use std::fs::File;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -52,7 +50,7 @@ pub fn repo_init_sha256() -> (TempDir, Repository) {
 pub fn commit(repo: &Repository) -> (Oid, Oid) {
     let mut index = t!(repo.index());
     let root = repo.path().parent().unwrap();
-    t!(File::create(&root.join("foo")));
+    t!(File::create(root.join("foo")));
     t!(index.add_path(Path::new("foo")));
 
     let tree_id = t!(index.write_tree());

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -376,7 +376,6 @@ extern "C" fn stream_free(stream: *mut raw::git_smart_subtransport_stream) {
 }
 
 #[cfg(test)]
-#[allow(clippy::needless_borrow)]
 mod tests {
     use super::*;
     use crate::{ErrorClass, ErrorCode};
@@ -410,7 +409,7 @@ mod tests {
         unsafe {
             INIT.call_once(|| {
                 register("dummy", move |remote| {
-                    Transport::smart(&remote, true, DummyTransport)
+                    Transport::smart(remote, true, DummyTransport)
                 })
                 .unwrap();
             })

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -397,7 +397,6 @@ impl<'tree> FusedIterator for TreeIter<'tree> {}
 impl<'tree> ExactSizeIterator for TreeIter<'tree> {}
 
 #[cfg(test)]
-#[allow(clippy::single_match)]
 mod tests {
     use super::{TreeWalkMode, TreeWalkResult};
     use crate::{Object, ObjectType, Repository, Tree, TreeEntry};
@@ -420,17 +419,14 @@ mod tests {
             } else {
                 let entry = self.entries.remove(0);
 
-                match entry.kind() {
-                    Some(ObjectType::Tree) => {
-                        let obj: Object<'a> = entry.to_object(self.repo).unwrap();
+                if let Some(ObjectType::Tree) = entry.kind() {
+                    let obj: Object<'a> = entry.to_object(self.repo).unwrap();
 
-                        let tree: &Tree<'a> = obj.as_tree().unwrap();
+                    let tree: &Tree<'a> = obj.as_tree().unwrap();
 
-                        for entry in tree.iter() {
-                            self.entries.push(entry.to_owned());
-                        }
+                    for entry in tree.iter() {
+                        self.entries.push(entry.to_owned());
                     }
-                    _ => {}
                 }
 
                 Some(entry)

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -397,7 +397,6 @@ impl<'tree> FusedIterator for TreeIter<'tree> {}
 impl<'tree> ExactSizeIterator for TreeIter<'tree> {}
 
 #[cfg(test)]
-#[allow(clippy::needless_borrows_for_generic_args)]
 #[allow(clippy::redundant_field_names)]
 #[allow(clippy::single_match)]
 mod tests {
@@ -494,7 +493,7 @@ mod tests {
         let mut index = repo.index().unwrap();
         for n in 0..8 {
             let name = format!("f{n}");
-            File::create(&td.path().join(&name))
+            File::create(td.path().join(&name))
                 .unwrap()
                 .write_all(name.as_bytes())
                 .unwrap();

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -397,7 +397,6 @@ impl<'tree> FusedIterator for TreeIter<'tree> {}
 impl<'tree> ExactSizeIterator for TreeIter<'tree> {}
 
 #[cfg(test)]
-#[allow(clippy::redundant_field_names)]
 #[allow(clippy::single_match)]
 mod tests {
     use super::{TreeWalkMode, TreeWalkResult};
@@ -448,7 +447,7 @@ mod tests {
 
         TestTreeIter {
             entries: initial,
-            repo: repo,
+            repo,
         }
     }
 

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -1,6 +1,5 @@
 //! Tests for some end-to-end logic about certain operations
 
-#![allow(clippy::needless_borrow)]
 #![allow(unused_variables)]
 
 use git2::{
@@ -291,17 +290,17 @@ fn repo_status() {
     fs::write(path.join(".gitignore"), "ignored-*").unwrap();
 
     let mut index = repo.index().unwrap();
-    index.add_path(&Path::new("BothModified")).unwrap();
-    index.add_path(&Path::new("IndexModified")).unwrap();
-    index.add_path(&Path::new("IndexDeleted")).unwrap();
-    index.add_path(&Path::new("IndexRenamed")).unwrap();
-    index.add_path(&Path::new("IndexTypechange")).unwrap();
-    index.add_path(&Path::new("Unchanged")).unwrap();
-    index.add_path(&Path::new("WorktreeDeleted")).unwrap();
-    index.add_path(&Path::new("WorktreeModified")).unwrap();
-    index.add_path(&Path::new("WorktreeRenamed")).unwrap();
-    index.add_path(&Path::new("WorktreeTypechange")).unwrap();
-    index.add_path(&Path::new(".gitignore")).unwrap();
+    index.add_path(Path::new("BothModified")).unwrap();
+    index.add_path(Path::new("IndexModified")).unwrap();
+    index.add_path(Path::new("IndexDeleted")).unwrap();
+    index.add_path(Path::new("IndexRenamed")).unwrap();
+    index.add_path(Path::new("IndexTypechange")).unwrap();
+    index.add_path(Path::new("Unchanged")).unwrap();
+    index.add_path(Path::new("WorktreeDeleted")).unwrap();
+    index.add_path(Path::new("WorktreeModified")).unwrap();
+    index.add_path(Path::new("WorktreeRenamed")).unwrap();
+    index.add_path(Path::new("WorktreeTypechange")).unwrap();
+    index.add_path(Path::new(".gitignore")).unwrap();
 
     let id = index.write_tree().unwrap();
 
@@ -328,13 +327,13 @@ fn repo_status() {
 
     fs::rename(path.join("IndexRenamed"), path.join("IndexRenamed-new")).unwrap();
 
-    index.add_path(&Path::new("BothModified")).unwrap();
-    index.remove_path(&Path::new("IndexDeleted")).unwrap();
-    index.add_path(&Path::new("IndexModified")).unwrap();
-    index.add_path(&Path::new("IndexNew")).unwrap();
-    index.remove_path(&Path::new("IndexRenamed")).unwrap();
-    index.add_path(&Path::new("IndexRenamed-new")).unwrap();
-    index.add_path(&Path::new("IndexTypechange")).unwrap();
+    index.add_path(Path::new("BothModified")).unwrap();
+    index.remove_path(Path::new("IndexDeleted")).unwrap();
+    index.add_path(Path::new("IndexModified")).unwrap();
+    index.add_path(Path::new("IndexNew")).unwrap();
+    index.remove_path(Path::new("IndexRenamed")).unwrap();
+    index.add_path(Path::new("IndexRenamed-new")).unwrap();
+    index.add_path(Path::new("IndexTypechange")).unwrap();
 
     // And between index and worktree
     fs::write(path.join("ignored-random"), "ignored-random").unwrap();
@@ -424,7 +423,7 @@ fn repo_status_clean() {
     fs::write(path.join("MyFile"), "content").unwrap();
 
     let mut index = repo.index().unwrap();
-    index.add_path(&Path::new("MyFile")).unwrap();
+    index.add_path(Path::new("MyFile")).unwrap();
 
     let id = index.write_tree().unwrap();
 
@@ -457,7 +456,7 @@ fn repo_status_clean() {
     }
 
     // Add it to the index
-    index.add_path(&Path::new("OtherFile")).unwrap();
+    index.add_path(Path::new("OtherFile")).unwrap();
 
     // Still dirty
     {
@@ -481,7 +480,7 @@ fn repo_status_clean() {
     }
 
     // After removing from the index, it should be clean again
-    index.remove_path(&Path::new("OtherFile")).unwrap();
+    index.remove_path(Path::new("OtherFile")).unwrap();
 
     {
         let status = repo.statuses(Some(&mut opts)).unwrap();

--- a/tests/global_state.rs
+++ b/tests/global_state.rs
@@ -1,8 +1,6 @@
 //! Test for some global state set up by libgit2's `git_libgit2_init` function
 //! that need to be synchronized within a single process.
 
-#![allow(clippy::needless_borrows_for_generic_args)]
-
 use git2::opts;
 use git2::{ConfigLevel, IntoCString};
 
@@ -18,7 +16,7 @@ fn search_path() -> Result<(), Box<dyn std::error::Error>> {
 
     // Set
     unsafe {
-        opts::set_search_path(ConfigLevel::Global, &path)?;
+        opts::set_search_path(ConfigLevel::Global, path)?;
     }
     assert_eq!(
         unsafe { opts::get_search_path(ConfigLevel::Global) },


### PR DESCRIPTION
Commits are split by file and lint for ease of review.

Includes fixes to

* the inline `mod tests` in the `src/` directory files
* the utilities in `src/tests.rs`
* the tests in the `tests` directory

None of the issues required keeping the old code with an `#[expect]` attribute, they could all be fixed.