### PR TITLE
[CString panic reduction] Reduce panics without changing return types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -955,7 +955,8 @@ impl ObjectType {
     /// Convert a string object type representation to its object type.
     #[expect(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Option<ObjectType> {
-        let raw = unsafe { call!(raw::git_object_string2type(CString::new(s).unwrap())) };
+        let cstr = CString::new(s).ok()?;
+        let raw = unsafe { call!(raw::git_object_string2type(cstr)) };
         ObjectType::from_raw(raw)
     }
 }
@@ -1636,9 +1637,8 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn object_type_invalid() {
-        ObjectType::from_str("ab\x0012");
+        assert_eq!(None, ObjectType::from_str("ab\x0012"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1636,6 +1636,12 @@ mod tests {
     }
 
     #[test]
+    #[should_panic]
+    fn object_type_invalid() {
+        ObjectType::from_str("ab\x0012");
+    }
+
+    #[test]
     fn convert_filemode() {
         assert_eq!(i32::from(FileMode::Blob), 0o100644);
         assert_eq!(i32::from(FileMode::BlobGroupWritable), 0o100664);

--- a/src/refspec.rs
+++ b/src/refspec.rs
@@ -114,3 +114,23 @@ impl<'remote> Binding for Refspec<'remote> {
         self.raw
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    #[should_panic]
+    fn dst_matches_invalid() {
+        let (_td, repo) = crate::test::repo_init();
+        repo.remote("origin", "https://github.com/rust-lang/git2-rs")
+            .expect("Remote added");
+        let remote = repo.find_remote("origin").expect("Remote exists");
+        let specs: Vec<_> = remote.refspecs().collect();
+        assert_eq!(1, specs.len());
+        assert_eq!(
+            "+refs/heads/*:refs/remotes/origin/*",
+            specs[0].str().expect("Valid string")
+        );
+
+        specs[0].dst_matches("ab\x0012");
+    }
+}

--- a/src/refspec.rs
+++ b/src/refspec.rs
@@ -37,7 +37,9 @@ impl<'remote> Refspec<'remote> {
 
     /// Check if a refspec's destination descriptor matches a reference
     pub fn dst_matches(&self, refname: &str) -> bool {
-        let refname = CString::new(refname).unwrap();
+        let Ok(refname) = CString::new(refname) else {
+            return false;
+        };
         unsafe { raw::git_refspec_dst_matches(self.raw, refname.as_ptr()) == 1 }
     }
 
@@ -118,7 +120,6 @@ impl<'remote> Binding for Refspec<'remote> {
 #[cfg(test)]
 mod tests {
     #[test]
-    #[should_panic]
     fn dst_matches_invalid() {
         let (_td, repo) = crate::test::repo_init();
         repo.remote("origin", "https://github.com/rust-lang/git2-rs")
@@ -131,6 +132,6 @@ mod tests {
             specs[0].str().expect("Valid string")
         );
 
-        specs[0].dst_matches("ab\x0012");
+        assert!(!specs[0].dst_matches("ab\x0012"));
     }
 }

--- a/src/refspec.rs
+++ b/src/refspec.rs
@@ -78,7 +78,7 @@ impl<'remote> Refspec<'remote> {
 
     /// Transform a reference to its target following the refspec's rules
     pub fn transform(&self, name: &str) -> Result<Buf, Error> {
-        let name = CString::new(name).unwrap();
+        let name = CString::new(name)?;
         let buf = Buf::new();
         unsafe {
             try_call!(raw::git_refspec_transform(
@@ -154,7 +154,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn transform_invalid() {
         let (_td, repo) = crate::test::repo_init();
         repo.remote("origin", "https://github.com/rust-lang/git2-rs")
@@ -167,6 +166,16 @@ mod tests {
             specs[0].str().expect("Valid string")
         );
 
-        let _ = specs[0].transform("ab\x0012");
+        // Cannot use unwrap_err() because Buf does not implement Debug
+        let result = match specs[0].transform("ab\x0012") {
+            Ok(_) => panic!("Expected an err"),
+            Err(e) => e,
+        };
+        assert_eq!(
+            crate::Error::from_str(
+                "data contained a nul byte that could not be represented as a string"
+            ),
+            result,
+        );
     }
 }

--- a/src/refspec.rs
+++ b/src/refspec.rs
@@ -134,4 +134,21 @@ mod tests {
 
         assert!(!specs[0].dst_matches("ab\x0012"));
     }
+
+    #[test]
+    #[should_panic]
+    fn src_matches_invalid() {
+        let (_td, repo) = crate::test::repo_init();
+        repo.remote("origin", "https://github.com/rust-lang/git2-rs")
+            .expect("Remote added");
+        let remote = repo.find_remote("origin").expect("Remote exists");
+        let specs: Vec<_> = remote.refspecs().collect();
+        assert_eq!(1, specs.len());
+        assert_eq!(
+            "+refs/heads/*:refs/remotes/origin/*",
+            specs[0].str().expect("Valid string")
+        );
+
+        specs[0].src_matches("ab\x0012");
+    }
 }

--- a/src/refspec.rs
+++ b/src/refspec.rs
@@ -55,7 +55,9 @@ impl<'remote> Refspec<'remote> {
 
     /// Check if a refspec's source descriptor matches a reference
     pub fn src_matches(&self, refname: &str) -> bool {
-        let refname = CString::new(refname).unwrap();
+        let Ok(refname) = CString::new(refname) else {
+            return false;
+        };
         unsafe { raw::git_refspec_src_matches(self.raw, refname.as_ptr()) == 1 }
     }
 
@@ -136,7 +138,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn src_matches_invalid() {
         let (_td, repo) = crate::test::repo_init();
         repo.remote("origin", "https://github.com/rust-lang/git2-rs")
@@ -149,6 +150,6 @@ mod tests {
             specs[0].str().expect("Valid string")
         );
 
-        specs[0].src_matches("ab\x0012");
+        assert!(!specs[0].src_matches("ab\x0012"));
     }
 }

--- a/src/refspec.rs
+++ b/src/refspec.rs
@@ -178,4 +178,21 @@ mod tests {
             result,
         );
     }
+
+    #[test]
+    #[should_panic]
+    fn rtransform_invalid() {
+        let (_td, repo) = crate::test::repo_init();
+        repo.remote("origin", "https://github.com/rust-lang/git2-rs")
+            .expect("Remote added");
+        let remote = repo.find_remote("origin").expect("Remote exists");
+        let specs: Vec<_> = remote.refspecs().collect();
+        assert_eq!(1, specs.len());
+        assert_eq!(
+            "+refs/heads/*:refs/remotes/origin/*",
+            specs[0].str().expect("Valid string")
+        );
+
+        let _ = specs[0].rtransform("ab\x0012");
+    }
 }

--- a/src/refspec.rs
+++ b/src/refspec.rs
@@ -152,4 +152,21 @@ mod tests {
 
         assert!(!specs[0].src_matches("ab\x0012"));
     }
+
+    #[test]
+    #[should_panic]
+    fn transform_invalid() {
+        let (_td, repo) = crate::test::repo_init();
+        repo.remote("origin", "https://github.com/rust-lang/git2-rs")
+            .expect("Remote added");
+        let remote = repo.find_remote("origin").expect("Remote exists");
+        let specs: Vec<_> = remote.refspecs().collect();
+        assert_eq!(1, specs.len());
+        assert_eq!(
+            "+refs/heads/*:refs/remotes/origin/*",
+            specs[0].str().expect("Valid string")
+        );
+
+        let _ = specs[0].transform("ab\x0012");
+    }
 }

--- a/src/refspec.rs
+++ b/src/refspec.rs
@@ -92,7 +92,7 @@ impl<'remote> Refspec<'remote> {
 
     /// Transform a target reference to its source reference following the refspec's rules
     pub fn rtransform(&self, name: &str) -> Result<Buf, Error> {
-        let name = CString::new(name).unwrap();
+        let name = CString::new(name)?;
         let buf = Buf::new();
         unsafe {
             try_call!(raw::git_refspec_rtransform(
@@ -180,7 +180,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn rtransform_invalid() {
         let (_td, repo) = crate::test::repo_init();
         repo.remote("origin", "https://github.com/rust-lang/git2-rs")
@@ -193,6 +192,16 @@ mod tests {
             specs[0].str().expect("Valid string")
         );
 
-        let _ = specs[0].rtransform("ab\x0012");
+        // Cannot use unwrap_err() because Buf does not implement Debug
+        let result = match specs[0].rtransform("ab\x0012") {
+            Ok(_) => panic!("Expected an err"),
+            Err(e) => e,
+        };
+        assert_eq!(
+            crate::Error::from_str(
+                "data contained a nul byte that could not be represented as a string"
+            ),
+            result,
+        );
     }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -59,7 +59,7 @@ impl<'repo> Transaction<'repo> {
         reflog_signature: Option<&Signature<'_>>,
         reflog_message: &str,
     ) -> Result<(), Error> {
-        let refname = CString::new(refname).unwrap();
+        let refname = CString::new(refname)?;
         let reflog_message = CString::new(reflog_message).unwrap();
         unsafe {
             try_call!(raw::git_transaction_set_target(
@@ -330,12 +330,17 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn invalid_set_target_refname() {
         let (_td, repo) = crate::test::repo_init();
 
         let mut tx = t!(repo.transaction());
         let oid = Oid::from_bytes(&[1u8; 20]).unwrap();
-        let _ = tx.set_target("ab\x0012", oid, None, "valid message");
+        let result = tx.set_target("ab\x0012", oid, None, "valid message");
+        assert_eq!(
+            Err(crate::Error::from_str(
+                "data contained a nul byte that could not be represented as a string"
+            )),
+            result,
+        );
     }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -38,7 +38,7 @@ impl<'repo> Binding for Transaction<'repo> {
 impl<'repo> Transaction<'repo> {
     /// Lock the specified reference by name.
     pub fn lock_ref(&mut self, refname: &str) -> Result<(), Error> {
-        let refname = CString::new(refname).unwrap();
+        let refname = CString::new(refname)?;
         unsafe {
             try_call!(raw::git_transaction_lock_ref(self.raw, refname));
         }
@@ -316,11 +316,16 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn invalid_lock_ref() {
         let (_td, repo) = crate::test::repo_init();
 
         let mut tx = t!(repo.transaction());
-        let _ = tx.lock_ref("ab\x0012");
+        let result = tx.lock_ref("ab\x0012");
+        assert_eq!(
+            Err(crate::Error::from_str(
+                "data contained a nul byte that could not be represented as a string"
+            )),
+            result,
+        );
     }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -372,4 +372,13 @@ mod tests {
             result,
         );
     }
+
+    #[test]
+    #[should_panic]
+    fn invalid_set_symbolic_target_target() {
+        let (_td, repo) = crate::test::repo_init();
+
+        let mut tx = t!(repo.transaction());
+        let _ = tx.set_symbolic_target("refs/heads/next", "ab\x0012", None, "valid message");
+    }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -129,7 +129,7 @@ impl<'repo> Transaction<'repo> {
     ///
     /// The reference must have been locked via `lock_ref`.
     pub fn remove(&mut self, refname: &str) -> Result<(), Error> {
-        let refname = CString::new(refname).unwrap();
+        let refname = CString::new(refname)?;
         unsafe {
             try_call!(raw::git_transaction_remove(self.raw, refname));
         }
@@ -418,11 +418,16 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn invalid_remove() {
         let (_td, repo) = crate::test::repo_init();
 
         let mut tx = t!(repo.transaction());
-        let _ = tx.remove("ab\x0012");
+        let result = tx.remove("ab\x0012");
+        assert_eq!(
+            Err(crate::Error::from_str(
+                "data contained a nul byte that could not be represented as a string"
+            )),
+            result,
+        );
     }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -60,7 +60,7 @@ impl<'repo> Transaction<'repo> {
         reflog_message: &str,
     ) -> Result<(), Error> {
         let refname = CString::new(refname)?;
-        let reflog_message = CString::new(reflog_message).unwrap();
+        let reflog_message = CString::new(reflog_message)?;
         unsafe {
             try_call!(raw::git_transaction_set_target(
                 self.raw,
@@ -345,12 +345,17 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn invalid_set_target_message() {
         let (_td, repo) = crate::test::repo_init();
 
         let mut tx = t!(repo.transaction());
         let oid = Oid::from_bytes(&[1u8; 20]).unwrap();
-        let _ = tx.set_target("refs/heads/main", oid, None, "ab\x0012");
+        let result = tx.set_target("refs/heads/main", oid, None, "ab\x0012");
+        assert_eq!(
+            Err(crate::Error::from_str(
+                "data contained a nul byte that could not be represented as a string"
+            )),
+            result,
+        );
     }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -89,7 +89,7 @@ impl<'repo> Transaction<'repo> {
     ) -> Result<(), Error> {
         let refname = CString::new(refname)?;
         let target = CString::new(target)?;
-        let reflog_message = CString::new(reflog_message).unwrap();
+        let reflog_message = CString::new(reflog_message)?;
         unsafe {
             try_call!(raw::git_transaction_set_symbolic_target(
                 self.raw,
@@ -388,11 +388,16 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn invalid_set_symbolic_target_message() {
         let (_td, repo) = crate::test::repo_init();
 
         let mut tx = t!(repo.transaction());
-        let _ = tx.set_symbolic_target("refs/heads/next", "refs/heads/main", None, "ab\x0012");
+        let result = tx.set_symbolic_target("refs/heads/next", "refs/heads/main", None, "ab\x0012");
+        assert_eq!(
+            Err(crate::Error::from_str(
+                "data contained a nul byte that could not be represented as a string"
+            )),
+            result,
+        );
     }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -328,4 +328,14 @@ mod tests {
             result,
         );
     }
+
+    #[test]
+    #[should_panic]
+    fn invalid_set_target_refname() {
+        let (_td, repo) = crate::test::repo_init();
+
+        let mut tx = t!(repo.transaction());
+        let oid = Oid::from_bytes(&[1u8; 20]).unwrap();
+        let _ = tx.set_target("ab\x0012", oid, None, "valid message");
+    }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -87,7 +87,7 @@ impl<'repo> Transaction<'repo> {
         reflog_signature: Option<&Signature<'_>>,
         reflog_message: &str,
     ) -> Result<(), Error> {
-        let refname = CString::new(refname).unwrap();
+        let refname = CString::new(refname)?;
         let target = CString::new(target).unwrap();
         let reflog_message = CString::new(reflog_message).unwrap();
         unsafe {
@@ -360,11 +360,16 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn invalid_set_symbolic_target_refname() {
         let (_td, repo) = crate::test::repo_init();
 
         let mut tx = t!(repo.transaction());
-        let _ = tx.set_symbolic_target("ab\x0012", "refs/heads/main", None, "valid message");
+        let result = tx.set_symbolic_target("ab\x0012", "refs/heads/main", None, "valid message");
+        assert_eq!(
+            Err(crate::Error::from_str(
+                "data contained a nul byte that could not be represented as a string"
+            )),
+            result,
+        );
     }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -314,4 +314,13 @@ mod tests {
             Err(e) if is_not_locked_err(&e)
         ))
     }
+
+    #[test]
+    #[should_panic]
+    fn invalid_lock_ref() {
+        let (_td, repo) = crate::test::repo_init();
+
+        let mut tx = t!(repo.transaction());
+        let _ = tx.lock_ref("ab\x0012");
+    }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -113,7 +113,7 @@ impl<'repo> Transaction<'repo> {
     /// written to the log (i.e. the `reflog_signature` and `reflog_message`
     /// parameters will be ignored).
     pub fn set_reflog(&mut self, refname: &str, reflog: Reflog) -> Result<(), Error> {
-        let refname = CString::new(refname).unwrap();
+        let refname = CString::new(refname)?;
         unsafe {
             try_call!(raw::git_transaction_set_reflog(
                 self.raw,
@@ -402,13 +402,18 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn invalid_set_reflog() {
         let (_td, repo) = crate::test::repo_init();
 
         let reflog = repo.reflog("dummy").expect("Valid name");
 
         let mut tx = t!(repo.transaction());
-        let _ = tx.set_reflog("ab\x0012", reflog);
+        let result = tx.set_reflog("ab\x0012", reflog);
+        assert_eq!(
+            Err(crate::Error::from_str(
+                "data contained a nul byte that could not be represented as a string"
+            )),
+            result,
+        );
     }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -343,4 +343,14 @@ mod tests {
             result,
         );
     }
+
+    #[test]
+    #[should_panic]
+    fn invalid_set_target_message() {
+        let (_td, repo) = crate::test::repo_init();
+
+        let mut tx = t!(repo.transaction());
+        let oid = Oid::from_bytes(&[1u8; 20]).unwrap();
+        let _ = tx.set_target("refs/heads/main", oid, None, "ab\x0012");
+    }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -358,4 +358,13 @@ mod tests {
             result,
         );
     }
+
+    #[test]
+    #[should_panic]
+    fn invalid_set_symbolic_target_refname() {
+        let (_td, repo) = crate::test::repo_init();
+
+        let mut tx = t!(repo.transaction());
+        let _ = tx.set_symbolic_target("ab\x0012", "refs/heads/main", None, "valid message");
+    }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -416,4 +416,13 @@ mod tests {
             result,
         );
     }
+
+    #[test]
+    #[should_panic]
+    fn invalid_remove() {
+        let (_td, repo) = crate::test::repo_init();
+
+        let mut tx = t!(repo.transaction());
+        let _ = tx.remove("ab\x0012");
+    }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -88,7 +88,7 @@ impl<'repo> Transaction<'repo> {
         reflog_message: &str,
     ) -> Result<(), Error> {
         let refname = CString::new(refname)?;
-        let target = CString::new(target).unwrap();
+        let target = CString::new(target)?;
         let reflog_message = CString::new(reflog_message).unwrap();
         unsafe {
             try_call!(raw::git_transaction_set_symbolic_target(
@@ -374,11 +374,16 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn invalid_set_symbolic_target_target() {
         let (_td, repo) = crate::test::repo_init();
 
         let mut tx = t!(repo.transaction());
-        let _ = tx.set_symbolic_target("refs/heads/next", "ab\x0012", None, "valid message");
+        let result = tx.set_symbolic_target("refs/heads/next", "ab\x0012", None, "valid message");
+        assert_eq!(
+            Err(crate::Error::from_str(
+                "data contained a nul byte that could not be represented as a string"
+            )),
+            result,
+        );
     }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -400,4 +400,15 @@ mod tests {
             result,
         );
     }
+
+    #[test]
+    #[should_panic]
+    fn invalid_set_reflog() {
+        let (_td, repo) = crate::test::repo_init();
+
+        let reflog = repo.reflog("dummy").expect("Valid name");
+
+        let mut tx = t!(repo.transaction());
+        let _ = tx.set_reflog("ab\x0012", reflog);
+    }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -386,4 +386,13 @@ mod tests {
             result,
         );
     }
+
+    #[test]
+    #[should_panic]
+    fn invalid_set_symbolic_target_message() {
+        let (_td, repo) = crate::test::repo_init();
+
+        let mut tx = t!(repo.transaction());
+        let _ = tx.set_symbolic_target("refs/heads/next", "refs/heads/main", None, "ab\x0012");
+    }
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -597,4 +597,22 @@ mod tests {
         let e = tree.walk(TreeWalkMode::PreOrder, |_, _| -1).unwrap_err();
         assert_eq!(e.class(), crate::ErrorClass::Callback);
     }
+
+    #[test]
+    #[should_panic]
+    fn invalid_name_bytes() {
+        let (td, repo) = crate::test::repo_init();
+
+        setup_repo(&td, &repo);
+
+        let head = repo.head().unwrap();
+        let target = head.target().unwrap();
+        let commit = repo.find_commit(target).unwrap();
+
+        let tree = repo.find_tree(commit.tree_id()).unwrap();
+        assert_eq!(tree.id(), commit.tree_id());
+        assert_eq!(tree.len(), 8);
+
+        tree.get_name_bytes(b"ab\x0012");
+    }
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -164,7 +164,7 @@ impl<'repo> Tree<'repo> {
     ///
     /// This allows for non-UTF-8 filenames.
     pub fn get_name_bytes(&self, filename: &[u8]) -> Option<TreeEntry<'_>> {
-        let filename = CString::new(filename).unwrap();
+        let filename = CString::new(filename).ok()?;
         let ptr = unsafe { call!(raw::git_tree_entry_byname(&*self.raw(), filename)) };
         if ptr.is_null() {
             None
@@ -599,7 +599,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn invalid_name_bytes() {
         let (td, repo) = crate::test::repo_init();
 
@@ -613,6 +612,7 @@ mod tests {
         assert_eq!(tree.id(), commit.tree_id());
         assert_eq!(tree.len(), 8);
 
-        tree.get_name_bytes(b"ab\x0012");
+        let result = tree.get_name_bytes(b"ab\x0012");
+        assert!(result.is_none());
     }
 }


### PR DESCRIPTION
For functions where the failure can be effectively community via the existing return type, instead of panicking when a CString cannot be created, return `false` or `None` or an error variant.

Part of #1297