### PR TITLE
Remove redundant casts

### DIFF
--- a/src/apply.rs
+++ b/src/apply.rs
@@ -102,7 +102,6 @@ impl<'cb> ApplyOptions<'cb> {
     }
 
     fn flag(&mut self, opt: raw::git_apply_flags_t, val: bool) -> &mut Self {
-        let opt = opt as u32;
         if val {
             self.raw.flags |= opt;
         } else {

--- a/src/config.rs
+++ b/src/config.rs
@@ -196,7 +196,7 @@ impl Config {
     /// level. A higher level means a higher priority. The first occurrence of
     /// the variable will be returned here.
     pub fn get_bool(&self, name: &str) -> Result<bool, Error> {
-        let mut out = 0 as libc::c_int;
+        let mut out = 0;
         let name = CString::new(name)?;
         unsafe {
             try_call!(raw::git_config_get_bool(&mut out, &*self.raw, name));

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -709,7 +709,6 @@ impl DiffOptions {
     }
 
     fn flag(&mut self, opt: raw::git_diff_option_t, val: bool) -> &mut DiffOptions {
-        let opt = opt as u32;
         if val {
             self.raw.flags |= opt;
         } else {

--- a/src/email.rs
+++ b/src/email.rs
@@ -51,7 +51,6 @@ impl EmailCreateOptions {
     }
 
     fn flag(&mut self, opt: raw::git_email_create_flags_t, val: bool) -> &mut Self {
-        let opt = opt as u32;
         if val {
             self.raw.flags |= opt;
         } else {

--- a/src/time.rs
+++ b/src/time.rs
@@ -31,12 +31,12 @@ impl Time {
 
     /// Return the time, in seconds, from epoch
     pub fn seconds(&self) -> i64 {
-        self.raw.time as i64
+        self.raw.time
     }
 
     /// Return the timezone offset, in minutes
     pub fn offset_minutes(&self) -> i32 {
-        self.raw.offset as i32
+        self.raw.offset
     }
 
     /// Return whether the offset was positive or negative. Primarily useful


### PR DESCRIPTION
I believe these casts can be safely removed, as the source type is already the target type.

For reference, these changes were found by an optimizer developed as a research project.

CC @nunoplopes