### PR TITLE
Reduce the amount of code in `unsafe` blocks (2)

### DIFF
--- a/src/apply.rs
+++ b/src/apply.rs
@@ -47,10 +47,10 @@ type HunkCB<'a> = dyn FnMut(Option<DiffHunk<'_>>) -> bool + 'a;
 type DeltaCB<'a> = dyn FnMut(Option<DiffDelta<'_>>) -> bool + 'a;
 
 extern "C" fn delta_cb_c(delta: *const raw::git_diff_delta, data: *mut c_void) -> c_int {
-    panic::wrap(|| unsafe {
-        let delta = Binding::from_raw_opt(delta as *mut _);
+    panic::wrap(|| {
+        let delta = unsafe { Binding::from_raw_opt(delta as *mut _) };
 
-        let payload = &mut *(data as *mut ApplyOptions<'_>);
+        let payload = unsafe { &mut *(data as *mut ApplyOptions<'_>) };
         let callback = match payload.delta_cb {
             Some(ref mut c) => c,
             None => return -1,
@@ -67,10 +67,10 @@ extern "C" fn delta_cb_c(delta: *const raw::git_diff_delta, data: *mut c_void) -
 }
 
 extern "C" fn hunk_cb_c(hunk: *const raw::git_diff_hunk, data: *mut c_void) -> c_int {
-    panic::wrap(|| unsafe {
-        let hunk = Binding::from_raw_opt(hunk);
+    panic::wrap(|| {
+        let hunk = unsafe { Binding::from_raw_opt(hunk) };
 
-        let payload = &mut *(data as *mut ApplyOptions<'_>);
+        let payload = unsafe { &mut *(data as *mut ApplyOptions<'_>) };
         let callback = match payload.hunk_cb {
             Some(ref mut c) => c,
             None => return -1,

--- a/src/blame.rs
+++ b/src/blame.rs
@@ -245,15 +245,14 @@ impl Default for BlameOptions {
 impl BlameOptions {
     /// Initialize options
     pub fn new() -> BlameOptions {
-        unsafe {
-            let mut raw: raw::git_blame_options = mem::zeroed();
-            assert_eq!(
-                raw::git_blame_init_options(&mut raw, raw::GIT_BLAME_OPTIONS_VERSION),
-                0
-            );
+        let mut raw: raw::git_blame_options = unsafe { mem::zeroed() };
 
-            Binding::from_raw(&raw as *const _ as *mut _)
-        }
+        assert_eq!(
+            unsafe { raw::git_blame_init_options(&mut raw, raw::GIT_BLAME_OPTIONS_VERSION) },
+            0
+        );
+
+        unsafe { Binding::from_raw(&raw as *const _ as *mut _) }
     }
 
     fn flag(&mut self, opt: u32, val: bool) -> &mut BlameOptions {

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -122,10 +122,8 @@ impl<'repo> Drop for BlobWriter<'repo> {
     fn drop(&mut self) {
         // We need cleanup in case the stream has not been committed
         if self.need_cleanup {
-            unsafe {
-                if let Some(f) = (*self.raw).free {
-                    f(self.raw)
-                }
+            if let Some(f) = unsafe { (*self.raw).free } {
+                f(self.raw)
             }
         }
     }

--- a/src/build.rs
+++ b/src/build.rs
@@ -296,23 +296,21 @@ extern "C" fn remote_create_cb(
     url: *const c_char,
     payload: *mut c_void,
 ) -> c_int {
-    unsafe {
-        let repo = Repository::from_raw(repo);
-        let code = panic::wrap(|| {
-            let name = CStr::from_ptr(name).to_str().unwrap();
-            let url = CStr::from_ptr(url).to_str().unwrap();
-            let f = payload as *mut Box<RemoteCreate<'_>>;
-            match (*f)(&repo, name, url) {
-                Ok(remote) => {
-                    *out = crate::remote::remote_into_raw(remote);
-                    0
-                }
-                Err(e) => e.raw_code(),
+    let repo = unsafe { Repository::from_raw(repo) };
+    let code = panic::wrap(|| {
+        let name = unsafe { CStr::from_ptr(name) }.to_str().unwrap();
+        let url = unsafe { CStr::from_ptr(url) }.to_str().unwrap();
+        let f = payload as *mut Box<RemoteCreate<'_>>;
+        match unsafe { (*f)(&repo, name, url) } {
+            Ok(remote) => {
+                unsafe { *out = crate::remote::remote_into_raw(remote) };
+                0
             }
-        });
-        mem::forget(repo);
-        code.unwrap_or(-1)
-    }
+            Err(e) => e.raw_code(),
+        }
+    });
+    mem::forget(repo);
+    code.unwrap_or(-1)
 }
 
 impl<'cb> Default for CheckoutBuilder<'cb> {
@@ -638,8 +636,8 @@ extern "C" fn progress_cb(
     total: size_t,
     data: *mut c_void,
 ) {
-    panic::wrap(|| unsafe {
-        let payload = &mut *(data as *mut CheckoutBuilder<'_>);
+    panic::wrap(|| {
+        let payload = unsafe { &mut *(data as *mut CheckoutBuilder<'_>) };
         let callback = match payload.progress {
             Some(ref mut c) => c,
             None => return,
@@ -647,7 +645,7 @@ extern "C" fn progress_cb(
         let path = if path.is_null() {
             None
         } else {
-            Some(util::bytes2path(CStr::from_ptr(path).to_bytes()))
+            Some(util::bytes2path(unsafe { CStr::from_ptr(path) }.to_bytes()))
         };
         callback(path, completed as usize, total as usize)
     });
@@ -662,8 +660,8 @@ extern "C" fn notify_cb(
     data: *mut c_void,
 ) -> c_int {
     // pack callback etc
-    panic::wrap(|| unsafe {
-        let payload = &mut *(data as *mut CheckoutBuilder<'_>);
+    panic::wrap(|| {
+        let payload = unsafe { &mut *(data as *mut CheckoutBuilder<'_>) };
         let callback = match payload.notify {
             Some(ref mut c) => c,
             None => return 0,
@@ -671,25 +669,25 @@ extern "C" fn notify_cb(
         let path = if path.is_null() {
             None
         } else {
-            Some(util::bytes2path(CStr::from_ptr(path).to_bytes()))
+            Some(util::bytes2path(unsafe { CStr::from_ptr(path) }.to_bytes()))
         };
 
         let baseline = if baseline.is_null() {
             None
         } else {
-            Some(DiffFile::from_raw(baseline))
+            Some(unsafe { DiffFile::from_raw(baseline) })
         };
 
         let target = if target.is_null() {
             None
         } else {
-            Some(DiffFile::from_raw(target))
+            Some(unsafe { DiffFile::from_raw(target) })
         };
 
         let workdir = if workdir.is_null() {
             None
         } else {
-            Some(DiffFile::from_raw(workdir))
+            Some(unsafe { DiffFile::from_raw(workdir) })
         };
 
         let why = CheckoutNotificationType::from_bits_truncate(why as u32);

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -288,8 +288,8 @@ impl<'repo> Commit<'repo> {
     ///
     /// Use the `parents` iterator to return an iterator over all parents.
     pub fn parent(&self, i: usize) -> Result<Commit<'repo>, Error> {
+        let mut raw = ptr::null_mut();
         unsafe {
-            let mut raw = ptr::null_mut();
             try_call!(raw::git_commit_parent(
                 &mut raw,
                 &*self.raw,

--- a/src/message.rs
+++ b/src/message.rs
@@ -201,8 +201,8 @@ impl DoubleEndedIterator for MessageTrailersStrsIterator<'_> {
 
 fn to_str_tuple(trailers: &MessageTrailers, index: usize) -> (&str, &str) {
     let (rkey, rvalue) = to_raw_tuple(trailers, index);
-    let key = unsafe { CStr::from_ptr(rkey).to_str().unwrap() };
-    let value = unsafe { CStr::from_ptr(rvalue).to_str().unwrap() };
+    let key = unsafe { CStr::from_ptr(rkey) }.to_str().unwrap();
+    let value = unsafe { CStr::from_ptr(rvalue) }.to_str().unwrap();
     (key, value)
 }
 
@@ -243,8 +243,8 @@ impl DoubleEndedIterator for MessageTrailersBytesIterator<'_> {
 
 fn to_bytes_tuple(trailers: &MessageTrailers, index: usize) -> (&[u8], &[u8]) {
     let (rkey, rvalue) = to_raw_tuple(trailers, index);
-    let key = unsafe { CStr::from_ptr(rkey).to_bytes() };
-    let value = unsafe { CStr::from_ptr(rvalue).to_bytes() };
+    let key = unsafe { CStr::from_ptr(rkey) }.to_bytes();
+    let value = unsafe { CStr::from_ptr(rvalue) }.to_bytes();
     (key, value)
 }
 

--- a/src/object.rs
+++ b/src/object.rs
@@ -157,11 +157,9 @@ impl<'repo> Object<'repo> {
     fn cast_into<T>(self, kind: ObjectType) -> Result<T, Object<'repo>> {
         assert_eq!(mem::size_of_val(&self), mem::size_of::<T>());
         if self.kind() == Some(kind) {
-            Ok(unsafe {
-                let other = ptr::read(&self as *const _ as *const T);
-                mem::forget(self);
-                other
-            })
+            let other = unsafe { ptr::read(&self as *const _ as *const T) };
+            mem::forget(self);
+            Ok(other)
         } else {
             Err(self)
         }
@@ -177,11 +175,9 @@ impl<'repo> CastOrPanic for Object<'repo> {
     fn cast_or_panic<T>(self, kind: ObjectType) -> T {
         assert_eq!(mem::size_of_val(&self), mem::size_of::<T>());
         if self.kind() == Some(kind) {
-            unsafe {
-                let other = ptr::read(&self as *const _ as *const T);
-                mem::forget(self);
-                other
-            }
+            let other = unsafe { ptr::read(&self as *const _ as *const T) };
+            mem::forget(self);
+            other
         } else {
             let buf;
             let akind = match self.kind() {
@@ -204,11 +200,9 @@ impl<'repo> CastOrPanic for Object<'repo> {
 impl<'repo> Clone for Object<'repo> {
     fn clone(&self) -> Object<'repo> {
         let mut raw = ptr::null_mut();
-        unsafe {
-            let rc = raw::git_object_dup(&mut raw, self.raw);
-            assert_eq!(rc, 0);
-            Binding::from_raw(raw)
-        }
+        let rc = unsafe { raw::git_object_dup(&mut raw, self.raw) };
+        assert_eq!(rc, 0);
+        unsafe { Binding::from_raw(raw) }
     }
 }
 

--- a/src/odb.rs
+++ b/src/odb.rs
@@ -167,8 +167,8 @@ impl<'repo> Odb<'repo> {
 
     /// Write an object to the database.
     pub fn write(&self, kind: ObjectType, data: &[u8]) -> Result<Oid, Error> {
+        let mut out = crate::util::zeroed_raw_oid();
         unsafe {
-            let mut out = crate::util::zeroed_raw_oid();
             try_call!(raw::git_odb_write(
                 &mut out,
                 self.raw,
@@ -471,14 +471,11 @@ pub struct OdbPackwriter<'repo> {
 impl<'repo> OdbPackwriter<'repo> {
     /// Finish writing the packfile
     pub fn commit(&mut self) -> Result<i32, Error> {
-        let res;
-        unsafe {
-            let writepack = &*self.raw;
-            res = match writepack.commit {
-                Some(commit) => commit(self.raw, &mut self.progress),
-                None => -1,
-            };
-        }
+        let writepack = unsafe { &*self.raw };
+        let res = match writepack.commit {
+            Some(commit) => unsafe { commit(self.raw, &mut self.progress) },
+            None => -1,
+        };
 
         if res < 0 {
             Err(Error::last_error(res))
@@ -505,14 +502,11 @@ impl<'repo> io::Write for OdbPackwriter<'repo> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let ptr = buf.as_ptr() as *mut c_void;
         let len = buf.len();
-        let res;
-        unsafe {
-            let writepack = &*self.raw;
-            res = match writepack.append {
-                Some(append) => append(self.raw, ptr, len, &mut self.progress),
-                None => -1,
-            };
-        }
+        let writepack = unsafe { &*self.raw };
+        let res = match writepack.append {
+            Some(append) => append(self.raw, ptr, len, &mut self.progress),
+            None => -1,
+        };
         if res < 0 {
             Err(io::Error::other("Write error"))
         } else {
@@ -526,14 +520,12 @@ impl<'repo> io::Write for OdbPackwriter<'repo> {
 
 impl<'repo> Drop for OdbPackwriter<'repo> {
     fn drop(&mut self) {
-        unsafe {
-            let writepack = &*self.raw;
-            if let Some(free) = writepack.free {
-                free(self.raw);
-            };
+        let writepack = unsafe { &*self.raw };
+        if let Some(free) = writepack.free {
+            unsafe { free(self.raw) };
+        };
 
-            drop(Box::from_raw(self.progress_payload_ptr));
-        }
+        drop(unsafe { Box::from_raw(self.progress_payload_ptr) });
     }
 }
 
@@ -544,11 +536,11 @@ struct ForeachCbData<'a> {
 }
 
 extern "C" fn foreach_cb(id: *const raw::git_oid, payload: *mut c_void) -> c_int {
-    panic::wrap(|| unsafe {
-        let data = &mut *(payload as *mut ForeachCbData<'_>);
+    panic::wrap(|| {
+        let data = unsafe { &mut *(payload as *mut ForeachCbData<'_>) };
         let res = {
             let callback = &mut data.callback;
-            callback(&Binding::from_raw(id))
+            callback(unsafe { &Binding::from_raw(id) })
         };
 
         if res {
@@ -564,15 +556,15 @@ pub(crate) extern "C" fn write_pack_progress_cb(
     stats: *const raw::git_indexer_progress,
     payload: *mut c_void,
 ) -> c_int {
-    let ok = panic::wrap(|| unsafe {
-        let payload = &mut *(payload as *mut OdbPackwriterCb<'_>);
+    let ok = panic::wrap(|| {
+        let payload = unsafe { &mut *(payload as *mut OdbPackwriterCb<'_>) };
 
         let callback = match payload.cb {
             Some(ref mut cb) => cb,
             None => return true,
         };
 
-        let progress: Progress<'_> = Binding::from_raw(stats);
+        let progress: Progress<'_> = unsafe { Binding::from_raw(stats) };
         callback(progress)
     });
     if ok == Some(true) {

--- a/src/oid_array.rs
+++ b/src/oid_array.rs
@@ -21,11 +21,11 @@ impl Deref for OidArray {
     type Target = [Oid];
 
     fn deref(&self) -> &[Oid] {
-        unsafe {
-            debug_assert_eq!(mem::size_of::<Oid>(), mem::size_of_val(&*self.raw.ids));
-
-            slice::from_raw_parts(self.raw.ids as *const Oid, self.raw.count as usize)
-        }
+        debug_assert_eq!(
+            mem::size_of::<Oid>(),
+            mem::size_of_val(unsafe { &*self.raw.ids })
+        );
+        unsafe { slice::from_raw_parts(self.raw.ids as *const Oid, self.raw.count as usize) }
     }
 }
 

--- a/src/packbuilder.rs
+++ b/src/packbuilder.rs
@@ -159,8 +159,8 @@ impl<'repo> PackBuilder<'repo> {
                 None,
                 ptr::null_mut()
             ));
-            self._progress = None;
         }
+        self._progress = None;
         Ok(())
     }
 
@@ -257,15 +257,13 @@ impl Binding for PackBuilderStage {
 }
 
 extern "C" fn foreach_c(buf: *const c_void, size: size_t, data: *mut c_void) -> c_int {
-    let r;
-    unsafe {
-        let buf = slice::from_raw_parts(buf as *const u8, size as usize);
+    let buf = unsafe { slice::from_raw_parts(buf as *const u8, size as usize) };
 
-        r = panic::wrap(|| {
-            let data = data as *mut &mut ForEachCb<'_>;
-            (*data)(buf)
-        });
-    }
+    let r = panic::wrap(|| {
+        let data = data as *mut &mut ForEachCb<'_>;
+        unsafe { (*data)(buf) }
+    });
+
     if r == Some(true) {
         0
     } else {
@@ -279,15 +277,13 @@ extern "C" fn progress_c(
     total: c_uint,
     data: *mut c_void,
 ) -> c_int {
-    let r;
-    unsafe {
-        let stage = Binding::from_raw(stage);
+    let stage = unsafe { Binding::from_raw(stage) };
 
-        r = panic::wrap(|| {
-            let data = data as *mut Box<ProgressCb<'_>>;
-            (*data)(stage, current, total)
-        });
-    }
+    let r = panic::wrap(|| {
+        let data = data as *mut Box<ProgressCb<'_>>;
+        unsafe { (*data)(stage, current, total) }
+    });
+
     if r == Some(true) {
         0
     } else {

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -429,11 +429,9 @@ impl<'repo> Eq for Reference<'repo> {}
 impl<'repo> Clone for Reference<'repo> {
     fn clone(&self) -> Reference<'repo> {
         let mut raw = ptr::null_mut();
-        unsafe {
-            let rc = raw::git_reference_dup(&mut raw, self.raw);
-            assert_eq!(rc, 0);
-            Binding::from_raw(raw)
-        }
+        let rc = unsafe { raw::git_reference_dup(&mut raw, self.raw) };
+        assert_eq!(rc, 0);
+        unsafe { Binding::from_raw(raw) }
     }
 }
 

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -403,11 +403,11 @@ impl<'repo> Remote<'repo> {
         let mut base = ptr::null_mut();
         unsafe {
             try_call!(raw::git_remote_ls(&mut base, &mut size, self.raw));
-            assert_eq!(
-                mem::size_of::<RemoteHead<'_>>(),
-                mem::size_of::<*const raw::git_remote_head>()
-            );
         }
+        assert_eq!(
+            mem::size_of::<RemoteHead<'_>>(),
+            mem::size_of::<*const raw::git_remote_head>()
+        );
         if base.is_null() {
             // We cannot use slice::from_raw_parts() since that requires
             // that the pointer be non-null, but that is fine since the size
@@ -440,8 +440,8 @@ impl<'repo> Remote<'repo> {
 
     /// Get the remote's list of fetch refspecs
     pub fn fetch_refspecs(&self) -> Result<StringArray, Error> {
+        let mut raw: raw::git_strarray = unsafe { mem::zeroed() };
         unsafe {
-            let mut raw: raw::git_strarray = mem::zeroed();
             try_call!(raw::git_remote_get_fetch_refspecs(&mut raw, self.raw));
             Ok(StringArray::from_raw(raw))
         }
@@ -449,8 +449,8 @@ impl<'repo> Remote<'repo> {
 
     /// Get the remote's list of push refspecs
     pub fn push_refspecs(&self) -> Result<StringArray, Error> {
+        let mut raw: raw::git_strarray = unsafe { mem::zeroed() };
         unsafe {
-            let mut raw: raw::git_strarray = mem::zeroed();
             try_call!(raw::git_remote_get_push_refspecs(&mut raw, self.raw));
             Ok(StringArray::from_raw(raw))
         }

--- a/src/remote_callbacks.rs
+++ b/src/remote_callbacks.rs
@@ -260,12 +260,13 @@ impl<'a> Binding for RemoteCallbacks<'a> {
 
     fn raw(&self) -> raw::git_remote_callbacks {
         let mut callbacks: raw::git_remote_callbacks = unsafe { mem::zeroed() };
-        unsafe {
-            assert_eq!(
-                raw::git_remote_init_callbacks(&mut callbacks, raw::GIT_REMOTE_CALLBACKS_VERSION),
-                0
-            );
-        }
+        assert_eq!(
+            unsafe {
+                raw::git_remote_init_callbacks(&mut callbacks, raw::GIT_REMOTE_CALLBACKS_VERSION)
+            },
+            0
+        );
+
         if self.progress.is_some() {
             callbacks.transfer_progress = Some(transfer_progress_cb);
         }
@@ -311,16 +312,18 @@ extern "C" fn credentials_cb(
     allowed_types: c_uint,
     payload: *mut c_void,
 ) -> c_int {
-    let ok = panic::wrap(|| unsafe {
-        let payload = &mut *(payload as *mut RemoteCallbacks<'_>);
+    let ok = panic::wrap(|| {
+        let payload = unsafe { &mut *(payload as *mut RemoteCallbacks<'_>) };
         let callback = payload
             .credentials
             .as_mut()
             .ok_or(raw::GIT_PASSTHROUGH as c_int)?;
-        *ret = ptr::null_mut();
-        let url = str::from_utf8(CStr::from_ptr(url).to_bytes())
+        unsafe {
+            *ret = ptr::null_mut();
+        }
+        let url = str::from_utf8(unsafe { CStr::from_ptr(url) }.to_bytes())
             .map_err(|_| raw::GIT_PASSTHROUGH as c_int)?;
-        let username_from_url = match crate::opt_bytes(&url, username_from_url) {
+        let username_from_url = match unsafe { crate::opt_bytes(&url, username_from_url) } {
             Some(username) => {
                 Some(str::from_utf8(username).map_err(|_| raw::GIT_PASSTHROUGH as c_int)?)
             }
@@ -329,7 +332,7 @@ extern "C" fn credentials_cb(
 
         let cred_type = CredentialType::from_bits_truncate(allowed_types as u32);
 
-        callback(url, username_from_url, cred_type).map_err(|e| e.raw_set_git_error())
+        callback(url, username_from_url, cred_type).map_err(|e| unsafe { e.raw_set_git_error() })
     });
     match ok {
         Some(Ok(cred)) => {
@@ -353,13 +356,13 @@ extern "C" fn transfer_progress_cb(
     stats: *const raw::git_indexer_progress,
     payload: *mut c_void,
 ) -> c_int {
-    let ok = panic::wrap(|| unsafe {
-        let payload = &mut *(payload as *mut RemoteCallbacks<'_>);
+    let ok = panic::wrap(|| {
+        let payload = unsafe { &mut *(payload as *mut RemoteCallbacks<'_>) };
         let callback = match payload.progress {
             Some(ref mut c) => c,
             None => return true,
         };
-        let progress = Binding::from_raw(stats);
+        let progress = unsafe { Binding::from_raw(stats) };
         callback(progress)
     });
     if ok == Some(true) {
@@ -370,13 +373,13 @@ extern "C" fn transfer_progress_cb(
 }
 
 extern "C" fn sideband_progress_cb(str: *const c_char, len: c_int, payload: *mut c_void) -> c_int {
-    let ok = panic::wrap(|| unsafe {
-        let payload = &mut *(payload as *mut RemoteCallbacks<'_>);
+    let ok = panic::wrap(|| {
+        let payload = unsafe { &mut *(payload as *mut RemoteCallbacks<'_>) };
         let callback = match payload.sideband_progress {
             Some(ref mut c) => c,
             None => return true,
         };
-        let buf = slice::from_raw_parts(str as *const u8, len as usize);
+        let buf = unsafe { slice::from_raw_parts(str as *const u8, len as usize) };
         callback(buf)
     });
     if ok == Some(true) {
@@ -392,15 +395,15 @@ extern "C" fn update_tips_cb(
     b: *const raw::git_oid,
     data: *mut c_void,
 ) -> c_int {
-    let ok = panic::wrap(|| unsafe {
-        let payload = &mut *(data as *mut RemoteCallbacks<'_>);
+    let ok = panic::wrap(|| {
+        let payload = unsafe { &mut *(data as *mut RemoteCallbacks<'_>) };
         let callback = match payload.update_tips {
             Some(ref mut c) => c,
             None => return true,
         };
-        let refname = str::from_utf8(CStr::from_ptr(refname).to_bytes()).unwrap();
-        let a = Binding::from_raw(a);
-        let b = Binding::from_raw(b);
+        let refname = str::from_utf8(unsafe { CStr::from_ptr(refname) }.to_bytes()).unwrap();
+        let a = unsafe { Binding::from_raw(a) };
+        let b = unsafe { Binding::from_raw(b) };
         callback(refname, a, b)
     });
     if ok == Some(true) {
@@ -416,14 +419,14 @@ extern "C" fn certificate_check_cb(
     hostname: *const c_char,
     data: *mut c_void,
 ) -> c_int {
-    let ok = panic::wrap(|| unsafe {
-        let payload = &mut *(data as *mut RemoteCallbacks<'_>);
+    let ok = panic::wrap(|| {
+        let payload = unsafe { &mut *(data as *mut RemoteCallbacks<'_>) };
         let callback = match payload.certificate_check {
             Some(ref mut c) => c,
             None => return Ok(CertificateCheckStatus::CertificatePassthrough),
         };
-        let cert = Binding::from_raw(cert);
-        let hostname = str::from_utf8(CStr::from_ptr(hostname).to_bytes()).unwrap();
+        let cert = unsafe { Binding::from_raw(cert) };
+        let hostname = str::from_utf8(unsafe { CStr::from_ptr(hostname) }.to_bytes()).unwrap();
         callback(&cert, hostname)
     });
     match ok {
@@ -442,21 +445,21 @@ extern "C" fn push_update_reference_cb(
     status: *const c_char,
     data: *mut c_void,
 ) -> c_int {
-    panic::wrap(|| unsafe {
-        let payload = &mut *(data as *mut RemoteCallbacks<'_>);
+    panic::wrap(|| {
+        let payload = unsafe { &mut *(data as *mut RemoteCallbacks<'_>) };
         let callback = match payload.push_update_reference {
             Some(ref mut c) => c,
             None => return 0,
         };
-        let refname = str::from_utf8(CStr::from_ptr(refname).to_bytes()).unwrap();
+        let refname = str::from_utf8(unsafe { CStr::from_ptr(refname) }.to_bytes()).unwrap();
         let status = if status.is_null() {
             None
         } else {
-            Some(str::from_utf8(CStr::from_ptr(status).to_bytes()).unwrap())
+            Some(str::from_utf8(unsafe { CStr::from_ptr(status) }.to_bytes()).unwrap())
         };
         match callback(refname, status) {
             Ok(()) => 0,
-            Err(e) => e.raw_set_git_error(),
+            Err(e) => unsafe { e.raw_set_git_error() },
         }
     })
     .unwrap_or(-1)
@@ -468,8 +471,8 @@ extern "C" fn push_transfer_progress_cb(
     bytes: size_t,
     data: *mut c_void,
 ) -> c_int {
-    panic::wrap(|| unsafe {
-        let payload = &mut *(data as *mut RemoteCallbacks<'_>);
+    panic::wrap(|| {
+        let payload = unsafe { &mut *(data as *mut RemoteCallbacks<'_>) };
         let callback = match payload.push_progress {
             Some(ref mut c) => c,
             None => return 0,
@@ -488,14 +491,14 @@ extern "C" fn pack_progress_cb(
     total: c_uint,
     data: *mut c_void,
 ) -> c_int {
-    panic::wrap(|| unsafe {
-        let payload = &mut *(data as *mut RemoteCallbacks<'_>);
+    panic::wrap(|| {
+        let payload = unsafe { &mut *(data as *mut RemoteCallbacks<'_>) };
         let callback = match payload.pack_progress {
             Some(ref mut c) => c,
             None => return 0,
         };
 
-        let stage = Binding::from_raw(stage);
+        let stage = unsafe { Binding::from_raw(stage) };
 
         callback(stage, current as usize, total as usize);
 
@@ -509,17 +512,17 @@ extern "C" fn push_negotiation_cb(
     len: size_t,
     payload: *mut c_void,
 ) -> c_int {
-    panic::wrap(|| unsafe {
-        let payload = &mut *(payload as *mut RemoteCallbacks<'_>);
+    panic::wrap(|| {
+        let payload = unsafe { &mut *(payload as *mut RemoteCallbacks<'_>) };
         let callback = match payload.push_negotiation {
             Some(ref mut c) => c,
             None => return 0,
         };
 
-        let updates = slice::from_raw_parts(updates as *mut PushUpdate<'_>, len);
+        let updates = unsafe { slice::from_raw_parts(updates as *mut PushUpdate<'_>, len) };
         match callback(updates) {
             Ok(()) => 0,
-            Err(e) => e.raw_set_git_error(),
+            Err(e) => unsafe { e.raw_set_git_error() },
         }
     })
     .unwrap_or(-1)

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -49,11 +49,11 @@ struct MergeheadForeachCbData<'a> {
 }
 
 extern "C" fn mergehead_foreach_cb(oid: *const raw::git_oid, payload: *mut c_void) -> c_int {
-    panic::wrap(|| unsafe {
-        let data = &mut *(payload as *mut MergeheadForeachCbData<'_>);
+    panic::wrap(|| {
+        let data = unsafe { &mut *(payload as *mut MergeheadForeachCbData<'_>) };
         let res = {
             let callback = &mut data.callback;
-            callback(&Binding::from_raw(oid))
+            callback(unsafe { &Binding::from_raw(oid) })
         };
 
         if res {
@@ -72,8 +72,8 @@ extern "C" fn fetchhead_foreach_cb(
     is_merge: c_uint,
     payload: *mut c_void,
 ) -> c_int {
-    panic::wrap(|| unsafe {
-        let data = &mut *(payload as *mut FetchheadForeachCbData<'_>);
+    panic::wrap(|| {
+        let data = unsafe { &mut *(payload as *mut FetchheadForeachCbData<'_>) };
         let res = {
             let callback = &mut data.callback;
 
@@ -81,9 +81,9 @@ extern "C" fn fetchhead_foreach_cb(
             assert!(!remote_url.is_null());
             assert!(!oid.is_null());
 
-            let ref_name = str::from_utf8(CStr::from_ptr(ref_name).to_bytes()).unwrap();
-            let remote_url = CStr::from_ptr(remote_url).to_bytes();
-            let oid = Binding::from_raw(oid);
+            let ref_name = str::from_utf8(unsafe { CStr::from_ptr(ref_name) }.to_bytes()).unwrap();
+            let remote_url = unsafe { CStr::from_ptr(remote_url) }.to_bytes();
+            let oid = unsafe { Binding::from_raw(oid) };
             let is_merge = is_merge == 1;
 
             callback(ref_name, remote_url, &oid, is_merge)
@@ -786,8 +786,8 @@ impl Repository {
         kind: ResetType,
         checkout: Option<&mut CheckoutBuilder<'_>>,
     ) -> Result<(), Error> {
+        let mut opts: raw::git_checkout_options = unsafe { mem::zeroed() };
         unsafe {
-            let mut opts: raw::git_checkout_options = mem::zeroed();
             try_call!(raw::git_checkout_init_options(
                 &mut opts,
                 raw::GIT_CHECKOUT_OPTIONS_VERSION
@@ -968,15 +968,13 @@ impl Repository {
             name: *const c_char,
             data: *mut c_void,
         ) -> c_int {
-            unsafe {
-                let data = &mut *(data as *mut Data<'_, '_>);
-                let mut raw = ptr::null_mut();
-                let rc = raw::git_submodule_lookup(&mut raw, data.repo.raw(), name);
-                if rc != 0 {
-                    return rc;
-                }
-                data.ret.push(Binding::from_raw(raw));
+            let data = unsafe { &mut *(data as *mut Data<'_, '_>) };
+            let mut raw = ptr::null_mut();
+            let rc = unsafe { raw::git_submodule_lookup(&mut raw, data.repo.raw(), name) };
+            if rc != 0 {
+                return rc;
             }
+            data.ret.push(unsafe { Binding::from_raw(raw) });
             0
         }
     }
@@ -1156,9 +1154,9 @@ impl Repository {
     /// the blob.
     pub fn blob(&self, data: &[u8]) -> Result<Oid, Error> {
         let mut raw = crate::util::zeroed_raw_oid();
+        let ptr = data.as_ptr() as *const c_void;
+        let len = data.len() as size_t;
         unsafe {
-            let ptr = data.as_ptr() as *const c_void;
-            let len = data.len() as size_t;
             try_call!(raw::git_blob_create_frombuffer(
                 &mut raw,
                 self.raw(),
@@ -1487,8 +1485,8 @@ impl Repository {
 
     /// Creates an `AnnotatedCommit` from the given commit id.
     pub fn find_annotated_commit(&self, id: Oid) -> Result<AnnotatedCommit<'_>, Error> {
+        let mut raw = ptr::null_mut();
         unsafe {
-            let mut raw = ptr::null_mut();
             try_call!(raw::git_annotated_commit_lookup(
                 &mut raw,
                 self.raw(),
@@ -2173,16 +2171,20 @@ impl Repository {
     /// then update `HEAD` using [`Repository::set_head`] to point to the
     /// branch you checked out.
     pub fn checkout_head(&self, opts: Option<&mut CheckoutBuilder<'_>>) -> Result<(), Error> {
+        let mut raw_opts = unsafe { mem::zeroed() };
         unsafe {
-            let mut raw_opts = mem::zeroed();
             try_call!(raw::git_checkout_init_options(
                 &mut raw_opts,
                 raw::GIT_CHECKOUT_OPTIONS_VERSION
             ));
-            if let Some(c) = opts {
+        }
+        if let Some(c) = opts {
+            unsafe {
                 c.configure(&mut raw_opts);
             }
+        }
 
+        unsafe {
             try_call!(raw::git_checkout_head(self.raw, &raw_opts));
         }
         Ok(())
@@ -2196,16 +2198,20 @@ impl Repository {
         index: Option<&mut Index>,
         opts: Option<&mut CheckoutBuilder<'_>>,
     ) -> Result<(), Error> {
+        let mut raw_opts = unsafe { mem::zeroed() };
         unsafe {
-            let mut raw_opts = mem::zeroed();
             try_call!(raw::git_checkout_init_options(
                 &mut raw_opts,
                 raw::GIT_CHECKOUT_OPTIONS_VERSION
             ));
-            if let Some(c) = opts {
+        }
+        if let Some(c) = opts {
+            unsafe {
                 c.configure(&mut raw_opts);
             }
+        }
 
+        unsafe {
             try_call!(raw::git_checkout_index(
                 self.raw,
                 index.map(|i| &mut *i.raw()),
@@ -2222,16 +2228,20 @@ impl Repository {
         treeish: &Object<'_>,
         opts: Option<&mut CheckoutBuilder<'_>>,
     ) -> Result<(), Error> {
+        let mut raw_opts = unsafe { mem::zeroed() };
         unsafe {
-            let mut raw_opts = mem::zeroed();
             try_call!(raw::git_checkout_init_options(
                 &mut raw_opts,
                 raw::GIT_CHECKOUT_OPTIONS_VERSION
             ));
-            if let Some(c) = opts {
+        }
+        if let Some(c) = opts {
+            unsafe {
                 c.configure(&mut raw_opts);
             }
+        }
 
+        unsafe {
             try_call!(raw::git_checkout_tree(self.raw, &*treeish.raw(), &raw_opts));
         }
         Ok(())
@@ -2256,16 +2266,20 @@ impl Repository {
             .map(|c| c.raw() as *const raw::git_annotated_commit)
             .collect::<Vec<_>>();
 
+        let mut raw_checkout_opts = unsafe { mem::zeroed() };
         unsafe {
-            let mut raw_checkout_opts = mem::zeroed();
             try_call!(raw::git_checkout_init_options(
                 &mut raw_checkout_opts,
                 raw::GIT_CHECKOUT_OPTIONS_VERSION
             ));
-            if let Some(c) = checkout_opts {
+        }
+        if let Some(c) = checkout_opts {
+            unsafe {
                 c.configure(&mut raw_checkout_opts);
             }
+        }
 
+        unsafe {
             try_call!(raw::git_merge(
                 self.raw,
                 commit_ptrs.as_mut_ptr(),
@@ -3084,8 +3098,8 @@ impl Repository {
         opts: Option<&mut StashSaveOptions<'_>>,
     ) -> Result<Oid, Error> {
         let mut raw_oid = crate::util::zeroed_raw_oid();
+        let opts = opts.map(|opts| unsafe { opts.raw() });
         unsafe {
-            let opts = opts.map(|opts| opts.raw());
             try_call!(raw::git_stash_save_with_opts(
                 &mut raw_oid,
                 self.raw(),

--- a/src/revert.rs
+++ b/src/revert.rs
@@ -44,27 +44,35 @@ impl<'cb> RevertOptions<'cb> {
 
     /// Obtain the raw struct
     pub fn raw(&mut self) -> raw::git_revert_options {
+        let mut checkout_opts: raw::git_checkout_options = unsafe { mem::zeroed() };
         unsafe {
-            let mut checkout_opts: raw::git_checkout_options = mem::zeroed();
             raw::git_checkout_init_options(&mut checkout_opts, raw::GIT_CHECKOUT_OPTIONS_VERSION);
-            if let Some(ref mut cb) = self.checkout_builder {
+        }
+        if let Some(ref mut cb) = self.checkout_builder {
+            unsafe {
                 cb.configure(&mut checkout_opts);
             }
+        }
 
-            let mut merge_opts: raw::git_merge_options = mem::zeroed();
+        let mut merge_opts: raw::git_merge_options = unsafe { mem::zeroed() };
+        unsafe {
             raw::git_merge_init_options(&mut merge_opts, raw::GIT_MERGE_OPTIONS_VERSION);
-            if let Some(ref opts) = self.merge_opts {
+        }
+        if let Some(ref opts) = self.merge_opts {
+            unsafe {
                 ptr::copy(opts.raw(), &mut merge_opts, 1);
             }
-
-            let mut revert_opts: raw::git_revert_options = mem::zeroed();
-            raw::git_revert_options_init(&mut revert_opts, raw::GIT_REVERT_OPTIONS_VERSION);
-            revert_opts.mainline = self.mainline;
-            revert_opts.checkout_opts = checkout_opts;
-            revert_opts.merge_opts = merge_opts;
-
-            revert_opts
         }
+
+        let mut revert_opts: raw::git_revert_options = unsafe { mem::zeroed() };
+        unsafe {
+            raw::git_revert_options_init(&mut revert_opts, raw::GIT_REVERT_OPTIONS_VERSION);
+        }
+        revert_opts.mainline = self.mainline;
+        revert_opts.checkout_opts = checkout_opts;
+        revert_opts.merge_opts = merge_opts;
+
+        revert_opts
     }
 }
 

--- a/src/revwalk.rs
+++ b/src/revwalk.rs
@@ -25,9 +25,9 @@ extern "C" fn revwalk_hide_cb<C>(commit_id: *const raw::git_oid, payload: *mut c
 where
     C: FnMut(Oid) -> bool,
 {
-    panic::wrap(|| unsafe {
+    panic::wrap(|| {
         let hide_cb = payload as *mut C;
-        if (*hide_cb)(Oid::from_raw(commit_id)) {
+        if unsafe { (*hide_cb)(Oid::from_raw(commit_id)) } {
             1
         } else {
             0

--- a/src/stash.rs
+++ b/src/stash.rs
@@ -156,14 +156,14 @@ pub(crate) extern "C" fn stash_cb(
     stash_id: *const raw::git_oid,
     payload: *mut c_void,
 ) -> c_int {
-    panic::wrap(|| unsafe {
-        let data = &mut *(payload as *mut StashCbData<'_>);
+    panic::wrap(|| {
+        let data = unsafe { &mut *(payload as *mut StashCbData<'_>) };
         let res = {
             let callback = &mut data.callback;
             callback(
                 index,
-                CStr::from_ptr(message).to_str().unwrap(),
-                &Binding::from_raw(stash_id),
+                unsafe { CStr::from_ptr(message) }.to_str().unwrap(),
+                unsafe { &Binding::from_raw(stash_id) },
             )
         };
 
@@ -195,8 +195,8 @@ extern "C" fn stash_apply_progress_cb(
     progress: raw::git_stash_apply_progress_t,
     payload: *mut c_void,
 ) -> c_int {
-    panic::wrap(|| unsafe {
-        let options = &mut *(payload as *mut StashApplyOptions<'_>);
+    panic::wrap(|| {
+        let options = unsafe { &mut *(payload as *mut StashApplyOptions<'_>) };
         let res = {
             let callback = options.progress.as_mut().unwrap();
             callback(convert_progress(progress))

--- a/src/submodule.rs
+++ b/src/submodule.rs
@@ -43,8 +43,8 @@ impl<'repo> Submodule<'repo> {
         opts: Option<&mut SubmoduleUpdateOptions<'_>>,
     ) -> Result<Repository, Error> {
         let mut raw_repo = ptr::null_mut();
+        let raw_opts = opts.map(|o| unsafe { o.raw() });
         unsafe {
-            let raw_opts = opts.map(|o| o.raw());
             try_call!(raw::git_submodule_clone(
                 &mut raw_repo,
                 self.raw,
@@ -239,8 +239,8 @@ impl<'repo> Submodule<'repo> {
         init: bool,
         opts: Option<&mut SubmoduleUpdateOptions<'_>>,
     ) -> Result<(), Error> {
+        let mut raw_opts = opts.map(|o| unsafe { o.raw() });
         unsafe {
-            let mut raw_opts = opts.map(|o| o.raw());
             try_call!(raw::git_submodule_update(
                 self.raw,
                 init as c_int,

--- a/src/tagforeach.rs
+++ b/src/tagforeach.rs
@@ -22,13 +22,13 @@ pub(crate) extern "C" fn tag_foreach_cb(
     oid: *mut git_oid,
     payload: *mut c_void,
 ) -> c_int {
-    panic::wrap(|| unsafe {
-        let id: Oid = Binding::from_raw(oid as *const _);
+    panic::wrap(|| {
+        let id: Oid = unsafe { Binding::from_raw(oid as *const _) };
 
-        let name = CStr::from_ptr(name);
+        let name = unsafe { CStr::from_ptr(name) };
         let name = name.to_bytes();
 
-        let payload = &mut *(payload as *mut TagForeachData<'_>);
+        let payload = unsafe { &mut *(payload as *mut TagForeachData<'_>) };
         let cb = &mut payload.cb;
 
         let res = cb(id, name);

--- a/src/test.rs
+++ b/src/test.rs
@@ -86,14 +86,15 @@ pub fn realpath(original: &Path) -> io::Result<PathBuf> {
     extern "C" {
         fn realpath(name: *const c_char, resolved: *mut c_char) -> *mut c_char;
     }
-    unsafe {
-        let cstr = CString::new(original.as_os_str().as_bytes())?;
-        let ptr = realpath(cstr.as_ptr(), ptr::null_mut());
-        if ptr.is_null() {
-            return Err(io::Error::last_os_error());
-        }
-        let bytes = CStr::from_ptr(ptr).to_bytes().to_vec();
-        libc::free(ptr as *mut _);
-        Ok(PathBuf::from(OsString::from_vec(bytes)))
+
+    let cstr = CString::new(original.as_os_str().as_bytes())?;
+    let ptr = unsafe { realpath(cstr.as_ptr(), ptr::null_mut()) };
+    if ptr.is_null() {
+        return Err(io::Error::last_os_error());
     }
+    let bytes = unsafe { CStr::from_ptr(ptr) }.to_bytes().to_vec();
+    unsafe {
+        libc::free(ptr as *mut _);
+    }
+    Ok(PathBuf::from(OsString::from_vec(bytes)))
 }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -170,8 +170,8 @@ impl Transport {
                 remote.raw(),
                 &mut defn as *mut _ as *mut _
             ));
-            mem::forget(raw); // ownership transport to `ret`
         }
+        mem::forget(raw); // ownership transport to `ret`
         return Ok(Transport {
             raw: ret,
             owned: true,
@@ -214,14 +214,16 @@ extern "C" fn transport_factory(
         }
     }
 
-    panic::wrap(|| unsafe {
+    panic::wrap(|| {
         let remote = Bomb {
-            remote: Some(Binding::from_raw(owner)),
+            remote: Some(unsafe { Binding::from_raw(owner) }),
         };
-        let data = &mut *(param as *mut TransportData);
+        let data = unsafe { &mut *(param as *mut TransportData) };
         match (data.factory)(remote.remote.as_ref().unwrap()) {
             Ok(mut transport) => {
-                *out = transport.raw;
+                unsafe {
+                    *out = transport.raw;
+                }
                 transport.owned = false;
                 0
             }
@@ -239,8 +241,8 @@ extern "C" fn subtransport_action(
     url: *const c_char,
     action: raw::git_smart_service_t,
 ) -> c_int {
-    panic::wrap(|| unsafe {
-        let url = CStr::from_ptr(url).to_bytes();
+    panic::wrap(|| {
+        let url = unsafe { CStr::from_ptr(url) }.to_bytes();
         let url = match str::from_utf8(url).ok() {
             Some(s) => s,
             None => return -1,
@@ -253,7 +255,7 @@ extern "C" fn subtransport_action(
             n => panic!("unknown action: {}", n),
         };
 
-        let transport = &mut *(raw_transport as *mut RawSmartSubtransport);
+        let transport = unsafe { &mut *(raw_transport as *mut RawSmartSubtransport) };
         // Note: we only need to generate if rpc is on. Else, for receive-pack and upload-pack
         // libgit2 reuses the stream generated for receive-pack-ls or upload-pack-ls.
         let generate_stream =
@@ -261,26 +263,30 @@ extern "C" fn subtransport_action(
         if generate_stream {
             let obj = match transport.obj.action(url, action) {
                 Ok(s) => s,
-                Err(e) => return e.raw_set_git_error(),
+                Err(e) => return unsafe { e.raw_set_git_error() },
             };
-            *stream = mem::transmute::<
-                Box<RawSmartSubtransportStream>,
-                *mut raw::git_smart_subtransport_stream,
-            >(Box::new(RawSmartSubtransportStream {
-                raw: raw::git_smart_subtransport_stream {
-                    subtransport: raw_transport,
-                    read: Some(stream_read),
-                    write: Some(stream_write),
-                    free: Some(stream_free),
-                },
-                obj,
-            }));
-            transport.stream = Some(*stream);
+            unsafe {
+                *stream = mem::transmute::<
+                    Box<RawSmartSubtransportStream>,
+                    *mut raw::git_smart_subtransport_stream,
+                >(Box::new(RawSmartSubtransportStream {
+                    raw: raw::git_smart_subtransport_stream {
+                        subtransport: raw_transport,
+                        read: Some(stream_read),
+                        write: Some(stream_write),
+                        free: Some(stream_free),
+                    },
+                    obj,
+                }));
+            }
+            transport.stream = Some(unsafe { *stream });
         } else {
             if transport.stream.is_none() {
                 return -1;
             }
-            *stream = transport.stream.unwrap();
+            unsafe {
+                *stream = transport.stream.unwrap();
+            }
         }
         0
     })
@@ -290,8 +296,8 @@ extern "C" fn subtransport_action(
 // callback used by smart transports to close a `SmartSubtransport` trait
 // object.
 extern "C" fn subtransport_close(transport: *mut raw::git_smart_subtransport) -> c_int {
-    let ret = panic::wrap(|| unsafe {
-        let transport = &mut *(transport as *mut RawSmartSubtransport);
+    let ret = panic::wrap(|| {
+        let transport = unsafe { &mut *(transport as *mut RawSmartSubtransport) };
         transport.obj.close()
     });
     match ret {
@@ -317,12 +323,14 @@ extern "C" fn stream_read(
     buf_size: size_t,
     bytes_read: *mut size_t,
 ) -> c_int {
-    let ret = panic::wrap(|| unsafe {
-        let transport = &mut *(stream as *mut RawSmartSubtransportStream);
-        let buf = slice::from_raw_parts_mut(buffer as *mut u8, buf_size as usize);
+    let ret = panic::wrap(|| {
+        let transport = unsafe { &mut *(stream as *mut RawSmartSubtransportStream) };
+        let buf = unsafe { slice::from_raw_parts_mut(buffer as *mut u8, buf_size as usize) };
         match transport.obj.read(buf) {
             Ok(n) => {
-                *bytes_read = n as size_t;
+                unsafe {
+                    *bytes_read = n as size_t;
+                }
                 Ok(n)
             }
             e => e,
@@ -330,10 +338,12 @@ extern "C" fn stream_read(
     });
     match ret {
         Some(Ok(_)) => 0,
-        Some(Err(e)) => unsafe {
-            set_err_io(&e);
+        Some(Err(e)) => {
+            unsafe {
+                set_err_io(&e);
+            }
             -2
-        },
+        }
         None => -1,
     }
 }
@@ -345,17 +355,19 @@ extern "C" fn stream_write(
     buffer: *const c_char,
     len: size_t,
 ) -> c_int {
-    let ret = panic::wrap(|| unsafe {
-        let transport = &mut *(stream as *mut RawSmartSubtransportStream);
-        let buf = slice::from_raw_parts(buffer as *const u8, len as usize);
+    let ret = panic::wrap(|| {
+        let transport = unsafe { &mut *(stream as *mut RawSmartSubtransportStream) };
+        let buf = unsafe { slice::from_raw_parts(buffer as *const u8, len as usize) };
         transport.obj.write_all(buf)
     });
     match ret {
         Some(Ok(())) => 0,
-        Some(Err(e)) => unsafe {
-            set_err_io(&e);
+        Some(Err(e)) => {
+            unsafe {
+                set_err_io(&e);
+            }
             -2
-        },
+        }
         None => -1,
     }
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -207,13 +207,13 @@ extern "C" fn treewalk_cb<T: Into<i32>>(
     entry: *const raw::git_tree_entry,
     payload: *mut c_void,
 ) -> c_int {
-    panic::wrap(|| unsafe {
-        let root = match CStr::from_ptr(root).to_str() {
+    panic::wrap(|| {
+        let root = match unsafe { CStr::from_ptr(root) }.to_str() {
             Ok(value) => value,
             _ => return -1,
         };
-        let entry = entry_from_raw_const(entry);
-        let payload = &mut *(payload as *mut TreeWalkCbData<'_, T>);
+        let entry = unsafe { entry_from_raw_const(entry) };
+        let payload = unsafe { &mut *(payload as *mut TreeWalkCbData<'_, T>) };
         let callback = &mut payload.callback;
         callback(root, &entry).into()
     })

--- a/src/treebuilder.rs
+++ b/src/treebuilder.rs
@@ -123,14 +123,14 @@ impl<'repo> TreeBuilder<'repo> {
 type FilterCb<'a> = dyn FnMut(&TreeEntry<'_>) -> bool + 'a;
 
 extern "C" fn filter_cb(entry: *const raw::git_tree_entry, payload: *mut c_void) -> c_int {
-    let ret = panic::wrap(|| unsafe {
+    let ret = panic::wrap(|| {
         // There's no way to return early from git_treebuilder_filter.
         if panic::panicked() {
             true
         } else {
-            let entry = tree::entry_from_raw_const(entry);
+            let entry = unsafe { tree::entry_from_raw_const(entry) };
             let payload = payload as *mut &mut FilterCb<'_>;
-            (*payload)(&entry)
+            unsafe { (*payload)(&entry) }
         }
     });
     if ret == Some(false) {

--- a/src/version.rs
+++ b/src/version.rs
@@ -27,8 +27,8 @@ impl Version {
         };
         unsafe {
             raw::git_libgit2_version(&mut v.major, &mut v.minor, &mut v.rev);
-            v.features = raw::git_libgit2_features();
         }
+        v.features = unsafe { raw::git_libgit2_features() };
         v
     }
 

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -70,9 +70,9 @@ impl Worktree {
     /// .git file within the worktree. This path can be passed to
     /// repo::Repository::open.
     pub fn path(&self) -> &Path {
-        unsafe {
-            util::bytes2path(crate::opt_bytes(self, raw::git_worktree_path(self.raw)).unwrap())
-        }
+        util::bytes2path(unsafe {
+            crate::opt_bytes(self, raw::git_worktree_path(self.raw)).unwrap()
+        })
     }
 
     /// Validates the worktree
@@ -147,12 +147,12 @@ impl<'a> WorktreeAddOptions<'a> {
     /// By default this will not lock the worktree
     pub fn new() -> WorktreeAddOptions<'a> {
         let mut raw = unsafe { mem::zeroed() };
-        unsafe {
-            assert_eq!(
-                raw::git_worktree_add_options_init(&mut raw, raw::GIT_WORKTREE_ADD_OPTIONS_VERSION),
-                0
-            );
-        }
+        assert_eq!(
+            unsafe {
+                raw::git_worktree_add_options_init(&mut raw, raw::GIT_WORKTREE_ADD_OPTIONS_VERSION)
+            },
+            0
+        );
         WorktreeAddOptions {
             raw,
             _marker: marker::PhantomData,
@@ -206,15 +206,15 @@ impl WorktreePruneOptions {
     /// unlocked and not checked out
     pub fn new() -> WorktreePruneOptions {
         let mut raw = unsafe { mem::zeroed() };
-        unsafe {
-            assert_eq!(
+        assert_eq!(
+            unsafe {
                 raw::git_worktree_prune_options_init(
                     &mut raw,
-                    raw::GIT_WORKTREE_PRUNE_OPTIONS_VERSION
-                ),
-                0
-            );
-        }
+                    raw::GIT_WORKTREE_PRUNE_OPTIONS_VERSION,
+                )
+            },
+            0
+        );
         WorktreePruneOptions { raw }
     }
 


### PR DESCRIPTION
For statements that do not need to be marked as unsafe, pull them out of the blocks