### PR TITLE
`RepoBuilder`: clean up documentation indentation

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -22,30 +22,30 @@ use crate::{CheckoutNotificationType, DiffFile, FileMode, Remote};
 /// use std::env;
 /// use std::path::Path;
 ///
-///   // Prepare callbacks.
-///   let mut callbacks = RemoteCallbacks::new();
-///   callbacks.credentials(|_url, username_from_url, _allowed_types| {
-///     Cred::ssh_key(
-///       username_from_url.unwrap(),
-///       None,
-///       Path::new(&format!("{}/.ssh/id_rsa", env::var("HOME").unwrap())),
-///       None,
-///     )
-///   });
+///  // Prepare callbacks.
+///  let mut callbacks = RemoteCallbacks::new();
+///  callbacks.credentials(|_url, username_from_url, _allowed_types| {
+///      Cred::ssh_key(
+///          username_from_url.unwrap(),
+///          None,
+///          Path::new(&format!("{}/.ssh/id_rsa", env::var("HOME").unwrap())),
+///          None,
+///      )
+///  });
 ///
-///   // Prepare fetch options.
-///   let mut fo = git2::FetchOptions::new();
-///   fo.remote_callbacks(callbacks);
+///  // Prepare fetch options.
+///  let mut fo = git2::FetchOptions::new();
+///  fo.remote_callbacks(callbacks);
 ///
-///   // Prepare builder.
-///   let mut builder = git2::build::RepoBuilder::new();
-///   builder.fetch_options(fo);
+///  // Prepare builder.
+///  let mut builder = git2::build::RepoBuilder::new();
+///  builder.fetch_options(fo);
 ///
-///   // Clone the project.
-///   builder.clone(
-///     "git@github.com:rust-lang/git2-rs.git",
-///     Path::new("/tmp/git2-rs"),
-///   );
+///  // Clone the project.
+///  builder.clone(
+///      "git@github.com:rust-lang/git2-rs.git",
+///      Path::new("/tmp/git2-rs"),
+///  );
 /// ```
 pub struct RepoBuilder<'cb> {
     bare: bool,


### PR DESCRIPTION
Don't randomly indent everything other than `use` statements with a space; indent parameters with 4 spaces per level rather than 2.