### PR TITLE
[Clippy] Fix clippy issues in examples code

### DIFF
--- a/examples/add.rs
+++ b/examples/add.rs
@@ -14,7 +14,6 @@
 
 #![deny(warnings)]
 #![allow(trivial_casts)]
-#![allow(clippy::needless_borrows_for_generic_args)]
 
 use clap::Parser;
 use git2::Repository;
@@ -36,7 +35,7 @@ struct Args {
 }
 
 fn run(args: &Args) -> Result<(), git2::Error> {
-    let repo = Repository::open(&Path::new("."))?;
+    let repo = Repository::open(Path::new("."))?;
     let mut index = repo.index()?;
 
     let cb = &mut |path: &Path, _matched_spec: &[u8]| -> i32 {

--- a/examples/clone.rs
+++ b/examples/clone.rs
@@ -13,7 +13,6 @@
  */
 
 #![deny(warnings)]
-#![allow(clippy::manual_checked_ops)]
 
 use clap::Parser;
 use git2::build::{CheckoutBuilder, RepoBuilder};
@@ -42,11 +41,7 @@ fn print(state: &mut State) {
     let stats = state.progress.as_ref().unwrap();
     let network_pct = (100 * stats.received_objects()) / stats.total_objects();
     let index_pct = (100 * stats.indexed_objects()) / stats.total_objects();
-    let co_pct = if state.total > 0 {
-        (100 * state.current) / state.total
-    } else {
-        0
-    };
+    let co_pct = (100 * state.current).checked_div(state.total).unwrap_or(0);
     let kbytes = stats.received_bytes() / 1024;
     if stats.received_objects() == stats.total_objects() {
         if !state.newline {

--- a/examples/clone.rs
+++ b/examples/clone.rs
@@ -13,7 +13,6 @@
  */
 
 #![deny(warnings)]
-#![allow(clippy::explicit_auto_deref)]
 #![allow(clippy::manual_checked_ops)]
 
 use clap::Parser;
@@ -95,7 +94,7 @@ fn run(args: &Args) -> Result<(), git2::Error> {
     cb.transfer_progress(|stats| {
         let mut state = state.borrow_mut();
         state.progress = Some(stats.to_owned());
-        print(&mut *state);
+        print(&mut state);
         true
     });
 
@@ -105,7 +104,7 @@ fn run(args: &Args) -> Result<(), git2::Error> {
         state.path = path.map(|p| p.to_path_buf());
         state.current = cur;
         state.total = total;
-        print(&mut *state);
+        print(&mut state);
     });
 
     let mut fo = FetchOptions::new();

--- a/examples/diff.rs
+++ b/examples/diff.rs
@@ -13,7 +13,6 @@
  */
 
 #![deny(warnings)]
-#![allow(clippy::explicit_auto_deref)]
 #![allow(clippy::needless_borrows_for_generic_args)]
 #![allow(clippy::redundant_closure)]
 
@@ -303,7 +302,7 @@ fn print_stats(diff: &Diff, args: &Args) -> Result<(), Error> {
         format |= git2::DiffStatsFormat::INCLUDE_SUMMARY;
     }
     let buf = stats.to_buf(format, 80)?;
-    print!("{}", str::from_utf8(&*buf).unwrap());
+    print!("{}", str::from_utf8(&buf).unwrap());
     Ok(())
 }
 

--- a/examples/diff.rs
+++ b/examples/diff.rs
@@ -13,7 +13,6 @@
  */
 
 #![deny(warnings)]
-#![allow(clippy::redundant_closure)]
 
 use clap::Parser;
 use git2::{Blob, Diff, DiffOptions, Error, Object, ObjectType, Oid, Repository};
@@ -323,7 +322,7 @@ fn resolve_blob<'a>(repo: &'a Repository, arg: Option<&String>) -> Result<Option
         Some(s) => Oid::from_str_ext(s, repo.object_format())?,
         None => return Ok(None),
     };
-    repo.find_blob(arg).map(|b| Some(b))
+    repo.find_blob(arg).map(Some)
 }
 
 impl Args {

--- a/examples/diff.rs
+++ b/examples/diff.rs
@@ -13,7 +13,6 @@
  */
 
 #![deny(warnings)]
-#![allow(clippy::needless_borrows_for_generic_args)]
 #![allow(clippy::redundant_closure)]
 
 use clap::Parser;
@@ -199,10 +198,10 @@ fn run(args: &Args) -> Result<(), Error> {
         opts.id_abbrev(amt);
     }
     if let Some(ref s) = args.flag_src_prefix {
-        opts.old_prefix(&s);
+        opts.old_prefix(s);
     }
     if let Some(ref s) = args.flag_dst_prefix {
-        opts.new_prefix(&s);
+        opts.new_prefix(s);
     }
     if let Some("diff-index") = args.flag_format.as_ref().map(|s| &s[..]) {
         opts.id_abbrev(40);

--- a/examples/init.rs
+++ b/examples/init.rs
@@ -13,7 +13,6 @@
  */
 
 #![deny(warnings)]
-#![allow(clippy::manual_strip)]
 
 use clap::Parser;
 use git2::ObjectFormat;
@@ -136,8 +135,8 @@ fn parse_shared(shared: &str) -> Result<RepositoryInitMode, Error> {
         "true" | "group" => Ok(git2::RepositoryInitMode::SHARED_GROUP),
         "all" | "world" => Ok(git2::RepositoryInitMode::SHARED_ALL),
         _ => {
-            if shared.starts_with('0') {
-                match u32::from_str_radix(&shared[1..], 8).ok() {
+            if let Some(after_zero) = shared.strip_prefix('0') {
+                match u32::from_str_radix(after_zero, 8).ok() {
                     Some(n) => Ok(RepositoryInitMode::from_bits_truncate(n)),
                     None => Err(Error::from_str("invalid octal value for --shared")),
                 }

--- a/examples/log.rs
+++ b/examples/log.rs
@@ -13,7 +13,6 @@
  */
 
 #![deny(warnings)]
-#![allow(clippy::needless_borrowed_reference)]
 
 use clap::Parser;
 use git2::{Commit, DiffOptions, ObjectType, Repository, Signature, Time};
@@ -227,7 +226,7 @@ fn log_message_matches(msg: Option<&str>, grep: &Option<String>) -> bool {
     match (grep, msg) {
         (&None, _) => true,
         (&Some(_), None) => false,
-        (&Some(ref s), Some(msg)) => msg.contains(s),
+        (Some(s), Some(msg)) => msg.contains(s),
     }
 }
 

--- a/examples/log.rs
+++ b/examples/log.rs
@@ -13,7 +13,6 @@
  */
 
 #![deny(warnings)]
-#![allow(clippy::manual_strip)]
 #![allow(clippy::needless_borrowed_reference)]
 
 use clap::Parser;
@@ -98,8 +97,8 @@ fn run(args: &Args) -> Result<(), Error> {
         },
     )?;
     for commit in &args.arg_commit {
-        if commit.starts_with('^') {
-            let obj = repo.revparse_single(&commit[1..])?;
+        if let Some(after_caret) = commit.strip_prefix('^') {
+            let obj = repo.revparse_single(after_caret)?;
             revwalk.hide(obj.id())?;
             continue;
         }

--- a/examples/pull.rs
+++ b/examples/pull.rs
@@ -12,7 +12,6 @@
  * <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
 
-#![allow(clippy::needless_borrow)]
 #![allow(clippy::needless_question_mark)]
 
 use clap::Parser;
@@ -186,7 +185,7 @@ fn do_merge<'a>(
     } else if analysis.0.is_normal() {
         // do a normal merge
         let head_commit = repo.reference_to_annotated_commit(&repo.head()?)?;
-        normal_merge(&repo, &head_commit, &fetch_commit)?;
+        normal_merge(repo, &head_commit, &fetch_commit)?;
     } else {
         println!("Nothing to do...");
     }
@@ -199,7 +198,7 @@ fn run(args: &Args) -> Result<(), git2::Error> {
     let repo = Repository::open(".")?;
     let mut remote = repo.find_remote(remote_name)?;
     let fetch_commit = do_fetch(&repo, &[remote_branch], &mut remote)?;
-    do_merge(&repo, &remote_branch, fetch_commit)
+    do_merge(&repo, remote_branch, fetch_commit)
 }
 
 fn main() {

--- a/examples/pull.rs
+++ b/examples/pull.rs
@@ -12,8 +12,6 @@
  * <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
 
-#![allow(clippy::needless_question_mark)]
-
 use clap::Parser;
 use git2::Repository;
 use std::io::{self, Write};
@@ -83,7 +81,7 @@ fn do_fetch<'a>(
     }
 
     let fetch_head = repo.find_reference("FETCH_HEAD")?;
-    Ok(repo.reference_to_annotated_commit(&fetch_head)?)
+    repo.reference_to_annotated_commit(&fetch_head)
 }
 
 fn fast_forward(

--- a/examples/rev-list.rs
+++ b/examples/rev-list.rs
@@ -14,7 +14,6 @@
  */
 
 #![deny(warnings)]
-#![allow(clippy::manual_strip)]
 
 use clap::Parser;
 use git2::{Error, Oid, Repository, Revwalk};
@@ -62,8 +61,8 @@ fn run(args: &Args) -> Result<(), git2::Error> {
         .map(|s| (s, true))
         .chain(args.arg_spec.iter().map(|s| (s, false)))
         .map(|(spec, hide)| {
-            if spec.starts_with('^') {
-                (&spec[1..], !hide)
+            if let Some(after_caret) = spec.strip_prefix('^') {
+                (after_caret, !hide)
             } else {
                 (&spec[..], hide)
             }

--- a/examples/tag.rs
+++ b/examples/tag.rs
@@ -13,7 +13,6 @@
  */
 
 #![deny(warnings)]
-#![allow(clippy::explicit_auto_deref)]
 
 use clap::Parser;
 use git2::{Commit, Error, Repository, Tag};
@@ -61,7 +60,7 @@ fn run(args: &Args) -> Result<(), Error> {
         println!(
             "Deleted tag '{}' (was {})",
             name,
-            str::from_utf8(&*id).unwrap()
+            str::from_utf8(&id).unwrap()
         );
     } else if args.flag_list {
         let pattern = args.arg_pattern.as_ref().map(|s| &s[..]).unwrap_or("*");


### PR DESCRIPTION
Commits are split by file and lint for ease of review.

Covers the code in the `examples/` directory.

None of the issues required keeping the old code with an `#[expect]` attribute, they could all be fixed.