### PR TITLE
[Clippy] Fix clippy issues in libgit2-sys crate

### DIFF
--- a/libgit2-sys/build.rs
+++ b/libgit2-sys/build.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::needless_borrows_for_generic_args)]
 #![allow(clippy::unnecessary_map_or)]
 
 use std::env;
@@ -123,7 +122,7 @@ The build is now aborting. To disable, unset the variable or use `LIBGIT2_NO_VEN
 
     if !Path::new("libgit2/src").exists() {
         let _ = Command::new("git")
-            .args(&["submodule", "update", "--init", "libgit2"])
+            .args(["submodule", "update", "--init", "libgit2"])
             .status();
     }
 

--- a/libgit2-sys/build.rs
+++ b/libgit2-sys/build.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::unnecessary_map_or)]
-
 use std::env;
 use std::fs;
 use std::io;
@@ -95,7 +93,7 @@ fn main() {
     // dependency graph activates `vendored` feature, there is no way to revert
     // it back. This env var serves as a workaround for this purpose.
     println!("cargo:rerun-if-env-changed=LIBGIT2_NO_VENDOR");
-    let forced_no_vendor = env::var_os("LIBGIT2_NO_VENDOR").map_or(false, |s| s != "0");
+    let forced_no_vendor = env::var_os("LIBGIT2_NO_VENDOR").is_some_and(|s| s != "0");
 
     if forced_no_vendor {
         if try_system_libgit2(unstable_sha256).is_err() {

--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -1,6 +1,5 @@
 #![doc(html_root_url = "https://docs.rs/libgit2-sys/0.18")]
 #![allow(non_camel_case_types, unused_extern_crates)]
-#![allow(clippy::legacy_numeric_constants)]
 
 // This is required to link libz when libssh2-sys is not included.
 extern crate libz_sys as libz;
@@ -2085,7 +2084,7 @@ pub type git_commit_create_cb = Option<
     ) -> c_int,
 >;
 
-pub const GIT_REBASE_NO_OPERATION: usize = usize::max_value();
+pub const GIT_REBASE_NO_OPERATION: usize = usize::MAX;
 
 #[repr(C)]
 pub struct git_rebase_options {


### PR DESCRIPTION
Commits are split by file and lint for ease of review.

None of the issues required keeping the old code with an `#[expect]` attribute, they could all be fixed.